### PR TITLE
Folder searching

### DIFF
--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -1405,3 +1405,15 @@ bool Desktopwidget::eventFilter (QObject *watched_object, QEvent *e)
   return filtered;
   }
 #endif
+
+const QString Desktopwidget::getRootDirectory()
+{
+   // Find out which directory is currently selected
+   QModelIndex ind = _dir->menuGetModelIndex();
+
+   // Get the top-level dirname of that
+   QModelIndex root = _model->findRoot(ind);
+   QString root_path = _model->data(root, QDirModel::FilePathRole).toString();
+
+   return root_path;
+}

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -738,6 +738,24 @@ void Desktopwidget::newDir ()
       }
    }
 
+bool Desktopwidget::newDir(const QString& dir_path, QModelIndex& index)
+{
+   QDir parent(dir_path);
+   QString dirname = parent.dirName();
+
+   if (!parent.cdUp()) {
+      // This really cannot happen
+      QMessageBox::warning(0, "Paperman", "Directory does not exist: " +
+                           parent.path());
+      return false;
+   }
+
+   qDebug() << "to_create" << dir_path;
+   QModelIndex parent_ind = _model->index(parent.path(), 0);
+   index = _model->mkdir(parent_ind, dirname);
+
+   return true;
+}
 
 void Desktopwidget::dirSelected (const QModelIndex &index, bool allow_undo)
    {

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -1417,3 +1417,10 @@ const QString Desktopwidget::getRootDirectory()
 
    return root_path;
 }
+
+QModelIndex Desktopwidget::getDirIndex(const QString dirname)
+{
+   QModelIndex ind = _model->index(dirname);
+
+   return ind;
+}

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -128,6 +128,18 @@ public:
    /** activate the locate feature, which allows looking for stacks by name */
    void activateLocate ();
 
+   /**
+    * @brief Get the root directory of the currentl selected paper repository
+    * @return Directory path
+    *
+    * The top level of the the Dirmodel contains a number of Diritem objects,
+    * each of which is a separate directory in the file system, with no
+    * relationship between them. There is always a highlighted directory in the
+    * Dirview _dir so this function finds the filesystem path associated with
+    * that _dir
+    */
+   const QString getRootDirectory();
+
 protected:
    //bool eventFilter (QObject *watched_object, QEvent *e);
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -143,6 +143,14 @@ public:
    /** convert a full directory path into a model index */
    QModelIndex getDirIndex(const QString dirname);
 
+   /**
+    * @brief Create a new directory
+    * @param dir_path   Full path to new directory
+    * @param index      Returns the Dirmodel index of the created directory
+    * @return true if OK, false on error
+    */
+   bool newDir(const QString& dir_path, QModelIndex& index);
+
 protected:
    //bool eventFilter (QObject *watched_object, QEvent *e);
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -140,6 +140,9 @@ public:
     */
    const QString getRootDirectory();
 
+   /** convert a full directory path into a model index */
+   QModelIndex getDirIndex(const QString dirname);
+
 protected:
    //bool eventFilter (QObject *watched_object, QEvent *e);
 

--- a/foldersel.h
+++ b/foldersel.h
@@ -1,0 +1,15 @@
+#ifndef FOLDERSEL_H
+#define FOLDERSEL_H
+
+#include <QLineEdit>
+
+class Foldersel : public QLineEdit
+{
+   Q_OBJECT
+
+public:
+   Foldersel(QWidget* parent);
+   ~Foldersel();
+};
+
+#endif // FOLDERSEL_H

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1248,6 +1248,7 @@ void Mainwidget::addMatches(QStringList& matches, uint baseLen,
 
 QStringList Mainwidget::findFolders(const QString &text, QString& dirPath)
 {
+   QStringList missing;
    showDesktop();
 
    dirPath = _desktop->getRootDirectory();
@@ -1259,6 +1260,6 @@ QStringList Mainwidget::findFolders(const QString &text, QString& dirPath)
 
    QDate date = QDate::currentDate();
 
-   return utilDetectMatches(date, matches);
+   return utilDetectMatches(date, matches, missing);
 
 }

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -307,7 +307,14 @@ void Mainwidget::updatePscan ()
    }
 
 
-void Mainwidget::scan (void)
+void Mainwidget::scanInto(const QString& dir_path)
+{
+   QModelIndex ind = _desktop->getDirIndex(dir_path);
+
+   scanInto(ind);
+}
+
+void Mainwidget::scanInto(QModelIndex target)
    {
    SANE_Status status;
    SANE_Parameters parameters;
@@ -348,6 +355,9 @@ void Mainwidget::scan (void)
          page_name = str;
       }
 
+   if (target != QModelIndex())
+      _desktop->selectDir(target);
+
    Paperscan scan;
 
    connect (&scan, SIGNAL (stackNew (const QString &)), this, SLOT (slotStackNew (const QString &)));
@@ -380,6 +390,11 @@ void Mainwidget::scan (void)
    updatePscan ();
    }
 
+
+void Mainwidget::scan(void)
+{
+   scanInto(QModelIndex());
+}
 
 void Mainwidget::slotStackNew (const QString &stack_name)
    {

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -339,6 +339,7 @@ void Mainwidget::scan (void)
       {
       QString str;
 
+      _pscan->scanStarting();
       str = _pscan->getStackName ();
       if (!str.isEmpty ())
          stack_name = str;

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -204,7 +204,8 @@ void Mainwidget::showPage (const QModelIndex &index, bool delay_smoothing)
 
 void Mainwidget::showDesktop ()
    {
-   setCurrentIndex(0);
+   if (currentIndex())
+      setCurrentIndex(0);
    }
 
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1233,10 +1233,6 @@ QStringList Mainwidget::findFolders(const QString &text, QString& dirPath)
 {
    showDesktop();
 
-   // We want at least three characters for a match
-   if (text.length() < 3)
-      return QStringList();
-
    dirPath = _desktop->getRootDirectory();
 
    Operation op("Finding folders", 100, this);

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1246,9 +1246,9 @@ void Mainwidget::addMatches(QStringList& matches, uint baseLen,
    }
 }
 
-QStringList Mainwidget::findFolders(const QString &text, QString& dirPath)
+QStringList Mainwidget::findFolders(const QString& text, QString& dirPath,
+                                    QStringList& missing)
 {
-   QStringList missing;
    showDesktop();
 
    dirPath = _desktop->getRootDirectory();

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -314,6 +314,14 @@ void Mainwidget::scanInto(const QString& dir_path)
    scanInto(ind);
 }
 
+void Mainwidget::scanIntoNewDir(const QString& dir_path)
+{
+   QModelIndex ind;
+
+   if (_desktop->newDir(dir_path, ind))
+      scanInto(ind);
+}
+
 void Mainwidget::scanInto(QModelIndex target)
    {
    SANE_Status status;

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -122,6 +122,12 @@ public:
     */
    void scanInto(const QString& dir_path);
 
+   /**
+    * @brief Start a new scan into a new directory
+    * @param dir_path   Full path of the directory to create and scan into
+    */
+   void scanIntoNewDir(const QString& dir_path);
+
 signals:
    void newContents (QString);
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -100,6 +100,17 @@ public:
    // called when the main window is closing, to save window settings
    void closing (void);
 
+   /**
+    * @brief  Find folders in the current repo which match a text string
+    * @param  text to match
+    * @param  returns the path to the root directory
+    * @return list of matching paths
+    *
+    * This looks for 4-digit years and 3-character months to try to guess
+    * which folders to put at the top of the list
+    */
+   QStringList findFolders(const QString &text, QString& dirPath);
+
 signals:
    void newContents (QString);
 
@@ -300,6 +311,20 @@ private:
 
    /** connect up the scanner signals */
    void connectScanner (void);
+
+   /**
+    * @brief Search for directories matching a string
+    * @param matches    List of matches to update
+    * @param baseLen    Number of characters to omit at the start of each match
+    * @param dirPath    Directory to scan
+    * @param match      String to match
+    * @param op         Operation, to show progress
+    *
+    * Adds dirPath if it matches the match string, then scans directories within
+    * dirPath recursively.
+    */
+   void addMatches(QStringList& matches, uint baseLen, const QString &dirPath,
+                   const QString &match, Operation *op);
 
 private:
    Desktopwidget *_desktop;

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -111,6 +111,15 @@ public:
     */
    QStringList findFolders(const QString &text, QString& dirPath);
 
+   /* Start a new scan using dir_ind as the destination dir in Dirmodel */
+   void scanInto(QModelIndex dir_ind);
+
+   /**
+    * @brief Start a new scan
+    * @param dir_path   Full path of the directory to scan into
+    */
+   void scanInto(const QString& dir_path);
+
 signals:
    void newContents (QString);
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -102,14 +102,16 @@ public:
 
    /**
     * @brief  Find folders in the current repo which match a text string
-    * @param  text to match
-    * @param  returns the path to the root directory
+    * @param  text    Text to match
+    * @param  dirPath Returns the path to the root directory
+    * @param  missing Suggestions for directories to create
     * @return list of matching paths
     *
     * This looks for 4-digit years and 3-character months to try to guess
     * which folders to put at the top of the list
     */
-   QStringList findFolders(const QString &text, QString& dirPath);
+   QStringList findFolders(const QString &text, QString& dirPath,
+                           QStringList& missing);
 
    /* Start a new scan using dir_ind as the destination dir in Dirmodel */
    void scanInto(QModelIndex dir_ind);

--- a/paperman.pro
+++ b/paperman.pro
@@ -46,6 +46,7 @@ RESOURCES = maxview.qrc
 TRANSLATIONS = maxview_en.ts
 
 HEADERS += desktopwidget.h \
+   foldersel.h \
    mainwidget.h \
    desk.h \
    pagewidget.h \

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -442,6 +442,8 @@ void Pscan::scan_clicked()
                tr("Do you want to add directory %1").arg(fname),
                QMessageBox::Ok, QMessageBox::Cancel) == QMessageBox::Ok;
             _awaiting_user = false;
+            if (ok)
+               _main->scanIntoNewDir(_folders_path + "/" + fname);
             return;
          }
          dir_path = _folders_path + "/" + _model->data(ind).toString();

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -768,7 +768,14 @@ void Pscan::showFolders()
 
 void Pscan::searchForFolders(const QString& match)
 {
-   QStringList folders = _main->findFolders(match, _folders_path);
+   QStringList folders;
+   bool valid = false;
+
+   // We want at least three characters for a match
+   if (match.length() >= 3) {
+      folders = _main->findFolders(match, _folders_path);
+      valid = true;
+   }
 
    // put the folder list into the model
    _model->removeRows(0, _model->rowCount(QModelIndex()), QModelIndex());
@@ -779,7 +786,8 @@ void Pscan::searchForFolders(const QString& match)
 
    if (!folders.size()) {
       _model->insertRows(0, 1, QModelIndex());
-      _model->setData(_model->index(0, 0, QModelIndex()), "<no match>");
+      _model->setData(_model->index(0, 0, QModelIndex()),
+                      valid ? "<no match>" : "<too short>");
    }
 
    // make sure the column is wide enough

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -167,6 +167,14 @@ void Pscan::init()
 
     setupBright ();
 
+    // setup the shortcuts for finding a folder
+    QObject::connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_F), this,
+                                   nullptr, nullptr, Qt::ApplicationShortcut),
+                     &QShortcut::activated, this, &Pscan::focusFind);
+    QObject::connect(new QShortcut(QKeySequence(Qt::Key_F6), this,
+                                   nullptr, nullptr, Qt::ApplicationShortcut),
+                     &QShortcut::activated, this, &Pscan::focusFind);
+
     // setup the keyboard shortcuts Ctrl-1 to Ctrl-5 for presets
     QObject::connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_1), this,
                                    nullptr, nullptr, Qt::ApplicationShortcut),
@@ -724,4 +732,10 @@ Presetadd::Presetadd(QWidget* parent, Qt::WindowFlags fl)
 
 Presetadd::~Presetadd()
 {
+}
+
+void Pscan::focusFind()
+{
+   activateWindow();
+   folderName->setFocus();
 }

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -73,6 +73,8 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     _folders = new QTableView(this);
     _model = new QStandardItemModel(1, 1, this);
     _folders->setModel(_model);
+    _folders->horizontalHeader()->hide();
+    _folders->verticalHeader()->hide();
     _folders->hide();
 
     init();

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -274,7 +274,7 @@ void Pscan::checkFolders()
 
    // show the folder list if focus is in folderName
    if (_folders_valid && QApplication::focusWidget() == folderName) {
-      _folders->show();
+      showFolders();
       _folders->setFocus(Qt::OtherFocusReason);
    }
 }

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -768,14 +768,16 @@ void Pscan::searchForFolders(const QString& match)
 {
    QStringList folders = _main->findFolders(match, _folders_path);
 
-   if (!folders.length())
-      return;
-
    // put the folder list into the model
    _model->removeRows(0, _model->rowCount(QModelIndex()), QModelIndex());
    for (int row = 0; row < folders.size(); row++) {
       _model->insertRows(row, 1, QModelIndex());
       _model->setData(_model->index(row, 0, QModelIndex()), folders[row]);
+   }
+
+   if (!folders.size()) {
+      _model->insertRows(0, 1, QModelIndex());
+      _model->setData(_model->index(0, 0, QModelIndex()), "<no match>");
    }
 
    // make sure the column is wide enough

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -86,6 +86,8 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     _folders->setEditTriggers(QTableView::NoEditTriggers);
 
     _folders->hide();
+    connect(_folders, SIGNAL(keypressReceived(QKeyEvent *)),
+            this, SLOT(keypressFromFolderList(QKeyEvent *)));
 
     init();
     readSettings();
@@ -826,6 +828,11 @@ void Pscan::on_folderName_textChanged(const QString &text)
    } while (match.size());
 }
 
+void Pscan::keypressFromFolderList(QKeyEvent *evt)
+{
+    QApplication::postEvent(folderName, evt);
+}
+
 Foldersel::Foldersel(QWidget* parent)
    : QLineEdit(QString(), parent)
 {
@@ -844,3 +851,20 @@ Folderlist::~Folderlist()
 {
 }
 
+void Folderlist::keyPressEvent(QKeyEvent *old)
+{
+   bool send = true;     // send to folderName field
+   bool pass_on = true;  // pass on to QTableView
+
+   if (send) {
+      QKeyEvent *evt = new QKeyEvent(old->type(), old->key(), old->modifiers(),
+                                     old->text(), old->isAutoRepeat(),
+                                     old->count());
+
+      // Send the keypress to the folderName field
+      emit keypressReceived(evt);
+   }
+
+   if (pass_on)
+      QTableView::keyPressEvent(old);
+}

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -173,6 +173,8 @@ void Pscan::init()
 
     _do_preset_check = false;
 
+    _searching = false;
+
     setupBright ();
 
     // setup the shortcuts for finding a folder
@@ -788,7 +790,20 @@ void Pscan::searchForFolders(const QString& match)
 
 void Pscan::on_folderName_textChanged(const QString &text)
 {
-   searchForFolders(text);
+   if (_searching) {
+      _next_search = text;
+      return;
+   }
+
+   QString match = text;
+   do {
+      _searching = true;
+      searchForFolders(match);
+      _searching = false;
+
+      match = _next_search;
+      _next_search = QString();
+   } while (match.size());
 }
 
 Foldersel::Foldersel(QWidget* parent)

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -808,6 +808,9 @@ void Pscan::searchForFolders(const QString& match)
    _folders->resizeColumnToContents(0);
 
    showFolders();
+
+   if (folders.size())
+      _folders->setFocus();
 }
 
 void Pscan::on_folderName_textChanged(const QString &text)

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -854,7 +854,7 @@ Folderlist::~Folderlist()
 void Folderlist::keyPressEvent(QKeyEvent *old)
 {
    bool send = true;     // send to folderName field
-   bool pass_on = true;  // pass on to QTableView
+   bool pass_on = old->key() != Qt::Key_Tab;  // pass on to QTableView
 
    if (send) {
       QKeyEvent *evt = new QKeyEvent(old->type(), old->key(), old->modifiers(),

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -75,6 +75,12 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     _folders->setModel(_model);
     _folders->horizontalHeader()->hide();
     _folders->verticalHeader()->hide();
+
+    // Set the default row height to 0 so that it will be as small as possible
+    // while still making the text visible
+    _folders->verticalHeader()->setDefaultSectionSize(0);
+    _folders->setShowGrid(false);
+
     _folders->hide();
 
     init();

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -22,11 +22,13 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 
 #include <QDebug>
+#include <QHeaderView>
 #include <QMessageBox>
 #include <QProcess>
 #include <QSettings>
 #include <QShortcut>
 #include <QStandardItemModel>
+#include <QTableView>
 
 #include "pscan.h"
 
@@ -68,6 +70,10 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     format->setId(grey, QScanner::grey);
     format->setId(dither, QScanner::dither);
     format->setId(colour, QScanner::colour);
+    _folders = new QTableView(this);
+    _model = new QStandardItemModel(1, 1, this);
+    _folders->setModel(_model);
+    _folders->hide();
 
     init();
     readSettings();
@@ -738,4 +744,45 @@ void Pscan::focusFind()
 {
    activateWindow();
    folderName->setFocus();
+}
+
+void Pscan::showFolders()
+{
+   // Get a rectangle the same size as folderName but starting below it
+   QRect rect = folderName->geometry();
+   rect.translate(QPoint(0, rect.height()));
+
+   // extend it to the bottom of the dialog
+   rect.setBottom(geometry().bottom());
+
+   // place the folders list in the right place
+   _folders->move(rect.topLeft());
+   _folders->resize(rect.size());
+   _folders->horizontalHeader()->resizeSection(0, rect.width());
+   _folders->show();
+}
+
+void Pscan::searchForFolders(const QString& match)
+{
+   QStringList folders = _main->findFolders(match, _folders_path);
+
+   if (!folders.length())
+      return;
+
+   // put the folder list into the model
+   _model->removeRows(0, _model->rowCount(QModelIndex()), QModelIndex());
+   for (int row = 0; row < folders.size(); row++) {
+      _model->insertRows(row, 1, QModelIndex());
+      _model->setData(_model->index(row, 0, QModelIndex()), folders[row]);
+   }
+
+   // make sure the column is wide enough
+   _folders->resizeColumnToContents(0);
+
+   showFolders();
+}
+
+void Pscan::on_folderName_textChanged(const QString &text)
+{
+   searchForFolders(text);
 }

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -70,7 +70,7 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     format->setId(grey, QScanner::grey);
     format->setId(dither, QScanner::dither);
     format->setId(colour, QScanner::colour);
-    _folders = new QTableView(this);
+    _folders = new Folderlist(this);
     _model = new QStandardItemModel(1, 1, this);
     _folders->setModel(_model);
     _folders->horizontalHeader()->hide();
@@ -834,3 +834,13 @@ Foldersel::Foldersel(QWidget* parent)
 Foldersel::~Foldersel()
 {
 }
+
+Folderlist::Folderlist(QWidget *parent)
+   : QTableView(parent)
+{
+}
+
+Folderlist::~Folderlist()
+{
+}
+

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -81,6 +81,10 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     _folders->verticalHeader()->setDefaultSectionSize(0);
     _folders->setShowGrid(false);
 
+    _folders->setSelectionBehavior(QTableView::SelectRows);
+    _folders->setSelectionMode(QTableView::SingleSelection);
+    _folders->setEditTriggers(QTableView::NoEditTriggers);
+
     _folders->hide();
 
     init();

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -101,6 +101,17 @@ Pscan::~Pscan()
     // no need to delete child widgets, Qt does it all for us
 }
 
+void Pscan::reject()
+{
+   _folders->hide();
+   QDialog::reject();
+}
+
+void Pscan::leaveEvent(QEvent *)
+{
+   _folders->hide();
+}
+
 void Pscan::presetAdd(const Preset& pre)
 {
     _presets.push_back(pre);

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -790,7 +790,9 @@ void Pscan::searchForFolders(const QString& match)
       _model->setData(_model->index(row, 0, QModelIndex()), folders[row]);
    }
 
-   if (!folders.size()) {
+   if (folders.size()) {
+      _folders->selectRow(0);
+   } else {
       _model->insertRows(0, 1, QModelIndex());
       _model->setData(_model->index(0, 0, QModelIndex()),
                       valid ? "<no match>" : "<too short>");

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -788,3 +788,12 @@ void Pscan::on_folderName_textChanged(const QString &text)
 {
    searchForFolders(text);
 }
+
+Foldersel::Foldersel(QWidget* parent)
+   : QLineEdit(QString(), parent)
+{
+}
+
+Foldersel::~Foldersel()
+{
+}

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -420,7 +420,19 @@ void Pscan::reset_clicked()
 
 void Pscan::scan_clicked()
 {
-   _main->scan ();
+   QString dir_path;
+
+   if (_folders_valid && _folders->isVisible()) {
+      QModelIndex ind = _folders->selected();
+
+      if (ind != QModelIndex()) {
+         dir_path = _folders_path + "/" + _model->data(ind).toString();
+         _main->scanInto(dir_path);
+         return;
+      }
+   }
+
+   _main->scan();
 }
 
 
@@ -848,7 +860,7 @@ void Pscan::searchForFolders(const QString& match)
    if (folders.size())
       _folders->setFocus();
 
-   _folders_valid = true;
+   _folders_valid = folders.size() > 0;
 }
 
 void Pscan::on_folderName_textChanged(const QString &text)
@@ -908,4 +920,14 @@ void Folderlist::keyPressEvent(QKeyEvent *old)
 
    if (pass_on)
       QTableView::keyPressEvent(old);
+}
+
+QModelIndex Folderlist::selected()
+{
+   QModelIndexList sel = selectedIndexes();
+
+   if (sel.size())
+      return sel[0];
+
+   return QModelIndex();
 }

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -830,18 +830,26 @@ void Pscan::searchForFolders(const QString& match)
 {
    QStringList folders;
    bool valid = false;
+   int row;
 
    // We want at least three characters for a match
    if (match.length() >= 3) {
-      folders = _main->findFolders(match, _folders_path);
+      folders = _main->findFolders(match, _folders_path, _missing);
       valid = true;
    }
 
    // put the folder list into the model
    _model->removeRows(0, _model->rowCount(QModelIndex()), QModelIndex());
-   for (int row = 0; row < folders.size(); row++) {
+
+   for (row = 0; row < _missing.size(); row++) {
       _model->insertRows(row, 1, QModelIndex());
-      _model->setData(_model->index(row, 0, QModelIndex()), folders[row]);
+      _model->setData(_model->index(row, 0, QModelIndex()),
+                      QString("<Add: %1>").arg(_missing[row]));
+   }
+   for (int i = 0; i < folders.size(); i++) {
+      _model->insertRows(row + i, 1, QModelIndex());
+      _model->setData(_model->index(row + i, 0, QModelIndex()),
+                      folders[i]);
    }
 
    if (folders.size()) {

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -255,6 +255,12 @@ void Pscan::closing()
    qs.endArray();
    }
 
+void Pscan::scanStarting()
+{
+   // close the folders list
+   _folders->close();
+}
+
 void Pscan::checkFolders()
 {
    // close the folder list if the focus is in anything other than the two

--- a/pscan.h
+++ b/pscan.h
@@ -21,11 +21,11 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
  Public License can be found in the /usr/share/common-licenses/GPL file.
 */
 
+#include <QTableView>
 #include "ui_presetadd.h"
 #include "ui_pscan.h"
 
 class QStandardItemModel;
-class QTableView;
 
 class Preset
 {
@@ -51,6 +51,15 @@ public:
     bool _valid;  // preset is valid
 };
 
+
+class Folderlist : public QTableView
+{
+   Q_OBJECT
+
+public:
+   Folderlist(QWidget *parent);
+   ~Folderlist();
+};
 
 class Presetadd : public QDialog, public Ui::Presetadd
 {
@@ -126,7 +135,7 @@ protected:
     bool _do_preset_check;
 
     // List of folders found using the folderName search
-    QTableView *_folders;
+    Folderlist *_folders;
 
     // directory path for the folder list
     QString _folders_path;

--- a/pscan.h
+++ b/pscan.h
@@ -60,6 +60,9 @@ public:
    Folderlist(QWidget *parent);
    ~Folderlist();
 
+   // Return the currently selected item, or -1 if none
+   QModelIndex selected();
+
 signals:
    void keypressReceived(QKeyEvent *event);
 

--- a/pscan.h
+++ b/pscan.h
@@ -172,6 +172,9 @@ protected:
     // true if the folders list has been set up
     bool _folders_valid;
 
+    // possible missing directories shown to the user
+    QStringList _missing;
+
     virtual void languageChange();
 
 private:

--- a/pscan.h
+++ b/pscan.h
@@ -91,6 +91,9 @@ public:
     void closing (void);
    void checkEnabled (bool scanning);
 
+   // Tell pscan that a scan is starting
+   void scanStarting();
+
 public slots:
     virtual void scannerChanged( QScanner * scanner );
     virtual void setMainwidget( Mainwidget * main );

--- a/pscan.h
+++ b/pscan.h
@@ -24,6 +24,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "ui_presetadd.h"
 #include "ui_pscan.h"
 
+class QStandardItemModel;
+class QTableView;
+
 class Preset
 {
 public:
@@ -105,6 +108,7 @@ public slots:
     void on_preset_activated(int item);
     void on_config_clicked();
     void on_stop_clicked ();
+    void on_folderName_textChanged(const QString &text);
 
 protected:
     PreviewWidget *_preview;
@@ -121,7 +125,15 @@ protected:
     // true to check the preset combbox to see an item matches current settings
     bool _do_preset_check;
 
-protected slots:
+    // List of folders found using the folderName search
+    QTableView *_folders;
+
+    // directory path for the folder list
+    QString _folders_path;
+
+    // Model containing the list of folders
+    QStandardItemModel *_model;
+
     virtual void languageChange();
 
 private:
@@ -159,4 +171,10 @@ private:
 
     /** Move the focus to the folder 'find' field */
     void focusFind();
+
+    /** Search for folders which match a string */
+    void searchForFolders(const QString& match);
+
+    /** Show the folders list, sizing it correctly */
+    void showFolders();
 };

--- a/pscan.h
+++ b/pscan.h
@@ -127,6 +127,10 @@ public slots:
     void keypressFromFolderList(QKeyEvent *evt);
 
 protected:
+    void reject();
+    void leaveEvent(QEvent *event);
+
+protected:
     PreviewWidget *_preview;
     QScanner *_scanner;
     Mainwidget *_main;

--- a/pscan.h
+++ b/pscan.h
@@ -134,6 +134,12 @@ protected:
     // Model containing the list of folders
     QStandardItemModel *_model;
 
+    // true if we are currently searching for folders
+    bool _searching;
+
+    // string which we saw while in the middle of searching
+    QString _next_search;
+
     virtual void languageChange();
 
 private:

--- a/pscan.h
+++ b/pscan.h
@@ -156,4 +156,7 @@ private:
 
     /** Select a preset using a shortcut; item is numbered from 1 */
     void presetShortcut(uint item);
+
+    /** Move the focus to the folder 'find' field */
+    void focusFind();
 };

--- a/pscan.h
+++ b/pscan.h
@@ -59,6 +59,12 @@ class Folderlist : public QTableView
 public:
    Folderlist(QWidget *parent);
    ~Folderlist();
+
+signals:
+   void keypressReceived(QKeyEvent *event);
+
+protected:
+   virtual void keyPressEvent(QKeyEvent *event);
 };
 
 class Presetadd : public QDialog, public Ui::Presetadd
@@ -118,6 +124,7 @@ public slots:
     void on_config_clicked();
     void on_stop_clicked ();
     void on_folderName_textChanged(const QString &text);
+    void keypressFromFolderList(QKeyEvent *evt);
 
 protected:
     PreviewWidget *_preview;

--- a/pscan.h
+++ b/pscan.h
@@ -125,10 +125,10 @@ public slots:
     void on_stop_clicked ();
     void on_folderName_textChanged(const QString &text);
     void keypressFromFolderList(QKeyEvent *evt);
+    void checkFolders(void);
 
 protected:
     void reject();
-    void leaveEvent(QEvent *event);
 
 protected:
     PreviewWidget *_preview;
@@ -159,6 +159,12 @@ protected:
 
     // string which we saw while in the middle of searching
     QString _next_search;
+
+    // timer for checking whether we should close the folder list
+    QTimer *_folders_timer;
+
+    // true if the folders list has been set up
+    bool _folders_valid;
 
     virtual void languageChange();
 

--- a/pscan.h
+++ b/pscan.h
@@ -175,6 +175,9 @@ protected:
     // possible missing directories shown to the user
     QStringList _missing;
 
+    // true if waiting for the user to confirm directory creation
+    bool _awaiting_user;
+
     virtual void languageChange();
 
 private:

--- a/pscan.ui
+++ b/pscan.ui
@@ -18,7 +18,7 @@
   <property name="windowIconText">
    <string> df</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
     <layout class="QVBoxLayout">
      <item>
@@ -90,6 +90,40 @@
         <widget class="QLineEdit" name="pageName">
          <property name="toolTip">
           <string>Enter the name for each page of the stack to be scanned</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="testLabel">
+         <property name="text">
+          <string>Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Minimum</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="folderName">
+         <property name="toolTip">
+          <string>Type here to interactively search for / create folders, then press &lt;enter&gt; to scan</string>
          </property>
         </widget>
        </item>
@@ -548,6 +582,7 @@
  <tabstops>
   <tabstop>stackName</tabstop>
   <tabstop>pageName</tabstop>
+  <tabstop>folderName</tabstop>
   <tabstop>mono</tabstop>
   <tabstop>dither</tabstop>
   <tabstop>grey</tabstop>
@@ -559,6 +594,7 @@
   <tabstop>cancel</tabstop>
   <tabstop>stop</tabstop>
   <tabstop>scan</tabstop>
+  <tabstop>preset</tabstop>
   <tabstop>options</tabstop>
   <tabstop>reset</tabstop>
   <tabstop>config</tabstop>

--- a/pscan.ui
+++ b/pscan.ui
@@ -121,7 +121,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLineEdit" name="folderName">
+        <widget class="Foldersel" name="folderName">
          <property name="toolTip">
           <string>Type here to interactively search for / create folders, then press &lt;enter&gt; to scan</string>
          </property>
@@ -577,6 +577,11 @@
    <class>SliderSpin</class>
    <extends>QWidget</extends>
    <header>sliderspin.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Foldersel</class>
+   <extends>QLineEdit</extends>
+   <header>foldersel.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/testpaperman.cpp
+++ b/tests/testpaperman.cpp
@@ -5,8 +5,31 @@
 class TestPaperman: public QObject
 {
    Q_OBJECT
+private slots:
+   void testDetectYear();
+   void testDetectMonth();
 };
 
+void TestPaperman::testDetectYear()
+{
+   QCOMPARE(utilDetectYear("/vid/bills/2024/03mar/fred.max"), 2024);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/2023/fred.max"), 2023);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/1899/fred.max"), 0);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/20201/fred.max"), 0);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/12020/fred.max"), 0);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/a2020/fred.max"), 2020);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/12020b/fred.max"), 0);
+   QCOMPARE(utilDetectYear("/vid/bills/tax/a2020b/fred.max"), 2020);
+}
+
+void TestPaperman::testDetectMonth()
+{
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/03mar/fred.max"), 3);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/04-mar/fred.max"), 3);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mar/fred.max"), 3);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-marc/fred.max"), 0);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mmar/fred.max"), 0);
+}
 
 QTEST_MAIN(TestPaperman)
 #include "testpaperman.moc"

--- a/tests/testpaperman.cpp
+++ b/tests/testpaperman.cpp
@@ -43,33 +43,89 @@ void TestPaperman::testDetectMonth()
 
 void TestPaperman::testDetectMatches()
 {
-   QStringList matches, final;
+   QStringList matches, final, missing;
    QDate date = QDate(2024, 9, 1);
 
-   final = utilDetectMatches(date, matches);
+   final = utilDetectMatches(date, matches, missing);
    QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 0);
 
    // Should ignore a month if it isn't preceeded by a year
    matches << "bills/03mar";
-   final = utilDetectMatches(date, matches);
+   final = utilDetectMatches(date, matches, missing);
    QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 0);
 
    matches << "bills/2024/03mar";
-   final = utilDetectMatches(date, matches);
+   final = utilDetectMatches(date, matches, missing);
    QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 0);
 
    // Check it can detect a month
    matches << "bills/2024/09sep";
-   final = utilDetectMatches(date, matches);
+   final = utilDetectMatches(date, matches, missing);
    QCOMPARE(final.size(), 1);
    QCOMPARE(final[0], "bills/2024/09sep");
+   QCOMPARE(missing.size(), 0);
 
    // Check it can detect a year
    matches << "bills/2024";
-   final = utilDetectMatches(date, matches);
+   final = utilDetectMatches(date, matches, missing);
    QCOMPARE(final.size(), 2);
-   QCOMPARE(final[0], "bills/2024/09sep");  // should be in other order
+   QCOMPARE(final[0], "bills/2024/09sep");
    QCOMPARE(final[1], "bills/2024");
+   QCOMPARE(missing.size(), 0);
+
+   // Advance to Oct 2024; check it can suggest adding a month
+   date = QDate(2024, 10, 1);
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 1);
+   QCOMPARE(final[0], "bills/2024");
+   QCOMPARE(missing.size(), 1);
+   QCOMPARE(missing[0], "bills/2024/10oct");
+
+   // Make sure it only suggests this if the year is right
+   date = QDate(2023, 10, 1);
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 0);
+
+   // Advance to Jan 2025; check it doesn't suggest adding January, since Dec
+   // isn't there. But it should suggest adding 2025
+   date = QDate(2025, 1, 1);
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 1);
+   QCOMPARE(missing[0], "bills/2025");
+
+   // Advance to Feb 2025; check that it suggests adding 2025
+   date = QDate(2025, 2, 1);
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 1);
+   QCOMPARE(missing[0], "bills/2025");
+
+   // Make to Jan 2025; now add Dec24 and check that it suggests adding Jan25
+   date = QDate(2025, 1, 1);
+   matches << "bills/2024/12dec";
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 1);
+   QCOMPARE(missing[0], "bills/2025/01jan");
+
+   // ...but not if Jan25 already exists
+   matches << "bills/2025/01jan";
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 1);
+   QCOMPARE(final[0], "bills/2025/01jan");
+   QCOMPARE(missing.size(), 0);
+
+   // Now move to 2026 and make sure it suggests to add that
+   matches << "bills/2025";
+   date = QDate(2026, 1, 1);
+   final = utilDetectMatches(date, matches, missing);
+   QCOMPARE(final.size(), 0);
+   QCOMPARE(missing.size(), 1);
+   QCOMPARE(missing[0], "bills/2026");
 }
 
 QTEST_MAIN(TestPaperman)

--- a/tests/testpaperman.cpp
+++ b/tests/testpaperman.cpp
@@ -8,6 +8,7 @@ class TestPaperman: public QObject
 private slots:
    void testDetectYear();
    void testDetectMonth();
+   void testDetectMatches();
 };
 
 void TestPaperman::testDetectYear()
@@ -25,10 +26,41 @@ void TestPaperman::testDetectYear()
 void TestPaperman::testDetectMonth()
 {
    QCOMPARE(utilDetectMonth("/vid/bills/2024/03mar/fred.max"), 3);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/04-mar/fred.max"), 3);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mar/fred.max"), 3);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/04-mar/fred.max"), 0);
+   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mar/fred.max"), 0);
    QCOMPARE(utilDetectMonth("/vid/bills/2024/07-marc/fred.max"), 0);
    QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mmar/fred.max"), 0);
+}
+
+void TestPaperman::testDetectMatches()
+{
+   QStringList matches, final;
+   QDate date = QDate(2024, 9, 1);
+
+   final = utilDetectMatches(date, matches);
+   QCOMPARE(final.size(), 0);
+
+   // Should ignore a month if it isn't preceeded by a year
+   matches << "bills/03mar";
+   final = utilDetectMatches(date, matches);
+   QCOMPARE(final.size(), 0);
+
+   matches << "bills/2024/03mar";
+   final = utilDetectMatches(date, matches);
+   QCOMPARE(final.size(), 0);
+
+   // Check it can detect a month
+   matches << "bills/2024/09sep";
+   final = utilDetectMatches(date, matches);
+   QCOMPARE(final.size(), 1);
+   QCOMPARE(final[0], "bills/2024/09sep");
+
+   // Check it can detect a year
+   matches << "bills/2024";
+   final = utilDetectMatches(date, matches);
+   QCOMPARE(final.size(), 2);
+   QCOMPARE(final[0], "bills/2024/09sep");  // should be in other order
+   QCOMPARE(final[1], "bills/2024");
 }
 
 QTEST_MAIN(TestPaperman)

--- a/tests/testpaperman.cpp
+++ b/tests/testpaperman.cpp
@@ -13,23 +13,32 @@ private slots:
 
 void TestPaperman::testDetectYear()
 {
-   QCOMPARE(utilDetectYear("/vid/bills/2024/03mar/fred.max"), 2024);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/2023/fred.max"), 2023);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/1899/fred.max"), 0);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/20201/fred.max"), 0);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/12020/fred.max"), 0);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/a2020/fred.max"), 2020);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/12020b/fred.max"), 0);
-   QCOMPARE(utilDetectYear("/vid/bills/tax/a2020b/fred.max"), 2020);
+   int pos;
+
+   QCOMPARE(utilDetectYear("bills/2024/03mar/fred.max", pos), 2024);
+   QCOMPARE(pos, 6);
+   QCOMPARE(utilDetectYear("bills/tax/2023/fred.max", pos), 2023);
+   QCOMPARE(pos, 10);
+   QCOMPARE(utilDetectYear("bills/tax/1899/fred.max", pos), 0);
+   QCOMPARE(utilDetectYear("bills/tax/20201/fred.max", pos), 0);
+   QCOMPARE(utilDetectYear("bills/tax/12020/fred.max", pos), 0);
+   QCOMPARE(utilDetectYear("bills/tax/a2020/fred.max", pos), 2020);
+   QCOMPARE(pos, 11);
+   QCOMPARE(utilDetectYear("bills/tax/12020b/fred.max", pos), 0);
+   QCOMPARE(utilDetectYear("bills/tax/a2020b/fred.max", pos), 2020);
+   QCOMPARE(pos, 11);
 }
 
 void TestPaperman::testDetectMonth()
 {
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/03mar/fred.max"), 3);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/04-mar/fred.max"), 0);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mar/fred.max"), 0);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-marc/fred.max"), 0);
-   QCOMPARE(utilDetectMonth("/vid/bills/2024/07-mmar/fred.max"), 0);
+   int pos;
+
+   QCOMPARE(utilDetectMonth("bills/2024/03mar/fred.max", pos), 3);
+   QCOMPARE(pos, 11);
+   QCOMPARE(utilDetectMonth("bills/2024/04-mar/fred.max", pos), 0);
+   QCOMPARE(utilDetectMonth("bills/2024/07mar/fred.max", pos), 0);
+   QCOMPARE(utilDetectMonth("bills/2024/07-marc/fred.max", pos), 0);
+   QCOMPARE(utilDetectMonth("bills/2024/07-mmar/fred.max", pos), 0);
 }
 
 void TestPaperman::testDetectMatches()

--- a/utils.cpp
+++ b/utils.cpp
@@ -637,3 +637,50 @@ QString utilRemoveQuotes (QString str)
    return str;
    }
 
+
+int utilDetectYear(const QString& fname)
+{
+   int len = fname.length();
+
+   // search for year from 1900 to 2099
+   QRegExp rx("(\\d{4})");
+
+   for (int pos = 0; pos = rx.indexIn(fname, pos), pos != -1;
+        pos += rx.matchedLength()) {
+
+      // make sure here is no digit either side
+      if (fname[pos - 1].isDigit() ||
+          (pos + 4 < len && fname[pos + 4].isDigit()))
+         continue;
+      int year = rx.cap(0).toInt();
+
+      if (year >= 1900 && year < 2100)
+          return year;
+   }
+
+   return 0;
+}
+
+int utilDetectMonth(const QString& fname)
+{
+   QString months = "(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)";
+   // search for year from 1900 to 2099
+   QRegExp rx(months, Qt::CaseInsensitive);
+
+   for (int pos = 0; pos = rx.indexIn(fname, pos), pos != -1;
+        pos += rx.matchedLength()) {
+
+      int len = rx.pos() + 3;
+
+      // make sure here is no letter either side
+      if (fname[pos - 1].isLetter() ||
+          (fname.size() > len && fname[len].isLetter()))
+         continue;
+
+      int month = 1 + months.indexOf(rx.cap(0)) / 4;
+
+      return month;
+   }
+
+   return 0;
+}

--- a/utils.cpp
+++ b/utils.cpp
@@ -639,7 +639,7 @@ QString utilRemoveQuotes (QString str)
    }
 
 
-int utilDetectYear(const QString& fname)
+int utilDetectYear(const QString& fname, int& foundPos)
 {
    int len = fname.length();
 
@@ -655,14 +655,16 @@ int utilDetectYear(const QString& fname)
          continue;
       int year = rx.cap(0).toInt();
 
-      if (year >= 1900 && year < 2100)
-          return year;
+      if (year >= 1900 && year < 2100) {
+         foundPos = pos;
+         return year;
+      }
    }
 
    return 0;
 }
 
-int utilDetectMonth(const QString& fname)
+int utilDetectMonth(const QString& fname, int& foundPos)
 {
    QString months = "(01jan|02feb|03mar|04apr|05may|06jun|07jul|08aug|09sep|10oct|11nov|12dec)";
    // search for year from 1900 to 2099
@@ -678,6 +680,7 @@ int utilDetectMonth(const QString& fname)
          continue;
 
       int month = 1 + months.indexOf(rx.cap(0)) / 6;
+      foundPos = pos;
 
       return month;
    }
@@ -690,8 +693,9 @@ QStringList utilDetectMatches(const QDate& date, QStringList& matches)
    QStringList to_sort;
 
    foreach (const QString& item, matches) {
-      int year = utilDetectYear(item);
-      int month = utilDetectMonth(item);
+      int ypos, mpos;
+      int year = utilDetectYear(item, ypos);
+      int month = utilDetectMonth(item, mpos);
 
       if (year && year != date.year())
           continue;

--- a/utils.h
+++ b/utils.h
@@ -186,9 +186,12 @@ int utilDetectMonth(const QString& fname, int& foundPos);
  * @brief Suggest possible existing directories and new ones to create
  * @param date     Date to use for searching
  * @param matches  Returns a sorted list of matches
+ * @param missing  Returns a list of directories which could be created to make
+ *                 a better match
  * @return List of matches in order of quality
  */
-QStringList utilDetectMatches(const QDate& date, QStringList& matches);
+QStringList utilDetectMatches(const QDate& date, QStringList& matches,
+                              QStringList& missing);
 
 #endif
 

--- a/utils.h
+++ b/utils.h
@@ -164,6 +164,7 @@ QString utilRemoveQuotes (QString str);
 /**
  * @brief Find a year in a filename
  * @param fname    Filename to check
+ * @param foundPos Position in fname where the match was found
  * @return year (e.g. 2024) or 0 if none found
  *
  * Supported options are:
@@ -171,14 +172,15 @@ QString utilRemoveQuotes (QString str);
  * 1. a year number as yyyy
  * 2. mmmyy or yymmm where mmm is a 3-character month name, yy 2-digit year
  */
-int utilDetectYear(const QString& fname);
+int utilDetectYear(const QString& fname, int& foundPos);
 
 /**
  * @brief Find a month in a filename
  * @param fname   Filename to check
+ * @param foundPos Position in fname where the match was found
  * @return month (1=January, 12=December) or 0 if none
  */
-int utilDetectMonth(const QString& fname);
+int utilDetectMonth(const QString& fname, int& foundPos);
 
 /**
  * @brief Suggest possible existing directories and new ones to create

--- a/utils.h
+++ b/utils.h
@@ -38,6 +38,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QList>
 #include <QString>
 
+class QDate;
 
 typedef unsigned char byte;
 
@@ -178,6 +179,14 @@ int utilDetectYear(const QString& fname);
  * @return month (1=January, 12=December) or 0 if none
  */
 int utilDetectMonth(const QString& fname);
+
+/**
+ * @brief Suggest possible existing directories and new ones to create
+ * @param date     Date to use for searching
+ * @param matches  Returns a sorted list of matches
+ * @return List of matches in order of quality
+ */
+QStringList utilDetectMatches(const QDate& date, QStringList& matches);
 
 #endif
 

--- a/utils.h
+++ b/utils.h
@@ -160,6 +160,24 @@ err_info *util_getUsername (QString &userName);
   \returns string without quotes, or unchanged if there are no quotes */
 QString utilRemoveQuotes (QString str);
 
+/**
+ * @brief Find a year in a filename
+ * @param fname    Filename to check
+ * @return year (e.g. 2024) or 0 if none found
+ *
+ * Supported options are:
+ *
+ * 1. a year number as yyyy
+ * 2. mmmyy or yymmm where mmm is a 3-character month name, yy 2-digit year
+ */
+int utilDetectYear(const QString& fname);
+
+/**
+ * @brief Find a month in a filename
+ * @param fname   Filename to check
+ * @return month (1=January, 12=December) or 0 if none
+ */
+int utilDetectMonth(const QString& fname);
 
 #endif
 


### PR DESCRIPTION
Add a folders field to pscan to allow a folder to be quickly selected as the target for a scan, rather than having to hunt around in the tree view for the right place