### PR TITLE
Fix the parallel-conversion corruption and make output deterministic

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ BUILDDIR      = $(DOCDIR)/_build
 
 .DEFAULT_GOAL := all
 
-all: paperman paperman-server app docs
+all: paperman paperman-server paperman-client app docs
 
 paperman:
 	$(MAKE) -f Makefile $@
@@ -40,6 +40,12 @@ paperman-server: Makefile.server builddate.h
 
 Makefile.server: paperman-server.pro
 	qmake paperman-server.pro -o Makefile.server
+
+paperman-client: Makefile.client
+	$(MAKE) -f Makefile.client
+
+Makefile.client: paperman-client.pro
+	qmake paperman-client.pro -o Makefile.client
 
 test-setup: paperman
 	python3 scripts/make_test_files.py
@@ -236,11 +242,12 @@ app-clean:
 clean: app-clean docs-clean
 	-test -f Makefile && $(MAKE) -f Makefile clean
 	-test -f Makefile.server && $(MAKE) -f Makefile.server clean
-	rm -f paperman paperman-server builddate.h Makefile.server *.o moc_*.cpp moc_predefs.h
+	-test -f Makefile.client && $(MAKE) -f Makefile.client clean
+	rm -f paperman paperman-server paperman-client builddate.h Makefile.server Makefile.client *.o moc_*.cpp moc_predefs.h
 
 distclean: app-clean docs-clean
-	rm -f paperman paperman-server builddate.h *.o moc_*.cpp moc_predefs.h
-	rm -f Makefile Makefile.qt6 Makefile.server server.mk .qmake.stash
+	rm -f paperman paperman-server paperman-client builddate.h *.o moc_*.cpp moc_predefs.h
+	rm -f Makefile Makefile.qt6 Makefile.server Makefile.client server.mk .qmake.stash
 	rm -rf .obj .moc .ui
 
 docs-clean:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,6 +54,7 @@ app-test:
 	cd app && flutter test
 
 test: paperman-server paperman test-setup app-test
+	QT_QPA_PLATFORM=offscreen ./paperman -t
 	scripts/test_page_fetch.sh
 	scripts/test_parallel.sh
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Scanning | Fast folder finding | Scanning dialog | Side-by-side preview & OCR
 - move stacks between directories
 - double click to view full size page image (also on right pane)
 - print stacks and pages, including page annotations
+- email files as PDF via Gmail (Ctrl+Shift+E, paste with Ctrl+V)
 - full undo/redo
 
 

--- a/backend.cpp
+++ b/backend.cpp
@@ -1,0 +1,19 @@
+/*
+License: GPL-2
+*/
+
+#include "backend.h"
+
+#include <QFileInfo>
+
+
+QString Backend::contentTypeForPath(const QString &path)
+{
+   QString ext = QFileInfo(path).suffix().toLower();
+   if (ext == "pdf")                        return "application/pdf";
+   if (ext == "jpg" || ext == "jpeg")       return "image/jpeg";
+   if (ext == "tif" || ext == "tiff")       return "image/tiff";
+   if (ext == "png")                        return "image/png";
+   /* .max and anything else: opaque bytes. */
+   return "application/octet-stream";
+}

--- a/backend.h
+++ b/backend.h
@@ -22,11 +22,35 @@ struct RepositoryInfo
 };
 
 
+/** A single entry in a directory listing: either a file or a
+ *  subdirectory.  Mirrors the JSON shape /browse returns. */
+struct DirectoryEntry
+{
+    QString name;
+    QString path;        //!< Repo-relative path
+    qint64 size = 0;     //!< 0 for directories
+    bool isDir = false;
+    QString modified;    //!< ISO-8601 (files only)
+    int count = 0;       //!< File count for directory entries (recursive)
+};
+
+
+struct DirectoryListing
+{
+    /** True if the call succeeded.  When false, @c error describes
+     *  why and @c notFound distinguishes 404 from 400. */
+    bool ok = false;
+    bool notFound = false;
+    QString error;
+    QList<DirectoryEntry> entries;
+};
+
+
 /**
  * Abstract data source the server reads from.  The local deployment
- * uses LocalBackend (in-process file access); a future RemoteBackend
- * will forward calls to another paperman-server over HTTP, letting the
- * GUI client and the server share the same call sites.
+ * uses LocalBackend (in-process file access); RemoteBackend forwards
+ * calls to another paperman-server over HTTP, letting the GUI client
+ * and the server share the same call sites.
  *
  * Only the surface the HTTP layer needs lives here.  Methods are added
  * as their HTTP handlers are migrated through the interface.
@@ -39,6 +63,13 @@ public:
     /** List configured repositories.  Order is the same as the
      *  paperman-server command line. */
     virtual QList<RepositoryInfo> listRepositories() = 0;
+
+    /** Browse a directory in a repository.  @c repo is the basename
+     *  returned by listRepositories(); @c dir is the path relative to
+     *  the repo root (empty means the root).  Directories come first
+     *  in the entries list. */
+    virtual DirectoryListing browseDirectory(const QString &repo,
+                                             const QString &dir) = 0;
 };
 
 #endif // BACKEND_H

--- a/backend.h
+++ b/backend.h
@@ -46,6 +46,18 @@ struct DirectoryListing
 };
 
 
+/** Result of a whole-file fetch.  @c contentType is derived from the
+ *  filename extension. */
+struct FileFetch
+{
+    bool ok = false;
+    bool notFound = false;
+    QString error;
+    QString contentType;
+    QByteArray bytes;
+};
+
+
 /**
  * Abstract data source the server reads from.  The local deployment
  * uses LocalBackend (in-process file access); RemoteBackend forwards
@@ -70,6 +82,18 @@ public:
      *  in the entries list. */
     virtual DirectoryListing browseDirectory(const QString &repo,
                                              const QString &dir) = 0;
+
+    /** Fetch the raw bytes of a file from a repository.  @c path is
+     *  relative to the repo root.  Returned bytes are the original
+     *  on-disk file (no PDF page extraction or format conversion —
+     *  those still live on the HTTP layer). */
+    virtual FileFetch readFile(const QString &repo,
+                               const QString &path) = 0;
+
+    /** MIME type for a path, derived from the filename extension.
+     *  Shared so LocalBackend and RemoteBackend agree on the type
+     *  without having to ask the server. */
+    static QString contentTypeForPath(const QString &path);
 };
 
 #endif // BACKEND_H

--- a/backend.h
+++ b/backend.h
@@ -1,0 +1,44 @@
+/*
+License: GPL-2
+*/
+
+#ifndef BACKEND_H
+#define BACKEND_H
+
+#include <QList>
+#include <QString>
+
+
+/**
+ * One entry in the repository list.  Mirrors the existing /repos JSON
+ * shape: a repository may be configured but missing on disk, in which
+ * case @c exists is false and @c name is empty.
+ */
+struct RepositoryInfo
+{
+    QString name;
+    QString path;
+    bool exists = false;
+};
+
+
+/**
+ * Abstract data source the server reads from.  The local deployment
+ * uses LocalBackend (in-process file access); a future RemoteBackend
+ * will forward calls to another paperman-server over HTTP, letting the
+ * GUI client and the server share the same call sites.
+ *
+ * Only the surface the HTTP layer needs lives here.  Methods are added
+ * as their HTTP handlers are migrated through the interface.
+ */
+class Backend
+{
+public:
+    virtual ~Backend() = default;
+
+    /** List configured repositories.  Order is the same as the
+     *  paperman-server command line. */
+    virtual QList<RepositoryInfo> listRepositories() = 0;
+};
+
+#endif // BACKEND_H

--- a/backendstats.cpp
+++ b/backendstats.cpp
@@ -1,0 +1,56 @@
+/*
+License: GPL-2
+*/
+
+#include "backendstats.h"
+
+
+void BackendStats::setUrl(const QString &url)
+{
+   if (_url == url)
+      return;
+   _url = url;
+   emit changed();
+}
+
+
+void BackendStats::reset()
+{
+   _sent = 0;
+   _received = 0;
+   _active = 0;
+   emit changed();
+}
+
+
+void BackendStats::requestStarted()
+{
+   _active++;
+   emit changed();
+}
+
+
+void BackendStats::requestFinished()
+{
+   if (_active > 0)
+      _active--;
+   emit changed();
+}
+
+
+void BackendStats::recordSent(qint64 bytes)
+{
+   if (bytes <= 0)
+      return;
+   _sent += bytes;
+   emit changed();
+}
+
+
+void BackendStats::recordReceived(qint64 bytes)
+{
+   if (bytes <= 0)
+      return;
+   _received += bytes;
+   emit changed();
+}

--- a/backendstats.h
+++ b/backendstats.h
@@ -1,0 +1,60 @@
+/*
+License: GPL-2
+*/
+
+#ifndef BACKENDSTATS_H
+#define BACKENDSTATS_H
+
+#include <QObject>
+#include <QString>
+
+
+/**
+ * Lightweight aggregator for network activity across one or more
+ * RemoteBackend instances.  Each request increments activeRequests
+ * for the duration of the call and adds to bytesSent/bytesReceived
+ * counters when the bytes leave/arrive.  The @c changed() signal
+ * fires after every update so a status widget can rebuild its
+ * display.
+ *
+ * The bytesSent/bytesReceived counters approximate body sizes —
+ * HTTP request/response headers are not counted.  Good enough for
+ * a user-facing "how much data have I pulled" indicator.
+ */
+class BackendStats : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BackendStats(QObject *parent = nullptr) : QObject(parent) {}
+
+    qint64 bytesSent() const     { return _sent; }
+    qint64 bytesReceived() const { return _received; }
+    int activeRequests() const   { return _active; }
+
+    /** URL of the paperman-server the user pointed paperman at,
+     *  shown next to the byte counters.  Empty when no remote
+     *  server is configured. */
+    QString url() const          { return _url; }
+    void setUrl(const QString &url);
+
+    /** Reset the byte counters and active count to zero.  Useful
+     *  for tests and for an "Reset stats" UI action. */
+    void reset();
+
+    /** Hooks called by RemoteBackend at each stage of a request. */
+    void requestStarted();
+    void requestFinished();
+    void recordSent(qint64 bytes);
+    void recordReceived(qint64 bytes);
+
+signals:
+    void changed();
+
+private:
+    qint64 _sent = 0;
+    qint64 _received = 0;
+    int _active = 0;
+    QString _url;
+};
+
+#endif // BACKENDSTATS_H

--- a/cachedfile.h
+++ b/cachedfile.h
@@ -1,0 +1,26 @@
+/*
+License: GPL-2
+*/
+
+#ifndef CACHEDFILE_H
+#define CACHEDFILE_H
+
+#include <QDateTime>
+#include <QString>
+
+
+/**
+ * One entry in the file cache LocalBackend maintains for each
+ * repository.  The cache is built from a recursive scan (or loaded
+ * from a `.papertree` index file) at startup and is the source of
+ * truth for fast directory browsing and search.
+ */
+struct CachedFile
+{
+    QString path;        //!< Relative path from repository root
+    QString name;        //!< Filename only
+    qint64 size;         //!< File size in bytes
+    QDateTime modified;  //!< Last modification time
+};
+
+#endif // CACHEDFILE_H

--- a/desk.cpp
+++ b/desk.cpp
@@ -45,6 +45,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "qimage.h"
 #include "qstring.h"
 
+#include "backend.h"
 #include "desk.h"
 #include "file.h"
 #include "filemax.h"
@@ -190,6 +191,31 @@ void Desk::updateRowCount (void)
 
 void Desk::addFiles(const QString &dirPath, Measure *meas)
    {
+   if (_backend) {
+      /* Remote (or otherwise backend-backed) desk: route the file
+       * list through the Backend instead of touching the local
+       * filesystem.  dirPath has a trailing "/" and _rootDir is
+       * the repo root.  browseDirectory wants the repo-relative
+       * subpath. */
+      QString rel = dirPath;
+      if (rel.startsWith(_rootDir))
+         rel = rel.mid(_rootDir.length());
+      if (rel.endsWith('/'))
+         rel.chop(1);
+      DirectoryListing listing = _backend->browseDirectory(_repoName, rel);
+      if (!listing.ok) {
+         qInfo() << "Desk::addFiles: backend error:" << listing.error;
+         return;
+      }
+      for (const DirectoryEntry &e : listing.entries) {
+         if (e.isDir)
+            continue;
+         addFile(e.name, dirPath, meas);
+      }
+      updateRowCount();
+      return;
+   }
+
    QDir dir (dirPath);
    dir.setFilter(QDir::Files | QDir::NoSymLinks);
    dir.setSorting(QDir::Name);

--- a/desk.cpp
+++ b/desk.cpp
@@ -337,20 +337,15 @@ File *Desk::createFile (const QString &dir, const QString fname)
    File::e_type type;
 
    type = File::typeFromName (fname);
-#if 0
-   QFileInfo fi (dir, fname);
-   QString ext = fi.suffix ();
-   File *f;
-   File::e_type type;
 
-   //FIXME: there should be an associate config for doing this
-   if (ext == "max")
-      type = File::Type_max;
-   else if (ext == "pdf")
-      type = File::Type_pdf;
-   else
+   /* Remote-backed desk: the dir/fname combination is a synthetic
+    * URL path that the Filemax/Filepdf/Filejpeg loaders can't open
+    * via QFile.  Use the Fileother stub instead; the Backend's
+    * thumbnail fetch populates the pixmap later via setThumbnail.
+    * Page viewing for remote files needs its own Backend-driven
+    * loader and isn't wired up yet. */
+   if (_isRemote)
       type = File::Type_other;
-#endif
 
    return File::createFile (dir, fname, this, type);
    }

--- a/desk.cpp
+++ b/desk.cpp
@@ -100,8 +100,13 @@ Desk::Desk(const QString &dirPath, const QString &trashPath, bool do_readDesk)
          _dir += "/";
    }
 
-   if (!trashPath.isEmpty ())
+   if (!trashPath.isEmpty () && QDir(trashPath).exists())
       {
+      /* Only manage the trash directory on a real local filesystem
+       * path.  For a remote repo trashPath is a synthetic URL
+       * (e.g. "http://host/repo/") that we obviously can't mkdir;
+       * the eventual remote-trash support will come via a Backend
+       * method, not by poking the local FS. */
       QDir dir;
       _trash_dir = trashPath + ".maxview-trash";
       if (!dir.exists (_trash_dir))

--- a/desk.h
+++ b/desk.h
@@ -103,9 +103,15 @@ public:
    /** Attach a Backend to this desk; addFiles() will route through it
     *  instead of QDir if set.  Non-owning pointer; the backend lives
     *  on the Diritem in Dirmodel.  @p repoName is the basename the
-    *  backend uses to identify this repository. */
-   void setBackend(Backend *backend, const QString &repoName)
-       { _backend = backend; _repoName = repoName; }
+    *  backend uses to identify this repository.  @p isRemote tells
+    *  us whether file paths handed to addFile are real on the local
+    *  filesystem; when false we force every File entry into the
+    *  Fileother stub (no local open is attempted) and skip the
+    *  .maxdesk write at destruction. */
+   void setBackend(Backend *backend, const QString &repoName,
+                   bool isRemote = false)
+       { _backend = backend; _repoName = repoName; _isRemote = isRemote;
+         if (isRemote) _do_writeDesk = false; }
 
    /** Backend currently attached to this desk (nullptr for local). */
    Backend *backend() const { return _backend; }
@@ -618,6 +624,7 @@ private:
    QString _rootDir;   //!< root directory for this model (where trash is)
    Backend *_backend = nullptr;  //!< Optional data source; nullptr = local QDir
    QString _repoName;  //!< Repository name when _backend is set
+   bool _isRemote = false;  //!< Backend is remote: skip local file ops
    QPoint _pos;        //!< next position for a file to appear
    int _rightMargin;   //!< right margin for items
    int _debug_level;     //!< the debug level to use for max debugging

--- a/desk.h
+++ b/desk.h
@@ -83,6 +83,9 @@ typedef struct filelist_info
 #endif
 
 
+class Backend;
+
+
 class Desk
    {
 public:
@@ -96,6 +99,13 @@ public:
 
    /** set up an empty temporary desk */
    Desk (void);
+
+   /** Attach a Backend to this desk; addFiles() will route through it
+    *  instead of QDir if set.  Non-owning pointer; the backend lives
+    *  on the Diritem in Dirmodel.  @p repoName is the basename the
+    *  backend uses to identify this repository. */
+   void setBackend(Backend *backend, const QString &repoName)
+       { _backend = backend; _repoName = repoName; }
 
    //! destructor
    ~Desk ();
@@ -598,6 +608,8 @@ private:
 //    std::list<file_info *>::iterator _it;
    QString _dir;       //!< directory the files are in
    QString _rootDir;   //!< root directory for this model (where trash is)
+   Backend *_backend = nullptr;  //!< Optional data source; nullptr = local QDir
+   QString _repoName;  //!< Repository name when _backend is set
    QPoint _pos;        //!< next position for a file to appear
    int _rightMargin;   //!< right margin for items
    int _debug_level;     //!< the debug level to use for max debugging

--- a/desk.h
+++ b/desk.h
@@ -107,6 +107,14 @@ public:
    void setBackend(Backend *backend, const QString &repoName)
        { _backend = backend; _repoName = repoName; }
 
+   /** Backend currently attached to this desk (nullptr for local). */
+   Backend *backend() const { return _backend; }
+   QString repoName() const { return _repoName; }
+
+   /** Non-owning view of this desk's files; used by Desktopmodel to
+    *  iterate when scheduling async thumbnail fetches. */
+   const QList<File *> &files() const { return _files; }
+
    //! destructor
    ~Desk ();
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -24,6 +24,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <assert.h>
 
 #include "config.h"
+#include "backend.h"
+#include "dirmodel.h"
 
 #include "qapplication.h"
 #include "qcursor.h"
@@ -1413,6 +1415,21 @@ QModelIndex Desktopmodel::showDir(QString dirPath, QString rootPath,
    }
 
    desk->setDebugLevel (_debug_level);
+
+   /* If the repository for this root path has a Backend (e.g. a
+    * remote paperman-server), route the file listing through it
+    * instead of the local filesystem.  The root path Dirmodel
+    * registered as the Diritem identifier has no trailing slash;
+    * trim ours before lookup. */
+   if (_dirmodel) {
+      QString rootKey = _rootPath;
+      if (rootKey.endsWith('/'))
+         rootKey.chop(1);
+      if (Backend *be = _dirmodel->backendForRoot(rootKey)) {
+         QString repoName = QFileInfo(rootKey).fileName();
+         desk->setBackend(be, repoName);
+      }
+   }
 
    // add files that are not in the maxdesk.ini file
    desk->addFiles(dirPath, meas);

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -58,6 +58,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #define DELAY_TIME 0  //1000
 
 
+QUrl *Desktopmodel::url_capture;
+
 Desktopmodel::Desktopmodel(QObject *parent)
       : QAbstractItemModel (parent)
    {

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -1429,7 +1429,12 @@ QModelIndex Desktopmodel::showDir(QString dirPath, QString rootPath,
          rootKey.chop(1);
       if (Backend *be = _dirmodel->backendForRoot(rootKey)) {
          repoName = QFileInfo(rootKey).fileName();
-         desk->setBackend(be, repoName);
+         /* Remote backends produce synthetic paths the local file
+          * loaders (Filemax, Filepdf, Filejpeg) can't open; tell
+          * Desk so it falls back to Fileother + skips writing
+          * .maxdesk.ini. */
+         bool isRemote = dynamic_cast<RemoteBackend *>(be) != nullptr;
+         desk->setBackend(be, repoName, isRemote);
       }
    }
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -1535,8 +1535,9 @@ QModelIndex Desktopmodel::indexForFile(File *file) const
    return QModelIndex();
 }
 
-Desk *Desktopmodel::prepareSearchDesk(QString& dirPath, QString& rootPath,
-                                      QModelIndex& ind, bool& add_items)
+QModelIndex Desktopmodel::finishFileSearch(QString dirPath, QString rootPath,
+                                           const QStringList& matches,
+                                           Measure *meas)
 {
    Desk *desk;
 
@@ -1553,42 +1554,28 @@ Desk *Desktopmodel::prepareSearchDesk(QString& dirPath, QString& rootPath,
     * We only have one desk for subdirectory searches and we reuse it
       each time
    */
-   if (ind.isValid()) {
-      desk = getDesk(ind);
-      add_items = true;
-   } else {
-      beginInsertRows (ind, _desks.size (), _desks.size ());
-      desk = new Desk("" , rootPath, false);
-      _desks << desk;
-      endInsertRows ();
-      ind = index (_desks.size () - 1, 0, QModelIndex ());
-      add_items = false;
-   }
-   desk->setDebugLevel (_debug_level);
+   if (_subdirs_index.isValid()) {
+      desk = getDesk(_subdirs_index);
+      desk->setDebugLevel (_debug_level);
 
-   clearAll (ind);
-   desk->advance ();
-
-   return desk;
-}
-
-QModelIndex Desktopmodel::finishFileSearch(QString dirPath, QString rootPath,
-                                           const QStringList& matches,
-                                           Measure *meas)
-{
-   bool add_items;
-   Desk *desk;
-
-   desk = prepareSearchDesk(dirPath, rootPath, _subdirs_index, add_items);
-
-   desk->addMatches(dirPath, matches, meas);
-   if (add_items)
-      {
-      /* we are re-using the same subdir desk for the new search. All the
-         items have been cleared, so we need to add the new matches */
+      // clear out the previous search, then add the new matches
+      clearAll (_subdirs_index);
+      desk->advance ();
+      desk->addMatches(dirPath, matches, meas);
       beginInsertRows (_subdirs_index, 0, desk->fileCount () - 1);
       endInsertRows ();
-      }
+   } else {
+      /* populate the desk before inserting its row, so that the model
+         (and any proxy on top of it) sees the files exactly once */
+      desk = new Desk("" , rootPath, false);
+      desk->setDebugLevel (_debug_level);
+      desk->advance ();
+      desk->addMatches(dirPath, matches, meas);
+      beginInsertRows (QModelIndex (), _desks.size (), _desks.size ());
+      _desks << desk;
+      endInsertRows ();
+      _subdirs_index = index (_desks.size () - 1, 0, QModelIndex ());
+   }
    _subdirs = true;
 
    // no pending list at present

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -26,6 +26,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "config.h"
 #include "backend.h"
 #include "dirmodel.h"
+#include "remotebackend.h"
 
 #include "qapplication.h"
 #include "qcursor.h"
@@ -1421,12 +1422,13 @@ QModelIndex Desktopmodel::showDir(QString dirPath, QString rootPath,
     * instead of the local filesystem.  The root path Dirmodel
     * registered as the Diritem identifier has no trailing slash;
     * trim ours before lookup. */
+   QString repoName;
    if (_dirmodel) {
       QString rootKey = _rootPath;
       if (rootKey.endsWith('/'))
          rootKey.chop(1);
       if (Backend *be = _dirmodel->backendForRoot(rootKey)) {
-         QString repoName = QFileInfo(rootKey).fileName();
+         repoName = QFileInfo(rootKey).fileName();
          desk->setBackend(be, repoName);
       }
    }
@@ -1434,11 +1436,88 @@ QModelIndex Desktopmodel::showDir(QString dirPath, QString rootPath,
    // add files that are not in the maxdesk.ini file
    desk->addFiles(dirPath, meas);
 
+   /* For a remote backend, kick off async thumbnail fetches now that
+    * the desk knows its files.  Local backends still rely on each
+    * File subclass to compute its own pixmap from disk data. */
+   if (auto *remote = dynamic_cast<RemoteBackend *>(desk->backend())) {
+      /* Compute the file's parent path relative to the repo root.
+       * _rootPath/dirPath both have trailing slashes here. */
+      QString dirInRepo = dirPath;
+      if (dirInRepo.startsWith(_rootPath + "/"))
+         dirInRepo = dirInRepo.mid(_rootPath.length() + 1);
+      else if (dirInRepo.startsWith(_rootPath))
+         dirInRepo = dirInRepo.mid(_rootPath.length());
+      if (dirInRepo.endsWith('/'))
+         dirInRepo.chop(1);
+      scheduleRemoteThumbnails(desk, remote, repoName, dirInRepo);
+   }
+
    // no pending list at present
    _pending_scan_list.clear ();
 
    return ind;
    }
+
+
+void Desktopmodel::scheduleRemoteThumbnails(Desk *desk,
+                                            RemoteBackend *backend,
+                                            const QString &repoName,
+                                            const QString &dirInRepo)
+{
+   if (!backend)
+      return;
+   /* Connect once per backend instance. */
+   if (!_connectedBackends.contains(backend)) {
+      connect(backend, &RemoteBackend::thumbnailReady,
+              this, &Desktopmodel::onThumbnailReady);
+      _connectedBackends.insert(backend);
+   }
+   for (File *f : desk->files()) {
+      QString path = dirInRepo.isEmpty()
+                         ? f->filename()
+                         : dirInRepo + "/" + f->filename();
+      quint64 t = backend->fetchThumbnailAsync(repoName, path);
+      _pendingThumbnails.insert(t, f);
+   }
+}
+
+
+void Desktopmodel::onThumbnailReady(quint64 token,
+                                    const QByteArray &jpegBytes)
+{
+   auto it = _pendingThumbnails.find(token);
+   if (it == _pendingThumbnails.end())
+      return;
+   File *file = it.value();
+   _pendingThumbnails.erase(it);
+
+   if (jpegBytes.isEmpty())
+      return;
+   QImage img;
+   if (!img.loadFromData(jpegBytes))
+      return;
+   file->setThumbnail(QPixmap::fromImage(img));
+
+   QModelIndex idx = indexForFile(file);
+   if (idx.isValid())
+      emit dataChanged(idx, idx, {Qt::DecorationRole});
+}
+
+
+QModelIndex Desktopmodel::indexForFile(File *file) const
+{
+   for (int d = 0; d < _desks.size(); d++) {
+      Desk *desk = _desks[d];
+      const QList<File *> &files = desk->files();
+      for (int r = 0; r < files.size(); r++) {
+         if (files[r] == file) {
+            QModelIndex deskInd = index(d, 0, QModelIndex());
+            return index(r, 0, deskInd);
+         }
+      }
+   }
+   return QModelIndex();
+}
 
 Desk *Desktopmodel::prepareSearchDesk(QString& dirPath, QString& rootPath,
                                       QModelIndex& ind, bool& add_items)

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -1599,35 +1599,28 @@ QModelIndex Desktopmodel::showFilesIn(const QString& inPath,
                                       const QString &rootPath, Measure *meas)
 {
    QString dirPath = inPath + "/", root = rootPath + "/";
-   bool add_items = true;
    Desk *desk;
 
    flushAllDesks ();
 
    QModelIndex ind = index(dirPath, QModelIndex ());
    if (ind.isValid()) {
+      // we are re-using the same desk, so reset to show the new contents
       desk = getDesk(ind);
-      add_items = false;
+      desk->addFromDir(dirPath, meas);
+      beginResetModel();
+      endResetModel();
    } else {
-      beginInsertRows (ind, _desks.size (), _desks.size ());
+      /* populate the desk before inserting its row, so that the model
+         (and any proxy on top of it) sees the files exactly once */
       desk = new Desk(dirPath, rootPath);
+      desk->addFromDir(dirPath, meas);
+      beginInsertRows (QModelIndex (), _desks.size (), _desks.size ());
       _desks << desk;
       endInsertRows ();
       ind = index(_desks.size () - 1, 0, QModelIndex ());
    }
    _otherdir_index = ind;
-
-   desk->addFromDir(dirPath, meas);
-   if (add_items)
-   {
-      /* we are re-using the same subdir desk for the new search. All the
-         items have been cleared, so we need to add the new matches */
-      beginInsertRows(_otherdir_index, 0, desk->fileCount() - 1);
-      endInsertRows();
-   } else {
-      beginResetModel();
-      endResetModel();
-   }
    _subdirs = true;
 
    // no pending list at present

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -1471,7 +1471,6 @@ void Desktopmodel::scheduleRemoteThumbnails(Desk *desk,
 {
    if (!backend)
       return;
-   /* Connect once per backend instance. */
    if (!_connectedBackends.contains(backend)) {
       connect(backend, &RemoteBackend::thumbnailReady,
               this, &Desktopmodel::onThumbnailReady);
@@ -1481,7 +1480,17 @@ void Desktopmodel::scheduleRemoteThumbnails(Desk *desk,
       QString path = dirInRepo.isEmpty()
                          ? f->filename()
                          : dirInRepo + "/" + f->filename();
-      quint64 t = backend->fetchThumbnailAsync(repoName, path);
+      /* "small" maps to ~150px on the server.  The local desktop
+       * grid uses Filemax::getPreviewPixmap which returns the
+       * embedded preview (~100-150px); 150 is close enough that
+       * the remote view doesn't show enormous thumbnails relative
+       * to the local one.  A future /preview endpoint that runs
+       * File::getPreviewPixmap on the server side would match
+       * exactly, but it needs QImage plumbing (the server uses
+       * QCoreApplication, no QPixmap support) — deferred. */
+      quint64 t = backend->fetchThumbnailAsync(repoName, path,
+                                               /*page=*/1,
+                                               /*size=*/"small");
       _pendingThumbnails.insert(t, f);
    }
 }

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -795,12 +795,13 @@ protected:
 public:
    // this is public since it is called from outside the undo system
    
-   /** email a set of files as attachments, optionally converting them first. 
-       If more than one file is sent, then they are packed into a zip archive
-       as it seems that Thunderbird can't cope with more than one attachment
-       through its '-compose- interface
-   
-      \param parent  desk containing the files 
+   /** email a set of files as attachments, optionally converting them first.
+       Puts the (single) file on the clipboard as a text/uri-list and opens
+       Gmail's compose URL in the browser; the user pastes the attachment
+       with Ctrl+V.  If more than one file is sent they are packed into a
+       zip archive first.
+
+      \param parent  desk containing the files
       \param slist   list of files to send
       \param type    type to convert to (or Type_other to leave as is)
       \returns error or NULL if ok */

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -107,6 +107,12 @@ public:
    Desktopmodel(QObject *parent);
    ~Desktopmodel();
 
+   /** Inject the Dirmodel that owns the repository list.  We use it
+    *  to look up the Backend associated with a root path when
+    *  opening a folder, so remote roots can populate their desks
+    *  via Backend::browseDirectory instead of QDir. */
+   void setDirmodel(class Dirmodel *dirmodel) { _dirmodel = dirmodel; }
+
    // debug output
    QDebug debug (void) const;
 
@@ -1325,6 +1331,7 @@ private:
    bool _about_to_add;        //!< true if about to add some items
    int _add_start;            //!< first row of added item
    Desktopmodelconv *_modelconv;  //!< model converter
+   class Dirmodel *_dirmodel = nullptr;  //!< Source of backend lookups
    QFontMetrics *_fm;         //!< metrics for the standard font (used for guessing sizes)
 
    /** true if we should generate a scaled image when new scan data is

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1313,19 +1313,6 @@ protected:
       \returns error or NULL if ok */
    err_info *emailFiles (QString &fname, QStringList &fnamelist, bool &can_delete);
 
-   /**
-    * @brief Get the 'subdirs'desk ready for use
-    * @param dirPath    Directory path to search (trailing "/" is added)
-    * @param rootPath   Root path of repository (trailing "/" is added)
-    * @param ind        Model index to use (updated if not value)
-    * @param add_items  Returns true if new items should be inserted into the
-    *                   model
-    * @return Desk to use for showing search results
-    */
-   Desk *prepareSearchDesk(QString& dirPath, QString& rootPath,
-                           QModelIndex& ind, bool& add_items);
-
-
 private:
    QList<Desk *> _desks;  //!< the model directories
    QTimer *_updateTimer;  //!< each time this times out we update another item

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -21,9 +21,10 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
  Public License can be found in the /usr/share/common-licenses/GPL file.
 */
 #include <QContextMenuEvent>
-
+#include <QHash>
 #include <QMouseEvent>
 #include <QKeyEvent>
+#include <QSet>
 
 
 class QFontMetrics;
@@ -947,7 +948,26 @@ signals:
      */
    void updateRepositoryList (QString &dirpath, bool add_not_delete);
 
+private slots:
+   /** Slot invoked when a previously-issued fetchThumbnailAsync()
+    *  finishes.  Looks up the File via the token map, decodes the
+    *  JPEG into a QPixmap, and emits dataChanged() so the view
+    *  repaints. */
+   void onThumbnailReady(quint64 token, const QByteArray &jpegBytes);
+
 private:
+   /** Issue async thumbnail fetches for every file in @p desk via
+    *  the provided RemoteBackend.  No-op if @p backend is null.
+    *  @p dirInRepo is the file's parent path relative to the repo
+    *  root (no trailing slash; empty for the repo root itself). */
+   void scheduleRemoteThumbnails(Desk *desk, class RemoteBackend *backend,
+                                 const QString &repoName,
+                                 const QString &dirInRepo);
+
+   /** Return the QModelIndex for an arbitrary File*; QModelIndex()
+    *  if the file isn't in any of our desks. */
+   QModelIndex indexForFile(File *file) const;
+
    bool getNewScaledImage (Paperscan &scan, const PPage *page, const char *data,
          int nbytes, QImage &image, int &scaled_linenum);
 
@@ -1332,6 +1352,14 @@ private:
    int _add_start;            //!< first row of added item
    Desktopmodelconv *_modelconv;  //!< model converter
    class Dirmodel *_dirmodel = nullptr;  //!< Source of backend lookups
+
+   /** Pending async-thumbnail requests: token from
+    *  RemoteBackend::fetchThumbnailAsync → File* that wants the
+    *  result.  Cleared in the slot. */
+   QHash<quint64, File *> _pendingThumbnails;
+   /** Set of RemoteBackends we've already connected our slot to,
+    *  so we don't connect twice when revisiting the same desk. */
+   QSet<class RemoteBackend *> _connectedBackends;
    QFontMetrics *_fm;         //!< metrics for the standard font (used for guessing sizes)
 
    /** true if we should generate a scaled image when new scan data is

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -22,6 +22,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 #include <QContextMenuEvent>
 #include <QHash>
+#include <QUrl>
 #include <QMouseEvent>
 #include <QKeyEvent>
 #include <QSet>
@@ -807,6 +808,11 @@ public:
       \returns error or NULL if ok */
    err_info *opEmailFiles (QModelIndex parent, QModelIndexList &slist,
          File::e_type type);
+
+   /** when non-null, URLs which would be opened in the browser (e.g.
+       the email compose window) are stored here instead. Used by
+       tests to check the URL without launching anything */
+   static QUrl *url_capture;
 
 #if 0 //p
    Desktopitem *itemFind (const QPoint & opos, int &which);

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -80,6 +80,7 @@ Desktopwidget::Desktopwidget (QWidget *parent)
    _dir->setModel(_dir_proxy);
 
    _contents = new Desktopmodel (this);
+   _contents->setDirmodel(_model);
 
    _toolbar = new Toolbar();
 

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -23,9 +23,12 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <assert.h>
 
+#include "backendstats.h"
+
 #include <QtGui>
 #include <QCheckBox>
 #include <QFileDialog>
+#include <QHBoxLayout>
 #include <QKeyEventTransition>
 #include <QStateMachine>
 #include <QState>
@@ -83,6 +86,33 @@ Desktopwidget::Desktopwidget (QWidget *parent)
    _contents->setDirmodel(_model);
 
    _toolbar = new Toolbar();
+
+   /* Append a network-activity indicator to the toolbar's existing
+    * horizontal row.  The toolbar's top-level layout is a
+    * QVBoxLayout; horizontalLayout_2 is the inner row that holds
+    * the buttons, generated from toolbar.ui.  Give the label its
+    * own size policy + minimum width so the toolbar layout actually
+    * allocates space for it. */
+   _netStatus = new QLabel(_toolbar);
+   _netStatus->setObjectName("netStatus");
+   _netStatus->setVisible(false);
+   _netStatus->setMargin(4);
+   _netStatus->setTextFormat(Qt::RichText);
+   _netStatus->setMinimumWidth(280);
+   _netStatus->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+   _toolbar->horizontalLayout_2->addWidget(_netStatus);
+
+   /* Throttle: BackendStats emits changed() on every request +
+    * every byte boundary, which can be many times per second
+    * during thumbnail bursts.  Repainting a rich-text QLabel on
+    * each one is wasted work.  Cap at one update per second. */
+   _netStatusTimer = new QTimer(this);
+   _netStatusTimer->setSingleShot(true);
+   _netStatusTimer->setInterval(1000);
+   connect(_netStatusTimer, &QTimer::timeout,
+           this, &Desktopwidget::flushNetStatus);
+   connect(_model->stats(), &BackendStats::changed,
+           this, &Desktopwidget::scheduleNetStatusUpdate);
 
    connect(_toolbar->pPrev, SIGNAL(clicked()), this, SLOT(pageLeft()));
    connect(_toolbar->pNext, SIGNAL(clicked()), this, SLOT(pageRight()));
@@ -341,6 +371,70 @@ QString Desktopwidget::addRemoteServer(const QUrl &baseUrl)
    if (_model->addRemoteRepository(baseUrl, &error))
       return QString();
    return error.isEmpty() ? QStringLiteral("unknown error") : error;
+}
+
+
+static QString formatBytes(qint64 n)
+{
+   if (n < 1024)               return QString::number(n) + " B";
+   if (n < 1024 * 1024)        return QString::number(n / 1024.0, 'f', 1) + " KB";
+   if (n < 1024LL * 1024 * 1024)
+                               return QString::number(n / (1024.0 * 1024), 'f', 1)
+                                      + " MB";
+   return QString::number(n / (1024.0 * 1024 * 1024), 'f', 2) + " GB";
+}
+
+
+void Desktopwidget::scheduleNetStatusUpdate()
+{
+   /* Leading edge: first change in a quiet window updates the
+    * label immediately and starts the throttle window.  Subsequent
+    * changes during the window flip a dirty flag; flushNetStatus
+    * picks up the final state when the timer fires. */
+   if (_netStatusTimer && !_netStatusTimer->isActive()) {
+      updateNetStatus();
+      _netStatusTimer->start();
+   } else {
+      _netStatusDirty = true;
+   }
+}
+
+
+void Desktopwidget::flushNetStatus()
+{
+   if (_netStatusDirty) {
+      _netStatusDirty = false;
+      updateNetStatus();
+      _netStatusTimer->start();  // open another throttle window for the next burst
+   }
+}
+
+
+void Desktopwidget::updateNetStatus()
+{
+   if (!_netStatus || !_model)
+      return;
+   BackendStats *s = _model->stats();
+   if (!s || s->url().isEmpty()) {
+      _netStatus->setVisible(false);
+      return;
+   }
+
+   /* ● green when idle, amber when one or more requests are in
+    * flight.  Two text styles share a single label so the layout
+    * doesn't shift width when activity toggles. */
+   bool busy = s->activeRequests() > 0;
+   QString dot = busy
+                     ? QStringLiteral("<span style='color:#cc8800'>●</span>")
+                     : QStringLiteral("<span style='color:#0aaa3a'>●</span>");
+   QString text = QString(
+       "%1 Connected to %2 &nbsp;&nbsp; "
+       "↑ %3 &nbsp;&nbsp; ↓ %4")
+           .arg(dot, s->url().toHtmlEscaped(),
+                formatBytes(s->bytesSent()),
+                formatBytes(s->bytesReceived()));
+   _netStatus->setText(text);
+   _netStatus->setVisible(true);
 }
 
 void Desktopwidget::slotModeChanging (int new_mode, int old_mode)

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -333,6 +333,15 @@ QList<err_info> Desktopwidget::addRepositories(const QStringList& dirs)
    return err_list;
 }
 
+
+QString Desktopwidget::addRemoteServer(const QUrl &baseUrl)
+{
+   QString error;
+   if (_model->addRemoteRepository(baseUrl, &error))
+      return QString();
+   return error.isEmpty() ? QStringLiteral("unknown error") : error;
+}
+
 void Desktopwidget::slotModeChanging (int new_mode, int old_mode)
    {
 //    qDebug () << "slotModeChanging" << new_mode << old_mode;

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -27,8 +27,12 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QtGui>
 #include <QCheckBox>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QFileDialog>
+#include <QFormLayout>
 #include <QHBoxLayout>
+#include <QLineEdit>
 #include <QKeyEventTransition>
 #include <QStateMachine>
 #include <QState>
@@ -365,12 +369,73 @@ QList<err_info> Desktopwidget::addRepositories(const QStringList& dirs)
 }
 
 
+/* A request fails because the server requires authentication and our
+ * cached token (if any) was rejected.  The HTTP layer surfaces this
+ * either as a raw "HTTP 401" string from RemoteBackend::waitForReply
+ * or as the server's "Host requires authentication" / "Invalid or
+ * missing credentials" prose; treat either as login-needed. */
+static bool isAuthError(const QString &message)
+{
+   return message.contains("401")
+       || message.contains("authentication", Qt::CaseInsensitive)
+       || message.contains("credentials", Qt::CaseInsensitive);
+}
+
+
 QString Desktopwidget::addRemoteServer(const QUrl &baseUrl)
 {
    QString error;
    if (_model->addRemoteRepository(baseUrl, &error))
       return QString();
+
+   /* No cached token, or the cached one expired (server restart wipes
+    * the in-memory token store).  Prompt for credentials and retry. */
+   if (isAuthError(error)) {
+      QString user, password;
+      if (!promptForCredentials(baseUrl, user, password))
+         return QStringLiteral("login cancelled");
+
+      QString loginErr;
+      if (!_model->loginToServer(baseUrl, user, password, &loginErr))
+         return QString("login failed: %1").arg(loginErr);
+
+      error.clear();
+      if (_model->addRemoteRepository(baseUrl, &error))
+         return QString();
+   }
    return error.isEmpty() ? QStringLiteral("unknown error") : error;
+}
+
+
+bool Desktopwidget::promptForCredentials(const QUrl &baseUrl,
+                                         QString &user,
+                                         QString &password)
+{
+   QDialog dlg(this);
+   dlg.setWindowTitle(QString("Log in to %1").arg(baseUrl.authority()));
+
+   auto *userEdit = new QLineEdit(&dlg);
+   userEdit->setPlaceholderText("username");
+   auto *passEdit = new QLineEdit(&dlg);
+   passEdit->setEchoMode(QLineEdit::Password);
+   passEdit->setPlaceholderText("password");
+
+   auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                            | QDialogButtonBox::Cancel,
+                                        &dlg);
+   connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+   connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+   auto *form = new QFormLayout(&dlg);
+   form->addRow("User:", userEdit);
+   form->addRow("Password:", passEdit);
+   form->addRow(buttons);
+
+   if (dlg.exec() != QDialog::Accepted)
+      return false;
+   user = userEdit->text();
+   password = passEdit->text();
+   return !user.isEmpty() && !password.isEmpty();
 }
 
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -94,9 +94,17 @@ public:
    QList<err_info> addRepositories(const QStringList& dirs);
 
    /** Add every repository served by a remote paperman-server as
-    *  top-level items.  Returns an empty string on success or a
+    *  top-level items.  If the server requires authentication and
+    *  no valid cached token is found, prompts for credentials and
+    *  retries.  Returns an empty string on success or a
     *  diagnostic on failure. */
    QString addRemoteServer(const QUrl &baseUrl);
+
+   /** Show a modal username/password dialog for @p baseUrl and
+    *  return the entered credentials.  Returns false if the user
+    *  cancels or leaves a field blank. */
+   bool promptForCredentials(const QUrl &baseUrl,
+                             QString &user, QString &password);
 
 private slots:
    /** BackendStats::changed handler.  Throttles updates to the

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -58,6 +58,7 @@ struct file_info;
 
 #include <QAbstractItemModel>
 #include <QDialog>
+#include <QLabel>
 #include <QUrl>
 
 #include "qsplitter.h"
@@ -96,6 +97,25 @@ public:
     *  top-level items.  Returns an empty string on success or a
     *  diagnostic on failure. */
    QString addRemoteServer(const QUrl &baseUrl);
+
+private slots:
+   /** BackendStats::changed handler.  Throttles updates to the
+    *  toolbar label to at most one per second: the first change in
+    *  a quiet window updates immediately and starts a 1-s window,
+    *  later changes within the window set a dirty flag, and the
+    *  trailing-edge timer flushes the final state. */
+   void scheduleNetStatusUpdate();
+   void flushNetStatus();
+
+private:
+   /** Rebuild the network-activity label from the latest
+    *  BackendStats numbers.  Called via scheduleNetStatusUpdate /
+    *  flushNetStatus, never directly from a signal. */
+   void updateNetStatus();
+
+private slots:
+
+public:
 
    /** constructor helper functions */
    QWidget *createToolbar(void);
@@ -537,6 +557,9 @@ private:
 //   QAction *_act_send, *_act_deliver_out;
 
    Toolbar *_toolbar;
+   QLabel *_netStatus = nullptr;  //!< Network activity indicator in the toolbar
+   QTimer *_netStatusTimer = nullptr;  //!< Trailing-edge throttle for label updates
+   bool _netStatusDirty = false;  //!< Changes arrived during the throttle window
    //QWidget *_toolbar;
 
    // more actions (toolbar)

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -58,6 +58,7 @@ struct file_info;
 
 #include <QAbstractItemModel>
 #include <QDialog>
+#include <QUrl>
 
 #include "qsplitter.h"
 #include "qstring.h"
@@ -90,6 +91,11 @@ public:
 
    //! Add the given list of extra repositories
    QList<err_info> addRepositories(const QStringList& dirs);
+
+   /** Add every repository served by a remote paperman-server as
+    *  top-level items.  Returns an empty string on success or a
+    *  diagnostic on failure. */
+   QString addRemoteServer(const QUrl &baseUrl);
 
    /** constructor helper functions */
    QWidget *createToolbar(void);

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -81,6 +81,7 @@ All QModelIndex parameters here refer to the proxy model _dir_proxy
 class Desktopwidget : public QSplitter //QWidget
    {
    Q_OBJECT
+   friend class TestDesktopUi;
    friend class TestOps;
 
 public:

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -729,7 +729,13 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
       item->setBackend(rb);
 
       DirNode *node = new DirNode;
-      node->name      = r.name;
+      /* Show the server's authority in the display name so a remote
+       * repo isn't visually indistinguishable from a local one with
+       * the same basename (a common case when the same NFS mount is
+       * served over HTTP as well).  repoName below stays unadorned
+       * since it's used as the wire-protocol key. */
+      node->name      = QString("%1 (%2)")
+                            .arg(r.name, baseUrl.authority());
       /* fullPath for a remote root is just the repo name; child
        * nodes append "/sub" and populateNode computes relPath by
        * stripping the root prefix, so the synthetic value works. */

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -716,7 +716,13 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
       /* _dir gets a synthetic identifier (URL + repo name) so the
        * existing setDir() canonicalisation logic doesn't try to look
        * it up on disk.  setDir() returns false for non-existent paths
-       * but still records the value, which is exactly what we want. */
+       * but still records the value, which is exactly what we want.
+       *
+       * The same string also becomes the root DirNode's fullPath
+       * below — Desktopmodel passes that back through dirSelected /
+       * showDir, and showDir looks the backend up via
+       * backendForRoot(rootKey).  Aligning the two means the lookup
+       * actually succeeds for remote roots. */
       QString synthPath = baseUrl.toString() + "/" + r.name;
       item->setDir(synthPath);
 
@@ -736,10 +742,11 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
        * since it's used as the wire-protocol key. */
       node->name      = QString("%1 (%2)")
                             .arg(r.name, baseUrl.authority());
-      /* fullPath for a remote root is just the repo name; child
-       * nodes append "/sub" and populateNode computes relPath by
-       * stripping the root prefix, so the synthetic value works. */
-      node->fullPath  = r.name;
+      /* fullPath matches Diritem._dir (set via item->setDir(synthPath)
+       * above) so showDir's backendForRoot lookup against
+       * Dirmodel::backendForRoot works.  Child nodes append "/sub" and
+       * populateNode computes relPath by stripping the root prefix. */
+      node->fullPath  = synthPath;
       node->parent    = _invisibleRoot;
       node->row       = _invisibleRoot->children.size();
       node->populated = false;

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -79,10 +79,14 @@ bool Diritem::setDir(QString &dir)
    // Try to get the canonical path, but if not, use the one supplied
    _dir = qd.canonicalPath ();
    if (_dir.isEmpty()) {
+      /* canonicalPath returns empty for paths that don't resolve on
+       * disk.  That's expected for synthetic IDs (e.g. the
+       * "http://host/repo" form used by addRemoteRepository) and for
+       * QSettings-remembered repos whose mount went away; callers
+       * use the bool return to decide whether to warn. */
       if (dir.endsWith ("/"))
          dir.chop (1);
       _dir = dir;
-      qDebug () << "Diritem invalid";
       return false;
       }
 

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -31,6 +31,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include "dirmodel.h"
 #include "backend.h"
+#include "backendstats.h"
 #include "localbackend.h"
 #include "remotebackend.h"
 #include "qmimedata.h"
@@ -684,11 +685,18 @@ static QString loadCachedToken(const QString &serverId)
 
 bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
 {
+   /* Tag the stats object with this server's URL so the toolbar
+    * widget has something to display.  Last writer wins if the
+    * user attaches multiple servers — minor UX wrinkle worth
+    * accepting in exchange for one-line setup. */
+   stats()->setUrl(baseUrl.toString());
+
    /* One probe RemoteBackend, used to discover the server's
     * repository list.  Each repo we add then gets its own
     * RemoteBackend instance (with the same token) so each Diritem
     * keeps the simple unique_ptr ownership invariant. */
    RemoteBackend probe(baseUrl);
+   probe.setStats(stats());
    QString serverId = probe.serverId();
    QString token = loadCachedToken(serverId);
    if (!token.isEmpty())
@@ -713,6 +721,7 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
       item->setDir(synthPath);
 
       RemoteBackend *rb = new RemoteBackend(baseUrl);
+      rb->setStats(stats());
       if (!token.isEmpty())
          rb->setBearerToken(token);
       connect(rb, &RemoteBackend::browseDirectoryReady,
@@ -749,6 +758,14 @@ Backend *Dirmodel::backendForRoot(const QString &rootPath) const
          return item->backend();
    }
    return nullptr;
+}
+
+
+BackendStats *Dirmodel::stats()
+{
+   if (!_stats)
+      _stats = new BackendStats(this);
+   return _stats;
 }
 
 

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -25,11 +25,14 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QDate>
 #include <QDebug>
 #include <QDir>
+#include <QFile>
 #include <QMessageBox>
+#include <QStandardPaths>
 
 #include "dirmodel.h"
 #include "backend.h"
 #include "localbackend.h"
+#include "remotebackend.h"
 #include "qmimedata.h"
 #include "qurl.h"
 
@@ -546,6 +549,81 @@ bool Dirmodel::addDir(QString& dir, bool ignore_error)
       delete item;
    return ok;
    }
+
+
+/* Load a token previously saved by paperman-client (or any other
+ * tool) so opening the GUI against a known server doesn't require
+ * re-entering credentials.  Empty if no token is cached. */
+static QString loadCachedToken(const QString &serverId)
+{
+   if (serverId.isEmpty())
+      return QString();
+   QString path = QStandardPaths::writableLocation(
+                      QStandardPaths::GenericConfigLocation)
+                  + "/paperman/" + serverId + ".token";
+   QFile f(path);
+   if (!f.open(QIODevice::ReadOnly))
+      return QString();
+   return QString::fromUtf8(f.readAll()).trimmed();
+}
+
+
+bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
+{
+   /* One probe RemoteBackend, used to discover the server's
+    * repository list.  Each repo we add then gets its own
+    * RemoteBackend instance (with the same token) so each Diritem
+    * keeps the simple unique_ptr ownership invariant. */
+   RemoteBackend probe(baseUrl);
+   QString serverId = probe.serverId();
+   QString token = loadCachedToken(serverId);
+   if (!token.isEmpty())
+      probe.setBearerToken(token);
+
+   QList<RepositoryInfo> repos = probe.listRepositories();
+   if (repos.isEmpty()) {
+      if (errorOut)
+         *errorOut = probe.lastError().isEmpty()
+                         ? QStringLiteral("no repositories returned")
+                         : probe.lastError();
+      return false;
+   }
+
+   for (const RepositoryInfo &r : repos) {
+      Diritem *item = new Diritem();
+      /* _dir gets a synthetic identifier (URL + repo name) so the
+       * existing setDir() canonicalisation logic doesn't try to look
+       * it up on disk.  setDir() returns false for non-existent paths
+       * but still records the value, which is exactly what we want. */
+      QString synthPath = baseUrl.toString() + "/" + r.name;
+      item->setDir(synthPath);
+
+      RemoteBackend *rb = new RemoteBackend(baseUrl);
+      if (!token.isEmpty())
+         rb->setBearerToken(token);
+      item->setBackend(rb);
+
+      DirNode *node = new DirNode;
+      node->name      = r.name;
+      /* fullPath for a remote root is just the repo name; child
+       * nodes append "/sub" and populateNode computes relPath by
+       * stripping the root prefix, so the synthetic value works. */
+      node->fullPath  = r.name;
+      node->parent    = _invisibleRoot;
+      node->row       = _invisibleRoot->children.size();
+      node->populated = false;
+      node->backend   = item->backend();
+      node->repoName  = r.name;
+
+      item->setNode(node);
+
+      beginInsertRows(QModelIndex(), _item.size(), _item.size());
+      _invisibleRoot->children.append(node);
+      _item.append(item);
+      endInsertRows();
+   }
+   return true;
+}
 
 
 bool Dirmodel::removeDirFromList (const QModelIndex &index)

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -669,6 +669,30 @@ bool Dirmodel::addDir(QString& dir, bool ignore_error)
 /* Load a token previously saved by paperman-client (or any other
  * tool) so opening the GUI against a known server doesn't require
  * re-entering credentials.  Empty if no token is cached. */
+/* Mirror of paperman-client's saveToken: write the bearer token
+ * for `serverId` so subsequent paperman runs (and CLI invocations)
+ * pick it up without re-prompting.  0600 perms so the token file
+ * isn't world-readable. */
+static bool saveCachedToken(const QString &serverId, const QString &token)
+{
+   if (serverId.isEmpty())
+      return false;
+   QString d = QStandardPaths::writableLocation(
+                   QStandardPaths::GenericConfigLocation)
+               + "/paperman";
+   QDir().mkpath(d);
+   QString path = d + "/" + serverId + ".token";
+   QFile f(path);
+   if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+      return false;
+   f.write(token.toUtf8());
+   f.write("\n");
+   f.close();
+   QFile::setPermissions(path, QFile::ReadOwner | QFile::WriteOwner);
+   return true;
+}
+
+
 static QString loadCachedToken(const QString &serverId)
 {
    if (serverId.isEmpty())
@@ -759,6 +783,34 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
       _invisibleRoot->children.append(node);
       _item.append(item);
       endInsertRows();
+   }
+   return true;
+}
+
+
+bool Dirmodel::loginToServer(const QUrl &baseUrl, const QString &user,
+                             const QString &password, QString *errorOut)
+{
+   RemoteBackend probe(baseUrl);
+   QString serverId = probe.serverId();
+   if (serverId.isEmpty()) {
+      if (errorOut)
+         *errorOut = probe.lastError().isEmpty()
+                         ? QStringLiteral("could not reach server")
+                         : probe.lastError();
+      return false;
+   }
+   if (!probe.login(user, password)) {
+      if (errorOut)
+         *errorOut = probe.lastError().isEmpty()
+                         ? QStringLiteral("login failed")
+                         : probe.lastError();
+      return false;
+   }
+   if (!saveCachedToken(serverId, probe.bearerToken())) {
+      if (errorOut)
+         *errorOut = QStringLiteral("could not write token file");
+      return false;
    }
    return true;
 }

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -742,6 +742,16 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
 }
 
 
+Backend *Dirmodel::backendForRoot(const QString &rootPath) const
+{
+   for (Diritem *item : _item) {
+      if (item->dir() == rootPath)
+         return item->backend();
+   }
+   return nullptr;
+}
+
+
 bool Dirmodel::removeDirFromList (const QModelIndex &index)
    {
    if (!isRoot (index))

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -219,9 +219,17 @@ DirNode *Dirmodel::nodeFromIndex(const QModelIndex &index) const
 }
 
 
+QModelIndex Dirmodel::indexForNode(DirNode *node) const
+{
+   if (!node || node == _invisibleRoot)
+      return QModelIndex();
+   return createIndex(node->row, 0, node);
+}
+
+
 void Dirmodel::populateNode(DirNode *node) const
 {
-   if (node->populated)
+   if (node->populated || node->loading)
       return;
 
    /* Subdirectories come from the Backend.  Each Diritem owns a
@@ -243,6 +251,37 @@ void Dirmodel::populateNode(DirNode *node) const
                          ? QString()
                          : node->fullPath.mid(root->fullPath.length() + 1);
 
+   /* RemoteBackend goes via the async path: insert a "Loading…"
+    * placeholder child so the disclosure arrow stays visible, and
+    * kick off the request.  onBrowseAsyncReady() will swap the
+    * placeholder for real children when the server responds. */
+   /* Backend is not a QObject, so we can't use qobject_cast; the
+    * Backend hierarchy has RTTI thanks to its virtual functions. */
+   auto *remote = dynamic_cast<RemoteBackend *>(node->backend);
+   if (remote) {
+      Dirmodel *self = const_cast<Dirmodel *>(this);
+
+      /* We're inside the view's rowCount() call, so just append the
+       * placeholder directly — the count we return below includes
+       * it.  beginInsertRows/endInsertRows is reserved for the
+       * later async swap. */
+      DirNode *placeholder = new DirNode;
+      placeholder->name      = QStringLiteral("Loading…");
+      placeholder->parent    = node;
+      placeholder->populated = true;
+      placeholder->row       = 0;
+      node->children.append(placeholder);
+
+      node->loading = true;
+      quint64 token = remote->browseDirectoryAsync(root->repoName, relPath);
+      self->_pendingBrowses.insert(token, node);
+      return;
+   }
+
+   /* Sync path for LocalBackend: populate directly so the rowCount
+    * probe that triggered us sees the right answer.  The view does
+    * not need begin/endInsertRows because it is currently asking
+    * for the row count. */
    DirectoryListing listing =
        node->backend->browseDirectory(root->repoName, relPath);
 
@@ -278,6 +317,74 @@ void Dirmodel::populateNode(DirNode *node) const
       child->repoName  = root->repoName;
       node->children.append(child);
    }
+}
+
+
+void Dirmodel::onBrowseAsyncReady(quint64 token,
+                                  const DirectoryListing &listing)
+{
+   auto it = _pendingBrowses.find(token);
+   if (it == _pendingBrowses.end())
+      return;  // stale (refresh raced, or model was reset)
+   DirNode *node = it.value();
+   _pendingBrowses.erase(it);
+
+   if (!node->loading)
+      return;  // refresh cancelled us
+   node->loading = false;
+
+   QModelIndex idx = indexForNode(node);
+
+   /* Remove the "Loading…" placeholder we inserted in populateNode. */
+   if (!node->children.isEmpty()) {
+      beginRemoveRows(idx, 0, node->children.size() - 1);
+      qDeleteAll(node->children);
+      node->children.clear();
+      endRemoveRows();
+   }
+
+   node->populated = true;
+
+   if (!listing.ok) {
+      node->loadFailed = true;
+      node->loadError  = listing.error.isEmpty()
+                             ? QStringLiteral("backend error")
+                             : listing.error;
+      emit backendError(node->fullPath, node->loadError);
+      return;
+   }
+
+   node->loadFailed = false;
+   node->loadError.clear();
+
+   /* Find the repo root for this branch so child fullPaths carry
+    * the same root prefix populateNode would have built. */
+   DirNode *root = node;
+   while (root->parent && root->parent != _invisibleRoot)
+      root = root->parent;
+
+   int realCount = 0;
+   for (const DirectoryEntry &e : listing.entries)
+      if (e.isDir)
+         realCount++;
+   if (realCount == 0)
+      return;
+
+   beginInsertRows(idx, 0, realCount - 1);
+   for (const DirectoryEntry &entry : listing.entries) {
+      if (!entry.isDir)
+         continue;
+      DirNode *child = new DirNode;
+      child->name      = entry.name;
+      child->fullPath  = root->fullPath + "/" + entry.path;
+      child->parent    = node;
+      child->populated = false;
+      child->row       = node->children.size();
+      child->backend   = node->backend;
+      child->repoName  = root->repoName;
+      node->children.append(child);
+   }
+   endInsertRows();
 }
 
 
@@ -380,8 +487,10 @@ void Dirmodel::refresh(const QModelIndex &parent)
    if (!node)
       return;
    /* A previously-failed populate leaves populated=true with
-    * loadFailed=true, so don't gate the refresh on populated alone. */
-   if (!node->populated && !node->loadFailed)
+    * loadFailed=true, so don't gate the refresh on populated alone.
+    * A node mid-async (loading=true with a placeholder child) also
+    * counts as worth resetting. */
+   if (!node->populated && !node->loadFailed && !node->loading)
       return;
 
    // beginRemoveRows/endRemoveRows alone is not enough: proxy models
@@ -394,6 +503,7 @@ void Dirmodel::refresh(const QModelIndex &parent)
    node->children.clear();
    node->populated  = false;
    node->loadFailed = false;
+   node->loading    = false;
    node->loadError.clear();
    endResetModel();
 }
@@ -601,6 +711,8 @@ bool Dirmodel::addRemoteRepository(const QUrl &baseUrl, QString *errorOut)
       RemoteBackend *rb = new RemoteBackend(baseUrl);
       if (!token.isEmpty())
          rb->setBearerToken(token);
+      connect(rb, &RemoteBackend::browseDirectoryReady,
+              this, &Dirmodel::onBrowseAsyncReady);
       item->setBackend(rb);
 
       DirNode *node = new DirNode;

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -1301,8 +1301,6 @@ void Dirmodel::addFileMatches(QStringList& matches, const uint baseLen,
             matches << dirPath.mid(baseLen) + fname;
       }
    }
-   if (!parent->childCount())
-      matches << dirPath.mid(baseLen);
 }
 
 QStringList Dirmodel::findFiles(const QString& text, const QString& dirPath,

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -220,14 +220,15 @@ void Dirmodel::populateNode(DirNode *node) const
 {
    if (node->populated)
       return;
-   node->populated = true;
 
    /* Subdirectories come from the Backend.  Each Diritem owns a
     * Backend (set in addDir); top-level DirNodes carry a non-owning
     * pointer to it and we propagate that to every child as we
     * populate, so deeper nodes don't need a walk-up. */
-   if (!node->backend)
+   if (!node->backend) {
+      node->populated = true;
       return;
+   }
 
    /* The path passed to browseDirectory is relative to the repo
     * root.  Walk up to the root to compute it; the root is the
@@ -241,8 +242,25 @@ void Dirmodel::populateNode(DirNode *node) const
 
    DirectoryListing listing =
        node->backend->browseDirectory(root->repoName, relPath);
-   if (!listing.ok)
+
+   /* Mark populated unconditionally so a failed call doesn't get
+    * re-issued by every rowCount() probe.  refresh() clears both
+    * populated and loadFailed, so users can retry by triggering a
+    * refresh on the failed branch. */
+   node->populated = true;
+
+   if (!listing.ok) {
+      node->loadFailed = true;
+      node->loadError  = listing.error.isEmpty()
+                             ? QStringLiteral("backend error")
+                             : listing.error;
+      emit const_cast<Dirmodel *>(this)->backendError(node->fullPath,
+                                                      node->loadError);
       return;
+   }
+
+   node->loadFailed = false;
+   node->loadError.clear();
 
    for (const DirectoryEntry &entry : listing.entries) {
       if (!entry.isDir)
@@ -356,7 +374,11 @@ bool Dirmodel::rmdir(const QModelIndex &index)
 void Dirmodel::refresh(const QModelIndex &parent)
 {
    DirNode *node = nodeFromIndex(parent);
-   if (!node || !node->populated)
+   if (!node)
+      return;
+   /* A previously-failed populate leaves populated=true with
+    * loadFailed=true, so don't gate the refresh on populated alone. */
+   if (!node->populated && !node->loadFailed)
       return;
 
    // beginRemoveRows/endRemoveRows alone is not enough: proxy models
@@ -367,7 +389,9 @@ void Dirmodel::refresh(const QModelIndex &parent)
    beginResetModel();
    qDeleteAll(node->children);
    node->children.clear();
-   node->populated = false;
+   node->populated  = false;
+   node->loadFailed = false;
+   node->loadError.clear();
    endResetModel();
 }
 
@@ -585,6 +609,12 @@ QVariant Dirmodel::data(const QModelIndex &index, int role) const
       case Qt::EditRole :
       case FileNameRole :
          return QVariant (node->name);
+
+      case Qt::ToolTipRole :
+         if (node->loadFailed)
+            return QVariant(QString("Could not list contents: %1")
+                                .arg(node->loadError));
+         return QVariant();
       }
 
    return QVariant();

--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -28,6 +28,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QMessageBox>
 
 #include "dirmodel.h"
+#include "backend.h"
+#include "localbackend.h"
 #include "qmimedata.h"
 #include "qurl.h"
 
@@ -50,6 +52,12 @@ Diritem::Diritem ()
 
 Diritem::~Diritem ()
    {
+   }
+
+
+void Diritem::setBackend(Backend *backend)
+   {
+   _backend.reset(backend);
    }
 
 #if 0 //p
@@ -214,18 +222,39 @@ void Dirmodel::populateNode(DirNode *node) const
       return;
    node->populated = true;
 
-   QDir dir(node->fullPath);
-   dir.setFilter(QDir::Dirs | QDir::NoDotAndDotDot);
-   dir.setSorting(QDir::Name | QDir::IgnoreCase);
+   /* Subdirectories come from the Backend.  Each Diritem owns a
+    * Backend (set in addDir); top-level DirNodes carry a non-owning
+    * pointer to it and we propagate that to every child as we
+    * populate, so deeper nodes don't need a walk-up. */
+   if (!node->backend)
+      return;
 
-   QFileInfoList entries = dir.entryInfoList();
-   for (int i = 0; i < entries.size(); i++) {
+   /* The path passed to browseDirectory is relative to the repo
+    * root.  Walk up to the root to compute it; the root is the
+    * DirNode whose parent is the invisible root. */
+   DirNode *root = node;
+   while (root->parent && root->parent != _invisibleRoot)
+      root = root->parent;
+   QString relPath = (node == root)
+                         ? QString()
+                         : node->fullPath.mid(root->fullPath.length() + 1);
+
+   DirectoryListing listing =
+       node->backend->browseDirectory(root->repoName, relPath);
+   if (!listing.ok)
+      return;
+
+   for (const DirectoryEntry &entry : listing.entries) {
+      if (!entry.isDir)
+         continue;
       DirNode *child = new DirNode;
-      child->name = entries[i].fileName();
-      child->fullPath = entries[i].absoluteFilePath();
-      child->parent = node;
+      child->name      = entry.name;
+      child->fullPath  = root->fullPath + "/" + entry.path;
+      child->parent    = node;
       child->populated = false;
-      child->row = i;
+      child->row       = node->children.size();
+      child->backend   = node->backend;
+      child->repoName  = root->repoName;
       node->children.append(child);
    }
 }
@@ -467,13 +496,20 @@ bool Dirmodel::addDir(QString& dir, bool ignore_error)
    bool ok = item->setDir(dir);
    if (ok || ignore_error)
       {
-      // Create a DirNode for this top-level repository
+      /* Each Diritem owns a LocalBackend bound to its single root
+       * path; the repo name (the directory's basename) is the key
+       * we use when calling browseDirectory.  A future addRemoteDir()
+       * would hand the item a RemoteBackend instead. */
+      item->setBackend(new LocalBackend(QStringList{item->dir()}));
+
       DirNode *node = new DirNode;
       node->name = QDir(item->dir()).dirName();
       node->fullPath = item->dir();
       node->parent = _invisibleRoot;
       node->row = _invisibleRoot->children.size();
       node->populated = false;
+      node->backend = item->backend();
+      node->repoName = node->name;
 
       item->setNode(node);
 

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -218,6 +218,12 @@ public:
     */
    bool addRemoteRepository(const QUrl &baseUrl, QString *errorOut = nullptr);
 
+   /**
+    * @brief Return the Backend that owns @p rootPath, or nullptr if
+    *        no top-level repository matches.  Non-owning pointer.
+    */
+   Backend *backendForRoot(const QString &rootPath) const;
+
    /** Remove a repository directory from the list
 
      \param index    model index of directory to remove */

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -200,6 +200,17 @@ public:
     */
    bool addDir(QString& dir, bool ignore_error = false);
 
+   /**
+    * @brief Add every repository served by a remote paperman-server
+    *        as a top-level item.  Each repo becomes its own Diritem
+    *        backed by RemoteBackend.
+    * @param baseUrl   Server base URL, e.g. http://ohau:8081
+    * @param errorOut  If non-null, populated with the failure
+    *                  reason when the call returns false
+    * @return true if at least one repository was added
+    */
+   bool addRemoteRepository(const QUrl &baseUrl, QString *errorOut = nullptr);
+
    /** Remove a repository directory from the list
 
      \param index    model index of directory to remove */

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -224,6 +224,21 @@ public:
     */
    Backend *backendForRoot(const QString &rootPath) const;
 
+   /**
+    * @brief Log in to a paperman-server with credentials and cache
+    *        the resulting bearer token under the server's UUID so
+    *        a subsequent addRemoteRepository call (or another tool)
+    *        picks it up automatically.
+    * @param baseUrl    Server URL
+    * @param user       Username
+    * @param password   Password
+    * @param errorOut   If non-null, set to the failure reason
+    * @return true on success
+    */
+   bool loginToServer(const QUrl &baseUrl, const QString &user,
+                      const QString &password,
+                      QString *errorOut = nullptr);
+
    /** Aggregate network-activity stats shared across every
     *  RemoteBackend the model owns.  Lazily created on the first
     *  remote add.  Non-owning pointer; the model owns the

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -224,6 +224,12 @@ public:
     */
    Backend *backendForRoot(const QString &rootPath) const;
 
+   /** Aggregate network-activity stats shared across every
+    *  RemoteBackend the model owns.  Lazily created on the first
+    *  remote add.  Non-owning pointer; the model owns the
+    *  underlying QObject. */
+   class BackendStats *stats();
+
    /** Remove a repository directory from the list
 
      \param index    model index of directory to remove */
@@ -493,6 +499,7 @@ private:
    QModelIndexList _recent;   //!< list of recent directories
    DirNode *_invisibleRoot;   //!< invisible root of the directory tree
    QHash<quint64, DirNode *> _pendingBrowses;  //!< In-flight async browses
+   class BackendStats *_stats = nullptr;  //!< Lazily created on first remote add
    };
 
 

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -58,8 +58,15 @@ struct DirNode
     *  key when calling backend->browseDirectory(). */
    QString repoName;
 
+   /** True if the last populateNode() against this node failed (e.g.
+    *  the backend was unreachable).  Surfaced via the tooltip role
+    *  so the user can see why a folder appears empty.  Cleared by
+    *  Dirmodel::refresh() so re-clicking a failed branch retries. */
+   bool loadFailed;
+   QString loadError;
+
    DirNode() : parent(nullptr), populated(false), row(0),
-               backend(nullptr) {}
+               backend(nullptr), loadFailed(false) {}
    ~DirNode() { qDeleteAll(children); }
    };
 
@@ -439,6 +446,11 @@ private:
 
 signals:
    void droppedOnFolder (const QMimeData *data, QString &path);
+
+   /** Emitted when a backend call fails while expanding a folder.
+    *  @c path is the absolute path of the folder we tried to expand;
+    *  @c error is the backend's diagnostic. */
+   void backendError(const QString &path, const QString &error);
 
 private:
    QList<Diritem *> _item;   //!< a list of items to display

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -25,6 +25,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
 
+#include <memory>
+
+class Backend;
 class Operation;
 class TreeItem;
 
@@ -46,7 +49,17 @@ struct DirNode
    bool populated;         //!< true if children have been scanned
    int row;                //!< position among siblings
 
-   DirNode() : parent(nullptr), populated(false), row(0) {}
+   /** Data source used to list this node's children.  Non-owning;
+    *  the Backend lives on the owning Diritem.  Propagated from
+    *  parent to child during populateNode(); the top-level node for
+    *  each Diritem is seeded in addDir(). */
+   Backend *backend;
+   /** Repository name (basename of the Diritem's root) used as the
+    *  key when calling backend->browseDirectory(). */
+   QString repoName;
+
+   DirNode() : parent(nullptr), populated(false), row(0),
+               backend(nullptr) {}
    ~DirNode() { qDeleteAll(children); }
    };
 
@@ -105,6 +118,14 @@ public:
    DirNode *node() const { return _node; }
    void setNode(DirNode *node) { _node = node; }
 
+   /** Transfer ownership of @p backend to this Diritem.  Replaces any
+    *  prior backend.  Called by Dirmodel::addDir() to bind the item
+    *  to a concrete data source. */
+   void setBackend(Backend *backend);
+
+   /** Non-owning pointer to the backend (or nullptr if not set). */
+   Backend *backend() const { return _backend.get(); }
+
 private:
    // Get the filename for the dir cache
    QString dirCacheFilename() const;
@@ -117,6 +138,7 @@ private:
    bool _recent;     //!< true if this item displays a 'recent' list
    TreeItem *_dir_cache;  //!< Cache of the directory tree, or 0
    DirNode *_node;   //!< The associated DirNode in the model tree
+   std::unique_ptr<Backend> _backend;  //!< Data source for this repo
    };
 
 

--- a/dirmodel.h
+++ b/dirmodel.h
@@ -23,11 +23,13 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 
 #include <QAbstractItemModel>
+#include <QHash>
 #include <QSortFilterProxyModel>
 
 #include <memory>
 
-class Backend;
+#include "backend.h"
+
 class Operation;
 class TreeItem;
 
@@ -65,8 +67,13 @@ struct DirNode
    bool loadFailed;
    QString loadError;
 
+   /** True while an async backend call is in flight for this node.
+    *  Used by Dirmodel::populateNode() to avoid issuing duplicate
+    *  requests and to display a "Loading…" placeholder child. */
+   bool loading;
+
    DirNode() : parent(nullptr), populated(false), row(0),
-               backend(nullptr), loadFailed(false) {}
+               backend(nullptr), loadFailed(false), loading(false) {}
    ~DirNode() { qDeleteAll(children); }
    };
 
@@ -455,6 +462,18 @@ private:
     */
    DirNode *nodeFromIndex(const QModelIndex &index) const;
 
+   /**
+    * @brief Get a model index for a DirNode
+    * @param node  DirNode (must be in this model's tree)
+    * @return Model index, or QModelIndex() for _invisibleRoot
+    */
+   QModelIndex indexForNode(DirNode *node) const;
+
+private slots:
+   /** Called by RemoteBackend when an async browseDirectory finishes. */
+   void onBrowseAsyncReady(quint64 token,
+                           const DirectoryListing &listing);
+
 signals:
    void droppedOnFolder (const QMimeData *data, QString &path);
 
@@ -467,6 +486,7 @@ private:
    QList<Diritem *> _item;   //!< a list of items to display
    QModelIndexList _recent;   //!< list of recent directories
    DirNode *_invisibleRoot;   //!< invisible root of the directory tree
+   QHash<quint64, DirNode *> _pendingBrowses;  //!< In-flight async browses
    };
 
 

--- a/dirview.cpp
+++ b/dirview.cpp
@@ -85,8 +85,12 @@ void Dirview::selectionChanged (const QItemSelection &selected, const QItemSelec
 
    QTreeView::selectionChanged (selected, deselected);
 
+   /* record the context for the menus, but do not synthesise a click:
+      the selection also changes programmatically (e.g. while undoing a
+      repository operation) and emitting clicked() here would push
+      spurious change-directory commands onto the undo stack */
    if (list.size () == 1)
-      selectContextItem (list [0]);
+      _context = QPersistentModelIndex (list [0]);
    }
 
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -518,7 +518,10 @@ err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool
    // Ctrl+V once the compose window is up.
    QUrl compose ("https://mail.google.com/mail/?view=cm&fs=1"
                  "&su=Files&body=see+attachment+(paste+with+Ctrl%2BV)");
-   QDesktopServices::openUrl (compose);
+   if (url_capture)
+      *url_capture = compose;
+   else
+      QDesktopServices::openUrl (compose);
 
    return NULL;
 }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -31,8 +31,13 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
    These operations are typically invoked by the undo system in desktopundo
 */
 
+#include <QApplication>
+#include <QClipboard>
+#include <QDesktopServices>
 #include <QFile>
+#include <QMimeData>
 #include <QProcess>
+#include <QUrl>
 
 #include "desktopmodel.h"
 #include "file.h"
@@ -499,15 +504,22 @@ err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool
    else
       CALL (util_buildZip (fname, fnamelist));
 
-// call thunderbird
-   QStringList args;
-   args << "-compose"
-         << QString ("subject=Files,body=see attachment,attachment='file://%1'").arg (fname);
+   // Put the file on the clipboard as a text/uri-list so Gmail compose
+   // (and any other webmail that accepts file paste) treats Ctrl+V as a
+   // file attach.  mailto: URLs cannot carry attachments per RFC 6068,
+   // so this is the only path that lands a real attachment in Gmail
+   // without a per-user OAuth dance.
+   QMimeData *mime = new QMimeData ();
+   mime->setUrls (QList<QUrl> () << QUrl::fromLocalFile (fname));
+   QApplication::clipboard ()->setMimeData (mime);
 
-   QProcess *myProcess = new QProcess();
-   myProcess->startDetached ("thunderbird", args);
+   // Open Gmail's compose URL with a pre-filled subject and body.  The
+   // attachment cannot ride on the URL, but the user pastes it with
+   // Ctrl+V once the compose window is up.
+   QUrl compose ("https://mail.google.com/mail/?view=cm&fs=1"
+                 "&su=Files&body=see+attachment+(paste+with+Ctrl%2BV)");
+   QDesktopServices::openUrl (compose);
 
-   //FIXME check for error in process
    return NULL;
 }
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -69,6 +69,76 @@ Authentication Behavior
 **Security Note**: Always use HTTPS (SSL/TLS) when accessing the server
 over a network to prevent API key interception.
 
+Per-User Accounts (v1)
+~~~~~~~~~~~~~~~~~~~~~~
+
+The server also supports per-user accounts managed via the
+``paperman-server`` CLI.  Once any user is registered, authentication is
+enforced for non-status endpoints even if ``PAPERMAN_API_KEY`` is unset.
+
+Manage users:
+
+.. code:: bash
+
+   paperman-server useradd alice            # prompts for password
+   paperman-server passwd alice             # change password
+   paperman-server userdel alice
+   paperman-server usermod alice --repos work,personal   # 'all' for unrestricted
+   paperman-server userlist
+
+Accounts live in ``~/.config/paperman-server/users.json`` (0600).  The
+CLI subcommands above are the supported way to edit it, but the format
+is plain JSON so it can also be read or restored from a backup:
+
+.. code:: json
+
+   {
+     "alice": {
+       "hash": "pbkdf2-sha256$200000$<salt-b64>$<hash-b64>",
+       "repos": [],
+       "admin": false
+     },
+     "bob": {
+       "hash": "pbkdf2-sha256$200000$<salt-b64>$<hash-b64>",
+       "repos": ["work", "personal"],
+       "admin": false
+     }
+   }
+
+Top-level keys are user names.  Each record has:
+
+-  ``hash`` — ``pbkdf2-sha256$<iters>$<salt-b64>$<hash-b64>``.  The
+   salt is 16 random bytes; the derived key is 32 bytes; both are
+   standard base64.  ``<iters>`` is the PBKDF2 iteration count used
+   when the password was set, so old hashes keep verifying after the
+   default is bumped.
+-  ``repos`` — list of repository names this user may access.  Match
+   is exact against the repository directory's basename.  An empty
+   list means "all repositories".
+-  ``admin`` — reserved for future use; currently ignored.
+
+The server reads the file once at startup, so out-of-band edits require
+a restart to take effect.
+
+To obtain a bearer token, POST to ``/v1/auth/login``:
+
+.. code:: bash
+
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"user":"alice","password":"s3cret"}' \
+        http://localhost:8080/v1/auth/login
+   # {"token":"...","user":"alice","expiry":"2026-07-01T..."}
+
+Then pass the token in subsequent requests:
+
+.. code:: bash
+
+   curl -H "Authorization: Bearer <token>" http://localhost:8080/repos
+
+Tokens are held in memory and invalidated on server restart (default
+TTL: 30 days).  ``X-API-Key`` continues to work in parallel and bypasses
+per-user repo gating.
+
 Common Response Format
 ----------------------
 
@@ -151,6 +221,35 @@ supports.  Auth-free so clients can probe before they have a token.
 .. code:: bash
 
    curl http://localhost:8080/v1/status
+
+--------------
+
+1b. Login (v1)
+~~~~~~~~~~~~~~
+
+Exchange a username and password for a bearer token.  See the
+*Per-User Accounts (v1)* section above for how to manage accounts.
+
+**Endpoint**: ``POST /v1/auth/login``
+
+**Body** (JSON):
+
+.. code:: json
+
+   {"user": "alice", "password": "s3cret"}
+
+**Response** (200):
+
+.. code:: json
+
+   {
+     "token": "<opaque bearer token>",
+     "user": "alice",
+     "expiry": "2026-07-01T12:34:56"
+   }
+
+**Errors**: 400 (missing fields), 401 (bad credentials).  Tokens are
+held in memory and lost on server restart.
 
 --------------
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -122,6 +122,38 @@ Get the current server status and repository information.
 
 --------------
 
+1a. Server Status (v1)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Versioned status endpoint for the new ``/v1/`` API.  Returns the API
+version, a stable per-server UUID (``serverId``) that clients should use
+to key their local caches, and a list of optional features the server
+supports.  Auth-free so clients can probe before they have a token.
+
+**Endpoint**: ``GET /v1/status``
+
+**Parameters**: None
+
+**Response**:
+
+.. code:: json
+
+   {
+     "status": "running",
+     "apiVersion": "1",
+     "serverId": "f6a8e7c4-2c4b-4d5e-9aab-23a1b9d0e7f0",
+     "version": "<server build version>",
+     "features": []
+   }
+
+**Example**:
+
+.. code:: bash
+
+   curl http://localhost:8080/v1/status
+
+--------------
+
 2. List Repositories
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -27,3 +27,23 @@ Features
 - OCR engine with full-text search
 - Search server with REST API
 - Mobile app with offline demo mode (see :doc:`app`)
+- Email files as PDF via Gmail (see `Emailing files`_)
+
+Emailing files
+--------------
+
+The Email menu (Ctrl+Shift+E for "Email as PDF") converts the selected
+files to the chosen format, copies the resulting file to the clipboard
+as a ``text/uri-list`` and opens Gmail's compose window in the default
+browser.  Once the compose window is up, click in the message body and
+press Ctrl+V to attach the file.
+
+The clipboard step is the only path that lands an actual attachment in
+Gmail: ``mailto:`` URLs cannot carry attachments per RFC 6068, so Gmail
+ignores any attachment argument on the compose URL itself.  The same
+flow works with other webmail clients (Outlook on the web, Fastmail)
+that accept file paste into compose, and with desktop Chrome / Firefox
+generally.
+
+If more than one file is selected they are packed into a single zip
+first, since most compose paste handlers only take one file.

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -4,6 +4,14 @@ Testing
 Paperman includes a built-in test suite that exercises the desktop operations,
 directory model, search server, and OCR indexing.
 
+Two suites drive the application through real UI events rather than calling
+operations directly: ``TestDesktopUi`` covers desktop interactions (clicking
+and double-clicking stacks, toolbar navigation, filtering, folder search and
+the directory tree) and ``TestPagewidget`` covers the page view (thumbnail
+selection, zoom and display rotation). These run the ``Mainwindow`` with the
+offscreen platform plugin and use ``QTest`` mouse and keyboard events, so
+they check the behaviour the user actually sees.
+
 Running Tests
 -------------
 

--- a/err.cpp
+++ b/err.cpp
@@ -56,6 +56,7 @@ static const char *err_msg [ERR_count] =
    "Bermuda chunk corrupt at %x",
    "G4 compression failed",
    "G4 decompression failed",
+   "JPEG compression failed",
    "Could not create directory '%s'",
    "Could not write image to '%s' as %s",
    "Could not read multi-page images from file '%s'",

--- a/err.h
+++ b/err.h
@@ -68,6 +68,7 @@ enum
    ERR_bermuda_chunk_corrupt1,
    ERR_g4_compression_failed,
    ERR_g4_decompression_failed,
+   ERR_jpeg_compression_failed,
    ERR_could_not_create_directory1,
    ERR_could_not_write_image_to_as2,
    ERR_could_not_read_multipage_images1,

--- a/file.cpp
+++ b/file.cpp
@@ -270,7 +270,7 @@ File::e_type File::typeFromName (const QString &fname)
 static QStringList env_names = QString ("from,to,subject,notes").split (',');
 
 
-File::e_env envFromName (const QString &name)
+File::e_env File::envFromName (const QString &name)
    {
    for (int i = 0; i < File::Env_count; i++)
       if (name == env_names [i])

--- a/file.h
+++ b/file.h
@@ -276,6 +276,12 @@ public:
    // image related
    virtual QPixmap pixmap (bool recalc = false) = 0;
 
+   /** Inject a precomputed thumbnail.  Used by Desktopmodel when the
+    *  backend renders thumbnails asynchronously (e.g. RemoteBackend
+    *  via /thumbnail) so that subclasses which don't compute their
+    *  own pixmap (Fileother) can display the supplied one. */
+   void setThumbnail(const QPixmap &pix) { _pixmap = pix; }
+
    /** returns the preview image for a particular page.
 
      If 'blank' then the image should be returned blank, either by using

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -734,9 +734,9 @@ err_info *Filemax::max_cache_data (cache_info &cache, int pos,
    {
    int n;
 
-   // Allocate extra padding so that callers which read a 4-byte word
-   // near the end of the buffer (e.g. decode_compressed_tile) do not
-   // overflow.  Qt zero-fills the extra bytes.
+   /* Allocate extra padding so that callers which read a 4-byte word
+      near the end of the buffer (e.g. decode_compressed_tile) do not
+      overflow */
    cache.buff.resize (size + 4);
 
    // read the data
@@ -751,9 +751,16 @@ err_info *Filemax::max_cache_data (cache_info &cache, int pos,
                _size);
       }
 
+   /* Zero everything fread() did not fill, including the padding. Qt 5
+      zero-filled the bytes added by resize() but Qt 6 leaves them
+      uninitialised, so a caller reading into the padding would see
+      values which change from run to run */
+   memset (cache.buff.data () + n, 0, cache.buff.size () - n);
+
    if (datap)
       *datap = (byte *)cache.buff.data ();
    cache.pos = pos;
+   cache.len = n;
    return NULL;
    }
 
@@ -764,9 +771,14 @@ byte *Filemax::max_check_scache (int pos)
    err_info *err = NULL;
 
 #define CACHE_4K_SIZE  4096
-   // if the cache has the wrong data, load it
-   if (pos < _scache.pos || (pos + 4 > _scache.pos + _scache.buff.size ()))
-      err = max_cache_data (_scache, pos, CACHE_4K_SIZE, 4, NULL);
+   /* Reload the cache unless all 4 bytes lie within the valid data.
+      Checking against the valid length matters: the buffer is padded,
+      and a read which straddles the end of the data would otherwise
+      return padding bytes instead of the real file contents. A minimum
+      of 2 allows a halfword read at the very end of the file, where
+      the padding is zeroed */
+   if (pos < _scache.pos || pos + 4 > _scache.pos + _scache.len)
+      err = max_cache_data (_scache, pos, CACHE_4K_SIZE, 2, NULL);
 
    // return the data
    if (err)
@@ -812,6 +824,7 @@ void Filemax::max_clear_cache (cache_info &cache, int pos, int size)
       {
       cache.buff.clear ();
       cache.pos = 0;
+      cache.len = 0;
       }
    }
 

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -4156,10 +4156,10 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
          break;
       }
 
-   // get size, rounding up to word boundary
-//   *sizep = out - encode->buff;
+   /* round up to a word boundary, zeroing the padding so that no
+      uninitialised bytes are written to the file */
    while (size & 3)
-      size++;
+      out [size++] = '\0';
    *sizep = size;
    return NULL;
    }
@@ -4186,7 +4186,7 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
       size plus headroom */
    encode.size = chunk.tile_size.x * chunk.tile_size.y *
          (bpp == 1 ? 1 : 4) + 1024;
-   encode.buff = (byte *)malloc (encode.size);
+   encode.buff = (byte *)malloc (encode.size + 8);
    if (!encode.buff)
       return ERR (-ENOMEM);
 

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -1511,7 +1511,8 @@ position in the image of the top left of the tile
    \param stride     image stride (line_bytes) value, pass as -1 to use
                             chunk->line_bytes */
 static byte *get_tile_size (chunk_info &chunk, int x, int y, cpoint *tile_size,
-                  int *tilenum, int stride, int tile_stride)
+                  int *tilenum, int stride, int tile_stride,
+                  int *valid_xp = NULL)
    {
    byte *ptr;
 
@@ -1531,6 +1532,13 @@ static byte *get_tile_size (chunk_info &chunk, int x, int y, cpoint *tile_size,
    tile_size->x = chunk.image_size.x - chunk.tile_size.x * x;
    if (tile_size->x > chunk.tile_size.x)
       tile_size->x = chunk.tile_size.x;
+
+   /* the tile width is padded to a multiple of 8 pixels, so it can
+      extend past the right edge of the image. Return the unpadded
+      width so that the encoder does not read pixels which don't
+      exist */
+   if (valid_xp)
+      *valid_xp = tile_size->x;
    tile_size->x = (tile_size->x + 7) & ~7;
    *tilenum = chunk.tile_extent.x * y + x;  // tile sequence number
    return ptr;
@@ -4118,7 +4126,7 @@ static err_info *encode_g4 (byte *out, int tile_line_bytes, byte *end,
 
 err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
               byte *ptr, cpoint *tile_size, int stride, int bpp,
-              int tile_line_bytes, int debug_max_steps)
+              int tile_line_bytes, int debug_max_steps, int valid_x)
    {
    byte *out = encode.buff, *end = encode.buff + encode.size;
    int size;
@@ -4142,7 +4150,7 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
       case 32 :
          size = encode.size;
          jpeg_encode (ptr, tile_size, out, &size, bpp, stride,
-              JPEG_QUALITY);
+              JPEG_QUALITY, valid_x);
          break;
       }
 
@@ -4186,10 +4194,11 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
          {
          int tilenum;
          int tile_line_bytes;
+         int valid_x;
 
          // recalculate tile_line_bytes each time
          ptr = get_tile_size (chunk, x, y, &tile_size, &tilenum, stride,
-                  encode.tile_line_bytes);
+                  encode.tile_line_bytes, &valid_x);
 
          calc_tile_bytes (tile_size.x, chunk.image_size.x, bpp,
                     &tile_line_bytes, &temp, false);
@@ -4202,7 +4211,7 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
             debug2 (("encoding tile %d (%d, %d), bpp %d, size %d x %d (0x%x x 0x%d)\n", tilenum, x, y,
                   bpp, tile_size.x, tile_size.y, tile_size.x, tile_size.y));
             e = encode_tile (chunk, encode, &size, ptr, &tile_size, stride,
-                  bpp, tile_line_bytes, debug.max_steps);
+                  bpp, tile_line_bytes, debug.max_steps, valid_x);
             if (e)
                {
                printf ("encode_tile() failed, tile %d\n", tilenum);

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -3034,13 +3034,18 @@ static int scale_2bpp (byte *image, cpoint *image_size, byte *preview,
          assert (in >= image && in <= image + image_line_bytes * (image_size->y - 1));
          mask = 1;
 
-         // calculate the value for each preview pixel
+         /* calculate the value for each preview pixel. The preview
+            width is padded to a multiple of 4 pixels, so the source
+            position can pass the right edge of the image: treat those
+            pixels as white rather than reading bits from the row
+            padding, which holds uninitialised data */
          for (x = 0; x < preview_size->x; x++)
             {
             sum = 0;
             for (xsub = 0; xsub < PREVIEW_SCALE; xsub++)
                {
-               sum += *in & mask ? 255 : 0;
+               if (x * PREVIEW_SCALE + xsub < image_size->x)
+                  sum += *in & mask ? 255 : 0;
                mask <<= 1;
                if (mask == 0x100)
                   {

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -4151,6 +4151,8 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
          size = encode.size;
          jpeg_encode (ptr, tile_size, out, &size, bpp, stride,
               JPEG_QUALITY, valid_x);
+         if (size < 0)
+            return err_make (ERRFN, ERR_jpeg_compression_failed);
          break;
       }
 
@@ -4179,8 +4181,11 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
 
    debug2 (("image size %d x %d\n", chunk.image_size.x, chunk.image_size.y));
 
-   // allocate enough memory for encoding each tile
-   encode.size = chunk.tile_size.x * chunk.tile_size.y;  // should be enough
+   /* allocate enough memory for encoding each tile. A JPEG of a noisy
+      tile can be larger than the raw pixels, so allow the full pixel
+      size plus headroom */
+   encode.size = chunk.tile_size.x * chunk.tile_size.y *
+         (bpp == 1 ? 1 : 4) + 1024;
    encode.buff = (byte *)malloc (encode.size);
    if (!encode.buff)
       return ERR (-ENOMEM);

--- a/filemax.h
+++ b/filemax.h
@@ -66,6 +66,7 @@ typedef struct cache_info
 //   int alloced;   //!< amount alloced to cache
 //   int size;      //!< size of cache
    int pos;       //!< file position of data in cache
+   int len;       //!< number of valid bytes in the cache
    } cache_info;
 
 

--- a/filemax.h
+++ b/filemax.h
@@ -147,6 +147,7 @@ typedef struct page_info
 class Filemax : public File
    {
    Q_OBJECT
+   friend class TestFile;
 
 public:
    Filemax (const QString &dir, const QString &filename, Desk *desk);

--- a/fileother.cpp
+++ b/fileother.cpp
@@ -147,6 +147,11 @@ err_info *Fileother::getPreviewInfo (int, QSize &, int &)
 // image related
 QPixmap Fileother::pixmap (bool)
    {
+   /* A backend (e.g. RemoteBackend) may have set _pixmap via
+    * File::setThumbnail() once the server returned a rendered
+    * thumbnail; prefer that over the generic placeholder. */
+   if (!_pixmap.isNull())
+      return _pixmap;
    return unknownPixmap ();
    }
 

--- a/localbackend.cpp
+++ b/localbackend.cpp
@@ -4,8 +4,12 @@ License: GPL-2
 
 #include "localbackend.h"
 
+#include <QDebug>
 #include <QDir>
+#include <QDirIterator>
+#include <QFile>
 #include <QFileInfo>
+#include <QTextStream>
 
 
 LocalBackend::LocalBackend(const QStringList &rootPaths)
@@ -25,4 +29,242 @@ QList<RepositoryInfo> LocalBackend::listRepositories()
       out.append(r);
    }
    return out;
+}
+
+
+QString LocalBackend::rootPathForName(const QString &repo) const
+{
+   for (const QString &p : _rootPaths) {
+      if (QFileInfo(p).fileName() == repo)
+         return p;
+   }
+   return QString();
+}
+
+
+DirectoryListing LocalBackend::browseDirectory(const QString &repo,
+                                               const QString &dir)
+{
+   DirectoryListing out;
+
+   /* Reject absolute paths and any traversal attempt before touching
+    * the filesystem. */
+   if (dir.contains("..") || dir.startsWith("/")) {
+      out.error = "invalid path";
+      return out;
+   }
+
+   QString rootPath = repo.isEmpty()
+                          ? (_rootPaths.isEmpty() ? QString()
+                                                  : _rootPaths.first())
+                          : rootPathForName(repo);
+   if (rootPath.isEmpty()) {
+      out.error    = "repository not found: " + repo;
+      out.notFound = true;
+      return out;
+   }
+
+   QString fullPath = rootPath;
+   if (!dir.isEmpty())
+      fullPath += "/" + dir;
+
+   QDir d(fullPath);
+   if (!d.exists()) {
+      out.error    = "directory not found";
+      out.notFound = true;
+      return out;
+   }
+
+   /* Subdirectories from the live filesystem (the cache only tracks
+    * files, not empty directory shells). */
+   QFileInfoList subdirs =
+       d.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+   for (const QFileInfo &sub : subdirs) {
+      if (sub.fileName().startsWith('.'))
+         continue;
+      DirectoryEntry e;
+      e.name = sub.fileName();
+      e.path = dir.isEmpty() ? sub.fileName()
+                             : dir + "/" + sub.fileName();
+      e.isDir = true;
+      e.count = countFilesRecursive(rootPath, e.path);
+      out.entries.append(e);
+   }
+
+   /* Files from the cache (faster than another filesystem scan). */
+   const QList<CachedFile> &cached = _fileCache.value(rootPath);
+   for (const CachedFile &file : cached) {
+      QString fileDir = QFileInfo(file.path).path();
+      bool inDir = (fileDir == "." && dir.isEmpty()) || fileDir == dir;
+      if (!inDir)
+         continue;
+
+      DirectoryEntry e;
+      e.name     = file.name;
+      e.path     = file.path;
+      e.size     = file.size;
+      e.modified = file.modified.toString(Qt::ISODate);
+      out.entries.append(e);
+   }
+
+   out.ok = true;
+   return out;
+}
+
+
+int LocalBackend::loadCacheForRepo(const QString &rootPath)
+{
+   QList<CachedFile> &fileList = _fileCache[rootPath];
+   fileList.clear();
+
+   QString papertreeFile = rootPath + "/.papertree";
+   if (QFile::exists(papertreeFile)
+       && loadFromPapertree(rootPath, fileList)) {
+      qDebug() << "LocalBackend: file cache loaded from papertree with"
+               << fileList.size() << "files";
+   } else {
+      scanDirectory(rootPath, "", fileList);
+      qDebug() << "LocalBackend: file cache built with"
+               << fileList.size() << "files";
+   }
+   return fileList.size();
+}
+
+
+int LocalBackend::cacheCount(const QString &rootPath) const
+{
+   return _fileCache.value(rootPath).size();
+}
+
+
+qint64 LocalBackend::cacheBytes(const QString &rootPath) const
+{
+   qint64 total = 0;
+   const QList<CachedFile> &files = _fileCache.value(rootPath);
+   for (const CachedFile &f : files)
+      total += f.size;
+   return total;
+}
+
+
+const QList<CachedFile> &
+LocalBackend::fileCacheFor(const QString &rootPath) const
+{
+   auto it = _fileCache.constFind(rootPath);
+   return it == _fileCache.constEnd() ? _emptyCache : it.value();
+}
+
+
+int LocalBackend::countFilesRecursive(const QString &repoPath,
+                                      const QString &dirPath) const
+{
+   const QList<CachedFile> &fileList = _fileCache.value(repoPath);
+
+   int count = 0;
+   QString prefix = dirPath.isEmpty() ? "" : dirPath + "/";
+   for (const CachedFile &file : fileList) {
+      if (dirPath.isEmpty() || file.path.startsWith(prefix))
+         count++;
+   }
+   return count;
+}
+
+
+bool LocalBackend::loadFromPapertree(const QString &repoPath,
+                                     QList<CachedFile> &fileList)
+{
+   QString papertreeFile = repoPath + "/.papertree";
+   QFile file(papertreeFile);
+
+   if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      qWarning() << "LocalBackend: failed to open papertree file:"
+                 << papertreeFile;
+      return false;
+   }
+
+   QTextStream in(&file);
+   QStringList dirStack;
+
+   while (!in.atEnd()) {
+      QString line = in.readLine();
+
+      int level = 0;
+      for (int i = 0; i < line.length(); i++) {
+         if (line[i] == ' ')
+            level++;
+         else
+            break;
+      }
+      if (level < 1)
+         continue;
+
+      QString name = line.mid(level);
+
+      while (dirStack.size() >= level)
+         dirStack.removeLast();
+
+      QString relativePath = dirStack.join("/");
+      if (!relativePath.isEmpty())
+         relativePath += "/";
+      relativePath += name;
+
+      QString fullPath = repoPath + "/" + relativePath;
+      QFileInfo fileInfo(fullPath);
+      if (!fileInfo.exists())
+         continue;
+
+      if (fileInfo.isDir()) {
+         dirStack.append(name);
+      } else if (fileInfo.isFile()) {
+         QString ext = name.section('.', -1).toLower();
+         if (ext == "max" || ext == "pdf" || ext == "jpg"
+             || ext == "jpeg" || ext == "tiff" || ext == "tif") {
+            CachedFile cachedFile;
+            cachedFile.path     = relativePath;
+            cachedFile.name     = name;
+            cachedFile.size     = fileInfo.size();
+            cachedFile.modified = fileInfo.lastModified();
+            fileList.append(cachedFile);
+         }
+      }
+   }
+
+   file.close();
+   return fileList.size() > 0;
+}
+
+
+void LocalBackend::scanDirectory(const QString &repoPath,
+                                 const QString &dirPath,
+                                 QList<CachedFile> &fileList)
+{
+   QString fullPath = repoPath;
+   if (!dirPath.isEmpty())
+      fullPath += "/" + dirPath;
+
+   QStringList nameFilters;
+   nameFilters << "*.max" << "*.pdf" << "*.jpg" << "*.jpeg"
+               << "*.tiff" << "*.tif";
+
+   QDirIterator it(fullPath, nameFilters,
+                   QDir::Files | QDir::Readable,
+                   QDirIterator::Subdirectories);
+
+   while (it.hasNext()) {
+      QString filePath = it.next();
+      QFileInfo info(filePath);
+
+      QString relativePath = filePath;
+      if (relativePath.startsWith(repoPath + "/"))
+         relativePath = relativePath.mid(repoPath.length() + 1);
+      else if (relativePath.startsWith(repoPath))
+         relativePath = relativePath.mid(repoPath.length());
+
+      CachedFile cached;
+      cached.path     = relativePath;
+      cached.name     = info.fileName();
+      cached.size     = info.size();
+      cached.modified = info.lastModified();
+      fileList.append(cached);
+   }
 }

--- a/localbackend.cpp
+++ b/localbackend.cpp
@@ -91,19 +91,23 @@ DirectoryListing LocalBackend::browseDirectory(const QString &repo,
       out.entries.append(e);
    }
 
-   /* Files from the cache (faster than another filesystem scan). */
-   const QList<CachedFile> &cached = _fileCache.value(rootPath);
-   for (const CachedFile &file : cached) {
-      QString fileDir = QFileInfo(file.path).path();
-      bool inDir = (fileDir == "." && dir.isEmpty()) || fileDir == dir;
-      if (!inDir)
-         continue;
-
+   /* Files from a fresh filesystem scan of just this directory.
+    * (The repo-wide _fileCache is built lazily — the server's
+    * search endpoint depends on it, but the GUI doesn't, so we
+    * can't assume it's populated here.  A single-directory scan
+    * is cheap.) */
+   QStringList nameFilters;
+   nameFilters << "*.max" << "*.pdf" << "*.jpg" << "*.jpeg"
+               << "*.tiff" << "*.tif";
+   QFileInfoList files = d.entryInfoList(nameFilters,
+       QDir::Files | QDir::NoSymLinks | QDir::Readable, QDir::Name);
+   for (const QFileInfo &f : files) {
       DirectoryEntry e;
-      e.name     = file.name;
-      e.path     = file.path;
-      e.size     = file.size;
-      e.modified = file.modified.toString(Qt::ISODate);
+      e.name     = f.fileName();
+      e.path     = dir.isEmpty() ? f.fileName()
+                                 : dir + "/" + f.fileName();
+      e.size     = f.size();
+      e.modified = f.lastModified().toString(Qt::ISODate);
       out.entries.append(e);
    }
 

--- a/localbackend.cpp
+++ b/localbackend.cpp
@@ -1,0 +1,28 @@
+/*
+License: GPL-2
+*/
+
+#include "localbackend.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+
+LocalBackend::LocalBackend(const QStringList &rootPaths)
+   : _rootPaths(rootPaths)
+{
+}
+
+
+QList<RepositoryInfo> LocalBackend::listRepositories()
+{
+   QList<RepositoryInfo> out;
+   for (const QString &path : _rootPaths) {
+      RepositoryInfo r;
+      r.path   = path;
+      r.exists = QDir(path).exists();
+      r.name   = r.exists ? QFileInfo(path).fileName() : QString();
+      out.append(r);
+   }
+   return out;
+}

--- a/localbackend.cpp
+++ b/localbackend.cpp
@@ -112,6 +112,43 @@ DirectoryListing LocalBackend::browseDirectory(const QString &repo,
 }
 
 
+FileFetch LocalBackend::readFile(const QString &repo, const QString &path)
+{
+   FileFetch out;
+
+   if (path.isEmpty() || path.contains("..") || path.startsWith("/")) {
+      out.error = "invalid path";
+      return out;
+   }
+
+   QString rootPath = repo.isEmpty()
+                          ? (_rootPaths.isEmpty() ? QString()
+                                                  : _rootPaths.first())
+                          : rootPathForName(repo);
+   if (rootPath.isEmpty()) {
+      out.error    = "repository not found: " + repo;
+      out.notFound = true;
+      return out;
+   }
+
+   QFile f(rootPath + "/" + path);
+   if (!f.exists()) {
+      out.error    = "file not found";
+      out.notFound = true;
+      return out;
+   }
+   if (!f.open(QIODevice::ReadOnly)) {
+      out.error = "cannot open: " + f.errorString();
+      return out;
+   }
+
+   out.bytes       = f.readAll();
+   out.contentType = Backend::contentTypeForPath(path);
+   out.ok          = true;
+   return out;
+}
+
+
 int LocalBackend::loadCacheForRepo(const QString &rootPath)
 {
    QList<CachedFile> &fileList = _fileCache[rootPath];

--- a/localbackend.h
+++ b/localbackend.h
@@ -1,0 +1,29 @@
+/*
+License: GPL-2
+*/
+
+#ifndef LOCALBACKEND_H
+#define LOCALBACKEND_H
+
+#include "backend.h"
+
+#include <QStringList>
+
+
+/**
+ * In-process Backend that reads directly from the local filesystem.
+ * The list of root paths is fixed for the lifetime of the instance
+ * (changing it requires restarting the server, same as today).
+ */
+class LocalBackend : public Backend
+{
+public:
+    explicit LocalBackend(const QStringList &rootPaths);
+
+    QList<RepositoryInfo> listRepositories() override;
+
+private:
+    QStringList _rootPaths;
+};
+
+#endif // LOCALBACKEND_H

--- a/localbackend.h
+++ b/localbackend.h
@@ -6,24 +6,63 @@ License: GPL-2
 #define LOCALBACKEND_H
 
 #include "backend.h"
+#include "cachedfile.h"
 
+#include <QHash>
+#include <QList>
 #include <QStringList>
 
 
 /**
  * In-process Backend that reads directly from the local filesystem.
- * The list of root paths is fixed for the lifetime of the instance
- * (changing it requires restarting the server, same as today).
+ * The list of root paths is fixed for the lifetime of the instance;
+ * the file cache it maintains can be rebuilt at runtime (e.g. when a
+ * `.papertree` file changes).
  */
 class LocalBackend : public Backend
 {
 public:
     explicit LocalBackend(const QStringList &rootPaths);
 
+    // Backend
     QList<RepositoryInfo> listRepositories() override;
+    DirectoryListing browseDirectory(const QString &repo,
+                                     const QString &dir) override;
+
+    /** Build (or rebuild) the in-memory file cache for one repo from
+     *  disk.  Returns the number of files cached.  Prefers loading
+     *  from `<root>/.papertree` if present and non-empty, otherwise
+     *  walks the directory tree. */
+    int loadCacheForRepo(const QString &rootPath);
+
+    /** Number of files cached for @p rootPath. */
+    int cacheCount(const QString &rootPath) const;
+
+    /** Total size in bytes of all cached files for @p rootPath. */
+    qint64 cacheBytes(const QString &rootPath) const;
+
+    /** Direct read-only access to the cached file list for
+     *  @p rootPath.  Returned reference remains valid until the next
+     *  loadCacheForRepo() call for the same path. */
+    const QList<CachedFile> &fileCacheFor(const QString &rootPath) const;
+
+    /** Translate a repository name (basename) to its on-disk root
+     *  path.  Returns empty string for unknown names. */
+    QString rootPathForName(const QString &repo) const;
 
 private:
+    void scanDirectory(const QString &repoPath, const QString &dirPath,
+                       QList<CachedFile> &fileList);
+    bool loadFromPapertree(const QString &repoPath,
+                           QList<CachedFile> &fileList);
+    int countFilesRecursive(const QString &repoPath,
+                            const QString &dirPath) const;
+
     QStringList _rootPaths;
+    QHash<QString, QList<CachedFile>> _fileCache;
+    /** Returned by fileCacheFor() when the repo is unknown so callers
+     *  don't need to handle a null reference. */
+    QList<CachedFile> _emptyCache;
 };
 
 #endif // LOCALBACKEND_H

--- a/localbackend.h
+++ b/localbackend.h
@@ -28,6 +28,8 @@ public:
     QList<RepositoryInfo> listRepositories() override;
     DirectoryListing browseDirectory(const QString &repo,
                                      const QString &dir) override;
+    FileFetch readFile(const QString &repo,
+                       const QString &path) override;
 
     /** Build (or rebuild) the in-memory file cache for one repo from
      *  disk.  Returns the number of files cached.  Prefers loading

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1158,97 +1158,103 @@ void Mainwidget::print (void)
       _opt->putxml ();
       }
    if (result && !_saved)
-      {
-      _pagecount = _opt->countPages ();
-      _new_page = false;
-      Operation op ("Printing", _pagecount, this);
-      QPainter painter;
-      if (!painter.begin (_printer))                // paint on printer
-         {
-         emit newContents ("Printing aborted");
-         return;
-         }
-
-      _watchButtons = false;
-      qApp->processEvents ();
-
-      QPaintDevice *device = painter.device();
-//       int dpiy = metrics.logicalDpiY();
-      int margin = 0;  //(int) ( (0/2.54)*dpiy ); // 2 cm margins
-//       QRect view( body );
-      char msg [300];
-      err_info *e = NULL;
-
-/*   bool sepSheet;
-   bool shrinkFit;*/
-
-      _from_page = _printer->fromPage () - 1;
-      _to_page = _printer->toPage () - 1;
-      _body = QRect ( margin, margin, device->width() - 2*margin,
-                      device->height() - 2*margin );
-      _painter = &painter;
-
-      if (_opt->_shrinkFit)
-         _printable = _body;
-      else
-         {
-#if QT_VERSION >= 0x040400
-         QMarginsF margins = _printer->pageLayout().margins();
-         qreal left = margins.left(), top = margins.top();
-         qreal right = margins.right(), bottom = margins.bottom();
-
-         _printable = QRect (left, top, _body.width () - left - right, _body.height () - top - bottom);
-#else
-         _printable = _printer->pageRect ();
-#endif
-         }
-
-      // set up the font
-      _painter->setFont (_opt->_font);
-
-      _reverse = _printer->pageOrder () == QPrinter::LastPageFirst;
-
-      // iterate through all stacks and pages
-      int seq = _reverse ? _pagecount - 1 : 0;      // page sequence number
-
-      for (int i = _reverse ? list.size () - 1 : 0; _reverse ? i >= 0 : i < list.size ();
-          _reverse ? i-- : i++)
-//       foreach (ind, list)
-         {
-         ind = list [i];
-         int numpages = _contents->data (ind, Desktopmodel::Role_pagecount).toInt ();
-         int blank = _opt->_sepSheet /*&& _printer->doubleSidedPrinting ()*/ && (numpages & 1)
-            ? 1 : 0;    // add a blank page?
-
-         for (int pnum = _reverse ? numpages + blank - 1 : 0;
-             _reverse ? pnum >= 0 : pnum < numpages + blank; _reverse ? pnum-- : pnum++)
-//          for (int pnum = 0; pnum < numpages + blank; pnum++)
-            {
-            if (op.setProgress (seq))
-               CALLB (err_make (ERRFN, ERR_operation_cancelled1, "print"));
-//             printf ("seq %d: row %d, %d of %d\n", seq, ind.row (), pnum, numpages);
-            CALLB (printPage (_reverse ? seq-- : seq++, ind, pnum, numpages));
-            }
-         if (e)
-            break;
-         }
-
-      painter.end ();
-
-//printf ("w,h = %d, %d\n", body.width (), body.height ());
-
-      if (e)
-         {
-         snprintf (msg, sizeof(msg), "Print error: %s", e->errstr);
-         emit newContents (msg);
-         }
-      else
-         emit newContents ("Printing completed");
-      }
+      printPages (list);
    else if (!result)
       emit newContents ("Printing aborted");
    _watchButtons = true;
    delete _opt;
+   }
+
+
+void Mainwidget::printPages (QModelIndexList &list)
+   {
+   QModelIndex ind;
+
+   _pagecount = _opt->countPages ();
+   _new_page = false;
+   Operation op ("Printing", _pagecount, this);
+   QPainter painter;
+   if (!painter.begin (_printer))                // paint on printer
+      {
+      emit newContents ("Printing aborted");
+      return;
+      }
+
+   _watchButtons = false;
+   qApp->processEvents ();
+
+   QPaintDevice *device = painter.device();
+//    int dpiy = metrics.logicalDpiY();
+   int margin = 0;  //(int) ( (0/2.54)*dpiy ); // 2 cm margins
+//    QRect view( body );
+   char msg [300];
+   err_info *e = NULL;
+
+/*   bool sepSheet;
+   bool shrinkFit;*/
+
+   _from_page = _printer->fromPage () - 1;
+   _to_page = _printer->toPage () - 1;
+   _body = QRect ( margin, margin, device->width() - 2*margin,
+                   device->height() - 2*margin );
+   _painter = &painter;
+
+   if (_opt->_shrinkFit)
+      _printable = _body;
+   else
+      {
+#if QT_VERSION >= 0x040400
+      QMarginsF margins = _printer->pageLayout().margins();
+      qreal left = margins.left(), top = margins.top();
+      qreal right = margins.right(), bottom = margins.bottom();
+
+      _printable = QRect (left, top, _body.width () - left - right, _body.height () - top - bottom);
+#else
+      _printable = _printer->pageRect ();
+#endif
+      }
+
+   // set up the font
+   _painter->setFont (_opt->_font);
+
+   _reverse = _printer->pageOrder () == QPrinter::LastPageFirst;
+
+   // iterate through all stacks and pages
+   int seq = _reverse ? _pagecount - 1 : 0;      // page sequence number
+
+   for (int i = _reverse ? list.size () - 1 : 0; _reverse ? i >= 0 : i < list.size ();
+       _reverse ? i-- : i++)
+//    foreach (ind, list)
+      {
+      ind = list [i];
+      int numpages = _contents->data (ind, Desktopmodel::Role_pagecount).toInt ();
+      int blank = _opt->_sepSheet /*&& _printer->doubleSidedPrinting ()*/ && (numpages & 1)
+         ? 1 : 0;    // add a blank page?
+
+      for (int pnum = _reverse ? numpages + blank - 1 : 0;
+          _reverse ? pnum >= 0 : pnum < numpages + blank; _reverse ? pnum-- : pnum++)
+//       for (int pnum = 0; pnum < numpages + blank; pnum++)
+         {
+         if (op.setProgress (seq))
+            CALLB (err_make (ERRFN, ERR_operation_cancelled1, "print"));
+//          printf ("seq %d: row %d, %d of %d\n", seq, ind.row (), pnum, numpages);
+         CALLB (printPage (_reverse ? seq-- : seq++, ind, pnum, numpages));
+         }
+      if (e)
+         break;
+      }
+
+   painter.end ();
+
+//printf ("w,h = %d, %d\n", body.width (), body.height ());
+
+   if (e)
+      {
+      snprintf (msg, sizeof(msg), "Print error: %s", e->errstr);
+      emit newContents (msg);
+      }
+   else
+      emit newContents ("Printing completed");
    }
 
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -216,7 +216,7 @@ void Mainwidget::showPage (const QModelIndex &index, bool delay_smoothing)
 #endif
    setCurrentIndex(1);
 //    _page->showPage (index.model (), index, delay_smoothing);
-   _page->showPages (index.model (), index, 0, -1, 2);
+   _page->showPages (index.model (), index, 0, -1, -1);
    }
 
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -309,6 +309,11 @@ private:
       \param numpages Number of pages in stack */
    err_info *printPage (int seq, QModelIndex &ind, int pnum, int numpages);
 
+   /** print all pages of the given stacks to _printer using the options
+       in _opt. This is the part of print() which runs after the user
+       accepts the print dialogue */
+   void printPages (QModelIndexList &list);
+
    //! setup the scan dialog and our _preview pointer
    void setupScanDialog (void);
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -73,6 +73,7 @@ extern "C"
 class Mainwidget : public QStackedWidget
    {
    Q_OBJECT
+   friend class TestOps;
 public:
    Mainwidget (QWidget *parent, const char *name = 0);
    ~Mainwidget();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -111,7 +111,7 @@ Mainwindow::~Mainwindow()
     // no need to delete child widgets, Qt does it all for us
 }
 
-void Mainwindow::startup(const QStringList& dirs)
+void Mainwindow::startup(const QStringList& dirs, const QString& serverUrl)
 {
    Desktopwidget *desktop;
 
@@ -121,6 +121,16 @@ void Mainwindow::startup(const QStringList& dirs)
    QList<err_info> err_list;
 
    err_list = desktop->addRepositories(dirs);
+
+   QString serverError;
+   if (!serverUrl.isEmpty()) {
+      QUrl url(serverUrl);
+      if (url.isValid() && !url.scheme().isEmpty()) {
+         serverError = desktop->addRemoteServer(url);
+      } else {
+         serverError = QString("invalid URL: %1").arg(serverUrl);
+      }
+   }
 
    show ();
    QModelIndex ind = QModelIndex();
@@ -136,6 +146,11 @@ void Mainwindow::startup(const QStringList& dirs)
          msg.append (QString ("%1\n").arg (err.errstr));
       QMessageBox::warning (0, "Maxview", msg);
       }
+
+   if (!serverError.isEmpty())
+      QMessageBox::warning(0, "Paperman",
+         QString("Failed to connect to %1: %2")
+             .arg(serverUrl, serverError));
 }
 
 void Mainwindow::shutdown()
@@ -148,7 +163,8 @@ void Mainwindow::shutdown()
       delete xmlConfig;
 }
 
-void Mainwindow::runGui(QApplication& app, QStringList args)
+void Mainwindow::runGui(QApplication& app, QStringList args,
+                        const QString& serverUrl)
     {
     Mainwindow *me;
 
@@ -156,7 +172,7 @@ void Mainwindow::runGui(QApplication& app, QStringList args)
 
     me = new Mainwindow();
 
-    me->startup(args);
+    me->startup(args, serverUrl);
     app.exec();
 
     me->shutdown();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -55,14 +55,17 @@ public:
    // Select whether the 'search' menu-option is available
    void setSearchEnabled(bool enable);
 
-   //! Add the given list of extra repositories, reporting any errors
-   void startup(const QStringList& dirs);
+   //! Add the given list of extra repositories, reporting any errors.
+   //! If @p serverUrl is non-empty, also connect to that paperman-server
+   //! and add every repository it serves as top-level items.
+   void startup(const QStringList& dirs, const QString& serverUrl = QString());
 
    //! Shut down, saving settings
    void shutdown();
 
    // Run the GUI with the given arguments
-   static void runGui(QApplication& app, QStringList args);
+   static void runGui(QApplication& app, QStringList args,
+                      const QString& serverUrl = QString());
 
 public slots:
     virtual void on_actionPrint_triggered(bool);

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -795,8 +795,10 @@ int main (int argc, char *argv[])
          int qt_argc = 1;
          int result = test_run(qt_argc, qt_argv, &app, filter);
 
-         if (result)
+         if (result) {
             qInfo() << "Failed: " << result;
+            return 1;
+         }
          }
 #else
          qInfo() << "Use this to build with tests: qmake CONFIG+=test";

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -544,7 +544,13 @@ int main (int argc, char *argv[])
       that they cannot read or modify the user's real configuration.
       This covers both QSettings (via XDG_CONFIG_HOME) and the xml
       config in ~/.maxview (via HOME). The QTemporaryDir is static so
-      the directory is removed when the process exits */
+      the directory is removed when the process exits.
+
+      Also point SANE at the scratch directory: with no dll.conf there,
+      no backends are loaded, so device enumeration returns at once
+      instead of probing the host's scanners (which takes many seconds
+      per sane_init). The tests only use the built-in simulated
+      scanner, which does not need a backend */
    for (int i = 1; i < argc; i++)
       if (!strcmp (argv [i], "-t"))
          {
@@ -552,6 +558,7 @@ int main (int argc, char *argv[])
          qputenv ("HOME", test_home.path ().toLocal8Bit ());
          qputenv ("XDG_CONFIG_HOME",
                   (test_home.path () + "/.config").toLocal8Bit ());
+         qputenv ("SANE_CONFIG_DIR", test_home.path ().toLocal8Bit ());
          break;
          }
 

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -38,6 +38,7 @@ C           copy        scan and print to default printer, save to 'photocopy' f
 #include <QStandardPaths>
 #include <QImage>
 #include <QProcess>
+#include <QTemporaryDir>
 #include <QRegularExpression>
 #include <QSettings>
 #include <QTemporaryDir>
@@ -539,6 +540,21 @@ static void usage (void)
 
 int main (int argc, char *argv[])
    {
+   /* When running tests, point the settings at a scratch directory so
+      that they cannot read or modify the user's real configuration.
+      This covers both QSettings (via XDG_CONFIG_HOME) and the xml
+      config in ~/.maxview (via HOME). The QTemporaryDir is static so
+      the directory is removed when the process exits */
+   for (int i = 1; i < argc; i++)
+      if (!strcmp (argv [i], "-t"))
+         {
+         static QTemporaryDir test_home;
+         qputenv ("HOME", test_home.path ().toLocal8Bit ());
+         qputenv ("XDG_CONFIG_HOME",
+                  (test_home.path () + "/.config").toLocal8Bit ());
+         break;
+         }
+
    //bool verbose = false, force = false, reloc = false, hack = false;
    //int debug = 0;
    char *dir = 0;

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -571,6 +571,7 @@ int main (int argc, char *argv[])
      {"rebuild-previews", 1, 0, 259},
      {"adjust", 1, 0, 260},
      {"quality", 1, 0, 261},
+     {"server", 1, 0, 262},
      {0, 0, 0, 0}
    };
    int op_type = -1, c;
@@ -582,6 +583,7 @@ int main (int argc, char *argv[])
    int jobs = 0;                          // 0 = auto
    int quality = 75;                      // JPEG quality (1-100)
    QString adjust_name;
+   QString serverUrl;                     // --server URL
 
    struct rlimit limit;
 
@@ -661,6 +663,10 @@ int main (int argc, char *argv[])
                fprintf (stderr, "--quality must be 1-100\n");
                return 1;
                }
+            break;
+
+         case 262 :    // --server URL
+            serverUrl = QString(optarg);
             break;
 
          case 'h' :
@@ -1064,9 +1070,9 @@ int main (int argc, char *argv[])
 
       case -1 :
          QStringList args;
-         for (int i = 1; i < argc; i++)
+         for (int i = optind; i < argc; i++)
             args << argv[i];
-         Mainwindow::runGui(app, args);
+         Mainwindow::runGui(app, args, serverUrl);
 #if 0
       case 1 :
          Desk maxdesk (QString(), QString());

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -175,9 +175,9 @@ public:
       \param index       the file index
       \param start       start page (0 for first)
       \param count       number of pages (-1 for all)
-      \param across      how many to show across (normally 1 or 2) */
+      \param curpage     page to display (-1 for the stack's current page) */
    void showPages (const QAbstractItemModel *model, const QModelIndex &index,
-         int start, int count, int across, bool reset = false);
+         int start, int count, int curpage, bool reset = false);
 
    void pageLeft (void);
    void pageRight (void);

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -131,6 +131,7 @@ private:
 class Pagewidget : public QWidget
    {
    Q_OBJECT
+   friend class TestPagewidget;
 
 public:
    /** which mode the viewer is in */

--- a/paperman-client.cpp
+++ b/paperman-client.cpp
@@ -1,0 +1,293 @@
+/*
+License: GPL-2
+   Project:    Paperman
+   File:       paperman-client.cpp
+
+   Thin command-line wrapper around RemoteBackend.  Lets you exercise
+   a paperman-server from the shell — useful for poking at a remote
+   deployment while the GUI still talks to the local filesystem.
+*/
+
+#include "remotebackend.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QStringList>
+#include <QUrl>
+
+#include <cstdio>
+#include <iostream>
+#include <termios.h>
+#include <unistd.h>
+
+
+static void usage(const char *prog)
+{
+   std::cerr <<
+      "Usage: " << prog << " [--server URL] <command> [args]\n"
+      "\n"
+      "Commands:\n"
+      "  login <user>               Prompt for password, save token\n"
+      "  logout                     Forget the saved token\n"
+      "  status                     Show server status\n"
+      "  repos                      List repositories\n"
+      "  ls <repo> [path]           List files in a repo directory\n"
+      "\n"
+      "Default server is $PAPERMAN_SERVER, else http://localhost:8080.\n"
+      "Tokens are stored per-server-id in "
+      "~/.config/paperman/<serverId>.token (0600).\n";
+}
+
+
+static QString readHidden(const QString &prompt)
+{
+   std::cout << prompt.toStdString() << std::flush;
+
+   termios oldt;
+   bool toggled = false;
+   if (isatty(fileno(stdin)) && tcgetattr(fileno(stdin), &oldt) == 0) {
+      termios newt = oldt;
+      newt.c_lflag &= ~(tcflag_t)ECHO;
+      if (tcsetattr(fileno(stdin), TCSANOW, &newt) == 0)
+         toggled = true;
+   }
+
+   char buf[256];
+   QString line;
+   if (fgets(buf, sizeof(buf), stdin)) {
+      line = QString::fromLocal8Bit(buf);
+      if (line.endsWith('\n'))
+         line.chop(1);
+   }
+
+   if (toggled) {
+      tcsetattr(fileno(stdin), TCSANOW, &oldt);
+      std::cout << "\n";
+   }
+   return line;
+}
+
+
+static QString tokenDir()
+{
+   QString d = QStandardPaths::writableLocation(
+                   QStandardPaths::GenericConfigLocation)
+               + "/paperman";
+   QDir().mkpath(d);
+   return d;
+}
+
+
+static QString tokenPathFor(const QString &serverId)
+{
+   return tokenDir() + "/" + serverId + ".token";
+}
+
+
+static QString loadToken(const QString &serverId)
+{
+   QFile f(tokenPathFor(serverId));
+   if (!f.open(QIODevice::ReadOnly))
+      return QString();
+   return QString::fromUtf8(f.readAll()).trimmed();
+}
+
+
+static bool saveToken(const QString &serverId, const QString &token)
+{
+   QString p = tokenPathFor(serverId);
+   QFile f(p);
+   if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+      return false;
+   f.write(token.toUtf8());
+   f.write("\n");
+   f.close();
+   QFile::setPermissions(p, QFile::ReadOwner | QFile::WriteOwner);
+   return true;
+}
+
+
+/* Construct a backend pre-loaded with any token we already have for
+ * this serverId.  An empty token is fine — endpoints that don't need
+ * auth still work. */
+static RemoteBackend *makeBackend(const QUrl &url, bool loadCachedToken)
+{
+   auto *b = new RemoteBackend(url);
+   if (loadCachedToken) {
+      QString sid = b->serverId();
+      if (!sid.isEmpty()) {
+         QString tok = loadToken(sid);
+         if (!tok.isEmpty())
+            b->setBearerToken(tok);
+      }
+   }
+   return b;
+}
+
+
+static int cmdStatus(RemoteBackend *b)
+{
+   QString sid = b->serverId();
+   if (sid.isEmpty()) {
+      std::cerr << "Failed: " << b->lastError().toStdString() << "\n";
+      return 1;
+   }
+   std::cout << "serverId: " << sid.toStdString() << "\n";
+   return 0;
+}
+
+
+static int cmdRepos(RemoteBackend *b)
+{
+   QList<RepositoryInfo> repos = b->listRepositories();
+   if (repos.isEmpty() && !b->lastError().isEmpty()) {
+      std::cerr << "Failed: " << b->lastError().toStdString() << "\n";
+      return 1;
+   }
+   for (const RepositoryInfo &r : repos) {
+      std::cout << r.name.toStdString() << "\t"
+                << (r.exists ? "ok" : "missing") << "\t"
+                << r.path.toStdString() << "\n";
+   }
+   return 0;
+}
+
+
+static int cmdLs(RemoteBackend *b, const QString &repo, const QString &path)
+{
+   DirectoryListing l = b->browseDirectory(repo, path);
+   if (l.entries.isEmpty() && !b->lastError().isEmpty()) {
+      std::cerr << "Failed: " << b->lastError().toStdString() << "\n";
+      return 1;
+   }
+   for (const DirectoryEntry &e : l.entries) {
+      if (e.isDir) {
+         std::cout << "d\t-\t" << e.name.toStdString() << "/\n";
+      } else {
+         std::cout << "-\t" << e.size << "\t"
+                   << e.name.toStdString() << "\n";
+      }
+   }
+   return 0;
+}
+
+
+static int cmdLogin(const QUrl &url, const QString &user)
+{
+   RemoteBackend b(url);
+   QString sid = b.serverId();
+   if (sid.isEmpty()) {
+      std::cerr << "Could not reach server at "
+                << url.toString().toStdString() << ": "
+                << b.lastError().toStdString() << "\n";
+      return 1;
+   }
+   QString pw = readHidden("Password: ");
+   if (pw.isEmpty()) {
+      std::cerr << "Aborted: empty password\n";
+      return 1;
+   }
+   if (!b.login(user, pw)) {
+      std::cerr << "Login failed: " << b.lastError().toStdString() << "\n";
+      return 1;
+   }
+   if (!saveToken(sid, b.bearerToken())) {
+      std::cerr << "Warning: could not write token file\n";
+      return 1;
+   }
+   std::cout << "Logged in as " << user.toStdString()
+             << "; token saved to "
+             << tokenPathFor(sid).toStdString() << "\n";
+   return 0;
+}
+
+
+static int cmdLogout(const QUrl &url)
+{
+   RemoteBackend b(url);
+   QString sid = b.serverId();
+   if (sid.isEmpty()) {
+      std::cerr << "Could not reach server: "
+                << b.lastError().toStdString() << "\n";
+      return 1;
+   }
+   QString p = tokenPathFor(sid);
+   if (QFile::exists(p) && !QFile::remove(p)) {
+      std::cerr << "Failed to remove " << p.toStdString() << "\n";
+      return 1;
+   }
+   std::cout << "Logged out (removed " << p.toStdString() << ")\n";
+   return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+   QCoreApplication app(argc, argv);
+   QStringList args = app.arguments();
+
+   QString serverUrl = QString::fromLocal8Bit(qgetenv("PAPERMAN_SERVER"));
+   if (serverUrl.isEmpty())
+      serverUrl = "http://localhost:8080";
+
+   /* Argument parsing: optional --server then a subcommand. */
+   QStringList rest;
+   for (int i = 1; i < args.size(); i++) {
+      if ((args[i] == "--server" || args[i] == "-s")
+          && i + 1 < args.size()) {
+         serverUrl = args[++i];
+      } else if (args[i] == "-h" || args[i] == "--help") {
+         usage(argv[0]);
+         return 0;
+      } else {
+         rest << args[i];
+      }
+   }
+   if (rest.isEmpty()) {
+      usage(argv[0]);
+      return 1;
+   }
+
+   QUrl url(serverUrl);
+   if (!url.isValid() || url.scheme().isEmpty()) {
+      std::cerr << "Bad server URL: " << serverUrl.toStdString() << "\n";
+      return 1;
+   }
+
+   QString cmd = rest[0];
+   if (cmd == "login") {
+      if (rest.size() < 2) { usage(argv[0]); return 1; }
+      return cmdLogin(url, rest[1]);
+   }
+   if (cmd == "logout") {
+      return cmdLogout(url);
+   }
+   if (cmd == "status") {
+      RemoteBackend *b = makeBackend(url, /*loadCachedToken=*/false);
+      int r = cmdStatus(b);
+      delete b;
+      return r;
+   }
+   if (cmd == "repos") {
+      RemoteBackend *b = makeBackend(url, /*loadCachedToken=*/true);
+      int r = cmdRepos(b);
+      delete b;
+      return r;
+   }
+   if (cmd == "ls") {
+      if (rest.size() < 2) { usage(argv[0]); return 1; }
+      QString repo = rest[1];
+      QString path = rest.size() > 2 ? rest[2] : QString();
+      RemoteBackend *b = makeBackend(url, /*loadCachedToken=*/true);
+      int r = cmdLs(b, repo, path);
+      delete b;
+      return r;
+   }
+
+   std::cerr << "Unknown command: " << cmd.toStdString() << "\n";
+   usage(argv[0]);
+   return 1;
+}

--- a/paperman-client.cpp
+++ b/paperman-client.cpp
@@ -35,6 +35,7 @@ static void usage(const char *prog)
       "  status                     Show server status\n"
       "  repos                      List repositories\n"
       "  ls <repo> [path]           List files in a repo directory\n"
+      "  cat <repo> <path> [-o OUT] Fetch a file (stdout, or to OUT)\n"
       "\n"
       "Default server is $PAPERMAN_SERVER, else http://localhost:8080.\n"
       "Tokens are stored per-server-id in "
@@ -151,6 +152,32 @@ static int cmdRepos(RemoteBackend *b)
       std::cout << r.name.toStdString() << "\t"
                 << (r.exists ? "ok" : "missing") << "\t"
                 << r.path.toStdString() << "\n";
+   }
+   return 0;
+}
+
+
+static int cmdCat(RemoteBackend *b, const QString &repo, const QString &path,
+                  const QString &outPath)
+{
+   FileFetch f = b->readFile(repo, path);
+   if (!f.ok) {
+      std::cerr << "Failed: " << f.error.toStdString() << "\n";
+      return 1;
+   }
+   if (outPath.isEmpty()) {
+      std::cout.write(f.bytes.constData(), f.bytes.size());
+   } else {
+      QFile out(outPath);
+      if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+         std::cerr << "Cannot write " << outPath.toStdString()
+                   << ": " << out.errorString().toStdString() << "\n";
+         return 1;
+      }
+      out.write(f.bytes);
+      std::cerr << "Wrote " << f.bytes.size() << " bytes ("
+                << f.contentType.toStdString() << ") to "
+                << outPath.toStdString() << "\n";
    }
    return 0;
 }
@@ -283,6 +310,22 @@ int main(int argc, char *argv[])
       QString path = rest.size() > 2 ? rest[2] : QString();
       RemoteBackend *b = makeBackend(url, /*loadCachedToken=*/true);
       int r = cmdLs(b, repo, path);
+      delete b;
+      return r;
+   }
+   if (cmd == "cat") {
+      if (rest.size() < 3) { usage(argv[0]); return 1; }
+      QString repo = rest[1];
+      QString path = rest[2];
+      QString outPath;
+      for (int i = 3; i < rest.size(); i++) {
+         if ((rest[i] == "-o" || rest[i] == "--out")
+             && i + 1 < rest.size()) {
+            outPath = rest[++i];
+         }
+      }
+      RemoteBackend *b = makeBackend(url, /*loadCachedToken=*/true);
+      int r = cmdCat(b, repo, path, outPath);
       delete b;
       return r;
    }

--- a/paperman-client.pro
+++ b/paperman-client.pro
@@ -12,6 +12,7 @@ HEADERS += backend.h \
     remotebackend.h
 
 SOURCES += paperman-client.cpp \
+    backend.cpp \
     remotebackend.cpp
 
 unix {

--- a/paperman-client.pro
+++ b/paperman-client.pro
@@ -1,0 +1,23 @@
+TEMPLATE = app
+TARGET = paperman-client
+LANGUAGE = C++
+QT = core network
+
+CONFIG += qt warn_on console
+CONFIG -= app_bundle
+
+DEFINES += QT_NO_WIDGETS
+
+HEADERS += backend.h \
+    remotebackend.h
+
+SOURCES += paperman-client.cpp \
+    remotebackend.cpp
+
+unix {
+    target.path = usr/bin
+    target.files = paperman-client
+    INSTALLS += target
+}
+
+message("Building Paperman client CLI")

--- a/paperman-server.cpp
+++ b/paperman-server.cpp
@@ -30,15 +30,25 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "builddate.h"
 #include "config.h"
 #include "searchserver.h"
+#include "userstore.h"
 
 #include <QCoreApplication>
 #include <QDir>
 #include <QDebug>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
+#include <termios.h>
+#include <unistd.h>
 
 void printUsage(const char *progName)
 {
     std::cout << "Usage: " << progName << " [options] <repository-path>\n"
+              << "       " << progName << " useradd <name>\n"
+              << "       " << progName << " passwd <name>\n"
+              << "       " << progName << " userdel <name>\n"
+              << "       " << progName << " usermod <name> [--repos R1,R2,..|all]\n"
+              << "       " << progName << " userlist\n"
               << "\n"
               << "Options:\n"
               << "  -p, --port <port>    Port to listen on (default: 8080)\n"
@@ -47,7 +57,152 @@ void printUsage(const char *progName)
               << "\n"
               << "Example:\n"
               << "  " << progName << " -p 9000 /home/user/Documents\n"
+              << "  " << progName << " useradd alice\n"
               << std::endl;
+}
+
+
+/* Read a line from stdin with terminal echo disabled (interactive
+ * password entry).  Returns the line without the trailing newline.
+ * Empty on EOF. */
+static QString readPasswordHidden(const QString &prompt)
+{
+    std::cout << prompt.toStdString() << std::flush;
+
+    termios oldt;
+    bool echoToggled = false;
+    if (isatty(fileno(stdin)) && tcgetattr(fileno(stdin), &oldt) == 0) {
+        termios newt = oldt;
+        newt.c_lflag &= ~(tcflag_t)ECHO;
+        if (tcsetattr(fileno(stdin), TCSANOW, &newt) == 0)
+            echoToggled = true;
+    }
+
+    char buf[256];
+    QString line;
+    if (fgets(buf, sizeof(buf), stdin)) {
+        line = QString::fromLocal8Bit(buf);
+        if (line.endsWith('\n'))
+            line.chop(1);
+    }
+
+    if (echoToggled) {
+        tcsetattr(fileno(stdin), TCSANOW, &oldt);
+        std::cout << "\n";
+    }
+    return line;
+}
+
+
+/* Prompt twice and confirm.  Empty input or mismatch aborts. */
+static bool promptNewPassword(QString &out)
+{
+    QString first = readPasswordHidden("New password: ");
+    if (first.isEmpty()) {
+        std::cerr << "Aborted: empty password\n";
+        return false;
+    }
+    QString second = readPasswordHidden("Confirm password: ");
+    if (first != second) {
+        std::cerr << "Aborted: passwords do not match\n";
+        return false;
+    }
+    out = first;
+    return true;
+}
+
+
+static int cmdUserAdd(const QString &name)
+{
+    UserStore store;
+    if (store.hasUser(name)) {
+        std::cerr << "User '" << name.toStdString() << "' already exists\n";
+        return 1;
+    }
+    QString password;
+    if (!promptNewPassword(password))
+        return 1;
+    if (!store.addUser(name, password)) {
+        std::cerr << "Failed to add user\n";
+        return 1;
+    }
+    std::cout << "Added user '" << name.toStdString() << "' to "
+              << store.filePath().toStdString() << "\n";
+    return 0;
+}
+
+
+static int cmdPasswd(const QString &name)
+{
+    UserStore store;
+    if (!store.hasUser(name)) {
+        std::cerr << "User '" << name.toStdString() << "' not found\n";
+        return 1;
+    }
+    QString password;
+    if (!promptNewPassword(password))
+        return 1;
+    if (!store.setPassword(name, password)) {
+        std::cerr << "Failed to set password\n";
+        return 1;
+    }
+    std::cout << "Password updated for '" << name.toStdString() << "'\n";
+    return 0;
+}
+
+
+static int cmdUserDel(const QString &name)
+{
+    UserStore store;
+    if (!store.delUser(name)) {
+        std::cerr << "User '" << name.toStdString() << "' not found\n";
+        return 1;
+    }
+    std::cout << "Removed user '" << name.toStdString() << "'\n";
+    return 0;
+}
+
+
+static int cmdUserList()
+{
+    UserStore store;
+    for (const QString &name : store.userNames()) {
+        const UserStore::User *u = store.lookup(name);
+        QString repos = u->repos.isEmpty()
+                            ? QStringLiteral("(all)")
+                            : u->repos.join(',');
+        std::cout << name.toStdString() << "\trepos="
+                  << repos.toStdString() << "\n";
+    }
+    return 0;
+}
+
+
+static int cmdUserMod(const QString &name, const QStringList &extraArgs)
+{
+    UserStore store;
+    if (!store.hasUser(name)) {
+        std::cerr << "User '" << name.toStdString() << "' not found\n";
+        return 1;
+    }
+    for (int i = 0; i < extraArgs.size(); i++) {
+        if (extraArgs[i] == "--repos" && i + 1 < extraArgs.size()) {
+            QString value = extraArgs[++i];
+            QStringList repos;
+            if (value != "all")
+                repos = value.split(',', Qt::SkipEmptyParts);
+            if (!store.setRepos(name, repos)) {
+                std::cerr << "Failed to update repos\n";
+                return 1;
+            }
+        } else {
+            std::cerr << "Unknown usermod option: "
+                      << extraArgs[i].toStdString() << "\n";
+            return 1;
+        }
+    }
+    std::cout << "Updated user '" << name.toStdString() << "'\n";
+    return 0;
 }
 
 int main(int argc, char *argv[])
@@ -56,6 +211,28 @@ int main(int argc, char *argv[])
 
     // Parse command line arguments
     QStringList args = app.arguments();
+
+    // User-management subcommands run and exit without starting the
+    // server.  They accept no port/repository options.
+    if (args.size() >= 2) {
+        QString sub = args[1];
+        if (sub == "useradd" || sub == "passwd" || sub == "userdel"
+            || sub == "usermod" || sub == "userlist") {
+            if (sub == "userlist")
+                return cmdUserList();
+            if (args.size() < 3) {
+                std::cerr << "Error: " << sub.toStdString()
+                          << " requires a username\n";
+                return 1;
+            }
+            QString name = args[2];
+            if (sub == "useradd")  return cmdUserAdd(name);
+            if (sub == "passwd")   return cmdPasswd(name);
+            if (sub == "userdel")  return cmdUserDel(name);
+            if (sub == "usermod")  return cmdUserMod(name, args.mid(3));
+        }
+    }
+
     QString repositoryPath;
     quint16 port = 8080;
     bool skipCache = false;

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -29,6 +29,7 @@ INCLUDEPATH += /usr/include/podofo
 
 HEADERS += builddate.h \
     backend.h \
+    cachedfile.h \
     localbackend.h \
     searchserver.h \
     serverlog.h \

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -28,6 +28,8 @@ LIBS += -lpodofo -ltiff -ljpeg -lz
 INCLUDEPATH += /usr/include/podofo
 
 HEADERS += builddate.h \
+    backend.h \
+    localbackend.h \
     searchserver.h \
     serverlog.h \
     tokenstore.h \
@@ -48,6 +50,7 @@ HEADERS += builddate.h \
     config.h
 
 SOURCES += searchserver.cpp \
+    localbackend.cpp \
     serverlog.cpp \
     tokenstore.cpp \
     userstore.cpp \

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -30,6 +30,8 @@ INCLUDEPATH += /usr/include/podofo
 HEADERS += builddate.h \
     searchserver.h \
     serverlog.h \
+    tokenstore.h \
+    userstore.h \
     file.h \
     filemax.h \
     filejpeg.h \
@@ -47,6 +49,8 @@ HEADERS += builddate.h \
 
 SOURCES += searchserver.cpp \
     serverlog.cpp \
+    tokenstore.cpp \
+    userstore.cpp \
     paperman-server.cpp \
     file.cpp \
     filemax.cpp \

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -51,6 +51,7 @@ HEADERS += builddate.h \
     config.h
 
 SOURCES += searchserver.cpp \
+    backend.cpp \
     localbackend.cpp \
     serverlog.cpp \
     tokenstore.cpp \

--- a/paperman.pro
+++ b/paperman.pro
@@ -246,6 +246,7 @@ test {
       test/suite.cpp \
       test/test_dirmodel.cpp \
       test/test_dirview.cpp \
+      test/test_file.cpp \
       test/test_ops.cpp \
       test/test_pageinfo.cpp \
       test/test_qscanner.cpp \
@@ -263,6 +264,7 @@ test {
    HEADERS += test/suite.h \
       test/test_dirmodel.h \
       test/test_dirview.h \
+      test/test_file.h \
       test/test_ops.h \
       test/test_pageinfo.h \
       test/test_qscanner.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -252,7 +252,9 @@ test {
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
       searchserver.cpp \
-      serverlog.cpp
+      serverlog.cpp \
+      tokenstore.cpp \
+      userstore.cpp
 
    HEADERS += test/suite.h \
       test/test_dirmodel.h \
@@ -264,7 +266,9 @@ test {
       test/test_searchserver.h \
       test/test_ocrsearch.h \
       searchserver.h \
-      serverlog.h
+      serverlog.h \
+      tokenstore.h \
+      userstore.h
 
     QMAKE_CXXFLAGS += -DENABLE_TEST
     QT += network

--- a/paperman.pro
+++ b/paperman.pro
@@ -253,6 +253,7 @@ test {
       test/test_ocrsearch.cpp \
       searchserver.cpp \
       backend.cpp \
+      backendstats.cpp \
       localbackend.cpp \
       remotebackend.cpp \
       serverlog.cpp \
@@ -269,6 +270,7 @@ test {
       test/test_searchserver.h \
       test/test_ocrsearch.h \
       backend.h \
+      backendstats.h \
       cachedfile.h \
       localbackend.h \
       remotebackend.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -252,6 +252,7 @@ test {
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
       searchserver.cpp \
+      backend.cpp \
       localbackend.cpp \
       remotebackend.cpp \
       serverlog.cpp \

--- a/paperman.pro
+++ b/paperman.pro
@@ -244,6 +244,7 @@ test {
    SOURCES += test/test_utils.cpp \
       test/test.cpp \
       test/suite.cpp \
+      test/test_desktopui.cpp \
       test/test_dirmodel.cpp \
       test/test_dirview.cpp \
       test/test_file.cpp \
@@ -262,6 +263,7 @@ test {
       userstore.cpp
 
    HEADERS += test/suite.h \
+      test/test_desktopui.h \
       test/test_dirmodel.h \
       test/test_dirview.h \
       test/test_file.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -268,6 +268,7 @@ test {
       test/test_searchserver.h \
       test/test_ocrsearch.h \
       backend.h \
+      cachedfile.h \
       localbackend.h \
       remotebackend.h \
       searchserver.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -252,6 +252,7 @@ test {
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
       searchserver.cpp \
+      localbackend.cpp \
       serverlog.cpp \
       tokenstore.cpp \
       userstore.cpp
@@ -265,6 +266,8 @@ test {
       test/test_utils.h \
       test/test_searchserver.h \
       test/test_ocrsearch.h \
+      backend.h \
+      localbackend.h \
       searchserver.h \
       serverlog.h \
       tokenstore.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -2,6 +2,7 @@ TEMPLATE = app
 LANGUAGE = C++
 QT += widgets
 QT += printsupport
+QT += network
 QT += testlib
 QT += sql
 QT += concurrent
@@ -136,7 +137,12 @@ HEADERS += desktopwidget.h \
  transfer.h \
     filejpeg.h \
     qlistwidgetitemiterator.h \
-    searchindex.h
+    searchindex.h \
+    backend.h \
+    backendstats.h \
+    cachedfile.h \
+    localbackend.h \
+    remotebackend.h
 
 SOURCES += desktopwidget.cpp \
    folderlist.cpp \
@@ -222,7 +228,11 @@ SOURCES += desktopwidget.cpp \
  transfer.cpp \
     filejpeg.cpp \
     qlistwidgetitemiterator.cpp \
-    searchindex.cpp 
+    searchindex.cpp \
+    backend.cpp \
+    backendstats.cpp \
+    localbackend.cpp \
+    remotebackend.cpp
 
 # add qtcreator debug macros if we are debugging
 #SOURCES += /usr/share/qtcreator/gdbmacros/gdbmacros.cpp
@@ -255,10 +265,6 @@ test {
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
       searchserver.cpp \
-      backend.cpp \
-      backendstats.cpp \
-      localbackend.cpp \
-      remotebackend.cpp \
       serverlog.cpp \
       tokenstore.cpp \
       userstore.cpp
@@ -275,18 +281,12 @@ test {
       test/test_utils.h \
       test/test_searchserver.h \
       test/test_ocrsearch.h \
-      backend.h \
-      backendstats.h \
-      cachedfile.h \
-      localbackend.h \
-      remotebackend.h \
       searchserver.h \
       serverlog.h \
       tokenstore.h \
       userstore.h
 
     QMAKE_CXXFLAGS += -DENABLE_TEST
-    QT += network
     QT += concurrent
 }
 

--- a/paperman.pro
+++ b/paperman.pro
@@ -253,6 +253,7 @@ test {
       test/test_ocrsearch.cpp \
       searchserver.cpp \
       localbackend.cpp \
+      remotebackend.cpp \
       serverlog.cpp \
       tokenstore.cpp \
       userstore.cpp
@@ -268,6 +269,7 @@ test {
       test/test_ocrsearch.h \
       backend.h \
       localbackend.h \
+      remotebackend.h \
       searchserver.h \
       serverlog.h \
       tokenstore.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -250,6 +250,7 @@ test {
       test/test_file.cpp \
       test/test_ops.cpp \
       test/test_pageinfo.cpp \
+      test/test_pagewidget.cpp \
       test/test_qscanner.cpp \
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
@@ -269,6 +270,7 @@ test {
       test/test_file.h \
       test/test_ops.h \
       test/test_pageinfo.h \
+      test/test_pagewidget.h \
       test/test_qscanner.h \
       test/test_utils.h \
       test/test_searchserver.h \

--- a/qi/qscrollbaroption.cpp
+++ b/qi/qscrollbaroption.cpp
@@ -82,7 +82,12 @@ void QScrollBarOption::setRange(int min,int max,int quant)
   mQuant = quant;
   mMinVal = min;
   mMaxVal = max;
-//  mpValueSlider->blockSignals(true);
+  /* Block the slider's signals while the range is reconfigured.
+     Changing the range can clamp the slider position, and the resulting
+     valueChanged() signals would push the clamped raw position to the
+     scanner as if the user had moved the slider. The caller follows up
+     with setValue() to restore the correct position */
+  mpValueSlider->blockSignals(true);
 	if(mSaneValueType == SANE_TYPE_FIXED)
   {
     mMinVal = int(SANE_UNFIX(min) * 100.0);
@@ -99,6 +104,7 @@ void QScrollBarOption::setRange(int min,int max,int quant)
     mpValueSlider->setPageStep(10);
     mHasQuant = true;
   }
+  mpValueSlider->blockSignals(false);
   if(mSaneValueType == SANE_TYPE_FIXED)
   {
     switch(mMetricSystem)

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -4,6 +4,8 @@ License: GPL-2
 
 #include "remotebackend.h"
 
+#include "backendstats.h"
+
 #include <QEventLoop>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -283,7 +285,21 @@ QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery)
    req.setTransferTimeout(kRequestTimeoutMs);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
-   return _nam->get(req);
+
+   QNetworkReply *reply = _nam->get(req);
+
+   if (_stats) {
+      /* Approximate the request size by the URL bytes.  Headers
+       * are uncounted; tolerable for a user-facing tally. */
+      _stats->requestStarted();
+      _stats->recordSent(pathAndQuery.toUtf8().size());
+      QObject::connect(reply, &QNetworkReply::finished, _stats,
+          [this, reply]() {
+             _stats->recordReceived(reply->bytesAvailable());
+             _stats->requestFinished();
+          });
+   }
+   return reply;
 }
 
 
@@ -303,7 +319,18 @@ QByteArray RemoteBackend::postRequest(const QString &path,
    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
-   return waitForReply(_nam->post(req, body));
+
+   QNetworkReply *reply = _nam->post(req, body);
+   if (_stats) {
+      _stats->requestStarted();
+      _stats->recordSent(path.toUtf8().size() + body.size());
+      QObject::connect(reply, &QNetworkReply::finished, _stats,
+          [this, reply]() {
+             _stats->recordReceived(reply->bytesAvailable());
+             _stats->requestFinished();
+          });
+   }
+   return waitForReply(reply);
 }
 
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -220,6 +220,55 @@ FileFetch RemoteBackend::readFile(const QString &repo, const QString &path)
 static const int kRequestTimeoutMs = 5000;
 
 
+/* Build the "/thumbnail?repo=...&path=...&page=N&size=..." path. */
+static QString thumbnailPathFor(const QString &repo, const QString &path,
+                                int page, const QString &size)
+{
+   QUrlQuery q;
+   q.addQueryItem("repo", repo);
+   q.addQueryItem("path", path);
+   q.addQueryItem("page", QString::number(page));
+   q.addQueryItem("size", size);
+   return "/thumbnail?" + q.toString();
+}
+
+
+QByteArray RemoteBackend::fetchThumbnail(const QString &repo,
+                                         const QString &path,
+                                         int page, const QString &size)
+{
+   return getRequest(thumbnailPathFor(repo, path, page, size));
+}
+
+
+quint64 RemoteBackend::fetchThumbnailAsync(const QString &repo,
+                                           const QString &path,
+                                           int page, const QString &size)
+{
+   quint64 token = _nextAsyncToken++;
+   QNetworkReply *reply = startGet(thumbnailPathFor(repo, path, page, size));
+   QObject::connect(reply, &QNetworkReply::finished, this,
+       [this, reply, token]() {
+          _lastError.clear();
+          QByteArray body = reply->readAll();
+          if (reply->error() != QNetworkReply::NoError) {
+             _lastError = reply->errorString();
+             body.clear();
+          } else {
+             int status = reply->attribute(
+                              QNetworkRequest::HttpStatusCodeAttribute).toInt();
+             if (status >= 400) {
+                _lastError = QString("HTTP %1").arg(status);
+                body.clear();
+             }
+          }
+          reply->deleteLater();
+          emit thumbnailReady(token, body);
+       });
+   return token;
+}
+
+
 QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery)
 {
    QUrl url(_baseUrl);

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -56,6 +56,20 @@ bool RemoteBackend::login(const QString &user, const QString &password)
 }
 
 
+QString RemoteBackend::serverId()
+{
+   if (!_serverId.isEmpty())
+      return _serverId;
+
+   QByteArray body = getRequest("/v1/status");
+   QJsonDocument doc = QJsonDocument::fromJson(body);
+   if (!doc.isObject())
+      return QString();
+   _serverId = doc.object().value("serverId").toString();
+   return _serverId;
+}
+
+
 QList<RepositoryInfo> RemoteBackend::listRepositories()
 {
    QList<RepositoryInfo> out;

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -14,17 +14,15 @@ License: GPL-2
 #include <QUrlQuery>
 
 
-RemoteBackend::RemoteBackend(const QUrl &baseUrl)
-   : _baseUrl(baseUrl)
-   , _nam(new QNetworkAccessManager)
+RemoteBackend::RemoteBackend(const QUrl &baseUrl, QObject *parent)
+   : QObject(parent)
+   , _baseUrl(baseUrl)
+   , _nam(new QNetworkAccessManager(this))
 {
 }
 
 
-RemoteBackend::~RemoteBackend()
-{
-   delete _nam;
-}
+RemoteBackend::~RemoteBackend() = default;
 
 
 bool RemoteBackend::login(const QString &user, const QString &password)
@@ -92,19 +90,64 @@ QList<RepositoryInfo> RemoteBackend::listRepositories()
 }
 
 
-DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
-                                                const QString &dir)
+/* Build the "/browse?repo=...&path=..." path-with-query string. */
+static QString browsePathFor(const QString &repo, const QString &dir)
 {
-   DirectoryListing out;
-
-   /* URL-encode parameters via QUrlQuery so repo names with funky
-    * characters don't break the request. */
    QUrlQuery q;
    q.addQueryItem("repo", repo);
    q.addQueryItem("path", dir);
-   QString pq = "/browse?" + q.toString();
+   return "/browse?" + q.toString();
+}
 
-   QByteArray body = getRequest(pq);
+
+DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
+                                                const QString &dir)
+{
+   QNetworkReply *reply = startGet(browsePathFor(repo, dir));
+
+   /* Spin the local event loop until the reply finishes (sync),
+    * then hand the still-live reply to the shared parser before
+    * scheduling its deletion. */
+   QEventLoop loop;
+   QObject::connect(reply, &QNetworkReply::finished,
+                    &loop, &QEventLoop::quit);
+   loop.exec();
+
+   DirectoryListing out = parseBrowseReply(reply);
+   reply->deleteLater();
+   return out;
+}
+
+
+quint64 RemoteBackend::browseDirectoryAsync(const QString &repo,
+                                            const QString &dir)
+{
+   quint64 token = _nextAsyncToken++;
+   QNetworkReply *reply = startGet(browsePathFor(repo, dir));
+   QObject::connect(reply, &QNetworkReply::finished, this,
+       [this, reply, token]() {
+          DirectoryListing listing = parseBrowseReply(reply);
+          reply->deleteLater();
+          emit browseDirectoryReady(token, listing);
+       });
+   return token;
+}
+
+
+DirectoryListing RemoteBackend::parseBrowseReply(QNetworkReply *reply)
+{
+   DirectoryListing out;
+   _lastError.clear();
+
+   QByteArray body = reply->readAll();
+   if (reply->error() != QNetworkReply::NoError) {
+      _lastError = reply->errorString();
+   } else {
+      int status = reply->attribute(
+                       QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      if (status >= 400)
+         _lastError = QString("HTTP %1").arg(status);
+   }
    if (!_lastError.isEmpty()) {
       out.error    = _lastError;
       out.notFound = _lastError.contains("404");
@@ -177,7 +220,7 @@ FileFetch RemoteBackend::readFile(const QString &repo, const QString &path)
 static const int kRequestTimeoutMs = 5000;
 
 
-QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
+QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery)
 {
    QUrl url(_baseUrl);
    int q = pathAndQuery.indexOf('?');
@@ -191,7 +234,13 @@ QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
    req.setTransferTimeout(kRequestTimeoutMs);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
-   return waitForReply(_nam->get(req));
+   return _nam->get(req);
+}
+
+
+QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
+{
+   return waitForReply(startGet(pathAndQuery));
 }
 
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -105,9 +105,17 @@ DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
    QString pq = "/browse?" + q.toString();
 
    QByteArray body = getRequest(pq);
-   QJsonDocument doc = QJsonDocument::fromJson(body);
-   if (!doc.isObject())
+   if (!_lastError.isEmpty()) {
+      out.error    = _lastError;
+      out.notFound = _lastError.contains("404");
       return out;
+   }
+
+   QJsonDocument doc = QJsonDocument::fromJson(body);
+   if (!doc.isObject()) {
+      out.error = "malformed response";
+      return out;
+   }
    QJsonObject obj = doc.object();
 
    /* Subdirectories first, matching the on-screen ordering the GUI
@@ -118,6 +126,7 @@ DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
       e.name  = d.value("name").toString();
       e.path  = d.value("path").toString();
       e.isDir = true;
+      e.count = d.value("count").toInt();
       out.entries.append(e);
    }
    for (const QJsonValue &v : obj.value("files").toArray()) {
@@ -129,6 +138,7 @@ DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
       e.modified = f.value("modified").toString();
       out.entries.append(e);
    }
+   out.ok = true;
    return out;
 }
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -143,6 +143,32 @@ DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
 }
 
 
+FileFetch RemoteBackend::readFile(const QString &repo, const QString &path)
+{
+   FileFetch out;
+
+   QUrlQuery q;
+   q.addQueryItem("repo", repo);
+   q.addQueryItem("path", path);
+   QString pq = "/file?" + q.toString();
+
+   QByteArray body = getRequest(pq);
+   if (!_lastError.isEmpty()) {
+      out.error    = _lastError;
+      out.notFound = _lastError.contains("404");
+      return out;
+   }
+
+   /* The server already sent a Content-Type header; we don't surface
+    * headers from getRequest() so derive it the same way the server
+    * did, from the path extension. */
+   out.bytes       = body;
+   out.contentType = Backend::contentTypeForPath(path);
+   out.ok          = true;
+   return out;
+}
+
+
 QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
 {
    QUrl url(_baseUrl);

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -169,6 +169,14 @@ FileFetch RemoteBackend::readFile(const QString &repo, const QString &path)
 }
 
 
+/* Default transfer timeout for every request.  Qt's own default is
+ * effectively unlimited, which means the GUI would freeze for tens of
+ * seconds if the server went away.  Five seconds is long enough for
+ * any honest LAN round-trip and short enough that a dead server
+ * surfaces quickly. */
+static const int kRequestTimeoutMs = 5000;
+
+
 QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
 {
    QUrl url(_baseUrl);
@@ -180,6 +188,7 @@ QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
       url.setQuery(pathAndQuery.mid(q + 1));
    }
    QNetworkRequest req(url);
+   req.setTransferTimeout(kRequestTimeoutMs);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
    return waitForReply(_nam->get(req));
@@ -192,6 +201,7 @@ QByteArray RemoteBackend::postRequest(const QString &path,
    QUrl url(_baseUrl);
    url.setPath(path);
    QNetworkRequest req(url);
+   req.setTransferTimeout(kRequestTimeoutMs);
    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -1,0 +1,172 @@
+/*
+License: GPL-2
+*/
+
+#include "remotebackend.h"
+
+#include <QEventLoop>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrlQuery>
+
+
+RemoteBackend::RemoteBackend(const QUrl &baseUrl)
+   : _baseUrl(baseUrl)
+   , _nam(new QNetworkAccessManager)
+{
+}
+
+
+RemoteBackend::~RemoteBackend()
+{
+   delete _nam;
+}
+
+
+bool RemoteBackend::login(const QString &user, const QString &password)
+{
+   QJsonObject body;
+   body["user"]     = user;
+   body["password"] = password;
+   QByteArray data = QJsonDocument(body).toJson(QJsonDocument::Compact);
+
+   QByteArray resp = postRequest("/v1/auth/login", data);
+   if (resp.isEmpty()) {
+      if (_lastError.isEmpty())
+         _lastError = "empty response from /v1/auth/login";
+      return false;
+   }
+
+   QJsonDocument doc = QJsonDocument::fromJson(resp);
+   if (!doc.isObject()) {
+      _lastError = "login response is not a JSON object";
+      return false;
+   }
+   QString token = doc.object().value("token").toString();
+   if (token.isEmpty()) {
+      _lastError = "login response missing token";
+      return false;
+   }
+   _token = token;
+   return true;
+}
+
+
+QList<RepositoryInfo> RemoteBackend::listRepositories()
+{
+   QList<RepositoryInfo> out;
+
+   QByteArray body = getRequest("/repos");
+   QJsonDocument doc = QJsonDocument::fromJson(body);
+   if (!doc.isObject())
+      return out;
+
+   QJsonArray arr = doc.object().value("repositories").toArray();
+   for (const QJsonValue &v : arr) {
+      QJsonObject o = v.toObject();
+      RepositoryInfo r;
+      r.name   = o.value("name").toString();
+      r.path   = o.value("path").toString();
+      r.exists = o.value("exists").toBool();
+      out.append(r);
+   }
+   return out;
+}
+
+
+DirectoryListing RemoteBackend::browseDirectory(const QString &repo,
+                                                const QString &dir)
+{
+   DirectoryListing out;
+
+   /* URL-encode parameters via QUrlQuery so repo names with funky
+    * characters don't break the request. */
+   QUrlQuery q;
+   q.addQueryItem("repo", repo);
+   q.addQueryItem("path", dir);
+   QString pq = "/browse?" + q.toString();
+
+   QByteArray body = getRequest(pq);
+   QJsonDocument doc = QJsonDocument::fromJson(body);
+   if (!doc.isObject())
+      return out;
+   QJsonObject obj = doc.object();
+
+   /* Subdirectories first, matching the on-screen ordering the GUI
+    * uses today. */
+   for (const QJsonValue &v : obj.value("directories").toArray()) {
+      QJsonObject d = v.toObject();
+      DirectoryEntry e;
+      e.name  = d.value("name").toString();
+      e.path  = d.value("path").toString();
+      e.isDir = true;
+      out.entries.append(e);
+   }
+   for (const QJsonValue &v : obj.value("files").toArray()) {
+      QJsonObject f = v.toObject();
+      DirectoryEntry e;
+      e.name     = f.value("name").toString();
+      e.path     = f.value("path").toString();
+      e.size     = f.value("size").toVariant().toLongLong();
+      e.modified = f.value("modified").toString();
+      out.entries.append(e);
+   }
+   return out;
+}
+
+
+QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
+{
+   QUrl url(_baseUrl);
+   int q = pathAndQuery.indexOf('?');
+   if (q < 0) {
+      url.setPath(pathAndQuery);
+   } else {
+      url.setPath(pathAndQuery.left(q));
+      url.setQuery(pathAndQuery.mid(q + 1));
+   }
+   QNetworkRequest req(url);
+   if (!_token.isEmpty())
+      req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
+   return waitForReply(_nam->get(req));
+}
+
+
+QByteArray RemoteBackend::postRequest(const QString &path,
+                                      const QByteArray &body)
+{
+   QUrl url(_baseUrl);
+   url.setPath(path);
+   QNetworkRequest req(url);
+   req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+   if (!_token.isEmpty())
+      req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
+   return waitForReply(_nam->post(req, body));
+}
+
+
+QByteArray RemoteBackend::waitForReply(QNetworkReply *reply)
+{
+   _lastError.clear();
+
+   QEventLoop loop;
+   QObject::connect(reply, &QNetworkReply::finished,
+                    &loop, &QEventLoop::quit);
+   loop.exec();
+
+   QByteArray data = reply->readAll();
+   if (reply->error() != QNetworkReply::NoError) {
+      _lastError = reply->errorString();
+   } else {
+      int status = reply->attribute(
+                       QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      if (status >= 400)
+         _lastError = QString("HTTP %1").arg(status);
+   }
+   reply->deleteLater();
+   return data;
+}

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -75,9 +75,26 @@ public:
      *  tokens to its own state (e.g. the DirNode being expanded). */
     quint64 browseDirectoryAsync(const QString &repo, const QString &dir);
 
+    /** Fetch a thumbnail (JPEG bytes) for a single page of a file.
+     *  @p size is "small", "medium", or "large" (matches the server's
+     *  /thumbnail vocabulary).  Sync: blocks until the server
+     *  responds.  Returns empty QByteArray on failure (lastError set). */
+    QByteArray fetchThumbnail(const QString &repo, const QString &path,
+                              int page = 1,
+                              const QString &size = QStringLiteral("medium"));
+
+    /** Async counterpart to fetchThumbnail.  Returns a token; emits
+     *  thumbnailReady(token, bytes) when the reply arrives.  Empty
+     *  bytes mean the request failed. */
+    quint64 fetchThumbnailAsync(const QString &repo, const QString &path,
+                                int page = 1,
+                                const QString &size
+                                    = QStringLiteral("medium"));
+
 signals:
     void browseDirectoryReady(quint64 token,
                               const DirectoryListing &listing);
+    void thumbnailReady(quint64 token, const QByteArray &jpegBytes);
 
 private:
     QByteArray getRequest(const QString &pathAndQuery);

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -57,6 +57,8 @@ public:
     QList<RepositoryInfo> listRepositories() override;
     DirectoryListing browseDirectory(const QString &repo,
                                      const QString &dir) override;
+    FileFetch readFile(const QString &repo,
+                       const QString &path) override;
 
 private:
     QByteArray getRequest(const QString &pathAndQuery);

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -51,6 +51,10 @@ public:
 
     bool isAuthenticated() const { return !_token.isEmpty(); }
 
+    /** Attach a BackendStats object for activity reporting.  Optional;
+     *  if unset the backend doesn't report anywhere.  Non-owning. */
+    void setStats(class BackendStats *stats) { _stats = stats; }
+
     /** Inject a token directly (e.g. one loaded from a config file). */
     void setBearerToken(const QString &token) { _token = token; }
 
@@ -116,6 +120,7 @@ private:
     QString _serverId;
     QString _lastError;
     QNetworkAccessManager *_nam;
+    class BackendStats *_stats = nullptr;
     quint64 _nextAsyncToken = 1;
 };
 

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -1,0 +1,83 @@
+/*
+License: GPL-2
+*/
+
+#ifndef REMOTEBACKEND_H
+#define REMOTEBACKEND_H
+
+#include "backend.h"
+
+#include <QString>
+#include <QUrl>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+
+/** A single entry in a directory listing: either a file or a
+ *  subdirectory.  Mirrors the JSON shape /browse returns. */
+struct DirectoryEntry
+{
+    QString name;
+    QString path;        //!< Repo-relative path
+    qint64 size = 0;     //!< 0 for directories
+    bool isDir = false;
+    QString modified;    //!< ISO-8601 (files only)
+};
+
+struct DirectoryListing
+{
+    QList<DirectoryEntry> entries;
+};
+
+
+/**
+ * Backend that talks to a paperman-server over HTTP.  Symmetric with
+ * LocalBackend but the data comes from the network instead of the
+ * local filesystem, so the GUI can transparently use either one.
+ *
+ * Calls are synchronous: each method spins a nested QEventLoop until
+ * the QNetworkReply finishes.  That matches the existing GUI's
+ * blocking call style and keeps tests straightforward; an async
+ * variant can come later.
+ *
+ * RemoteBackend manages a bearer token internally: after a successful
+ * login() the token is attached as `Authorization: Bearer ...` to all
+ * subsequent requests.
+ */
+class RemoteBackend : public Backend
+{
+public:
+    explicit RemoteBackend(const QUrl &baseUrl);
+    ~RemoteBackend() override;
+
+    /** Exchange credentials for a bearer token.  Returns true on
+     *  success; on failure, lastError() carries detail. */
+    bool login(const QString &user, const QString &password);
+
+    bool isAuthenticated() const { return !_token.isEmpty(); }
+
+    /** Last network or server-side error, if any. */
+    QString lastError() const { return _lastError; }
+
+    // Backend
+    QList<RepositoryInfo> listRepositories() override;
+
+    /** List the contents of `dir` (relative to the named repository).
+     *  Empty `dir` lists the repo root.  Directories come first in the
+     *  returned list. */
+    DirectoryListing browseDirectory(const QString &repo,
+                                     const QString &dir);
+
+private:
+    QByteArray getRequest(const QString &pathAndQuery);
+    QByteArray postRequest(const QString &path, const QByteArray &body);
+    QByteArray waitForReply(QNetworkReply *reply);
+
+    QUrl _baseUrl;
+    QString _token;
+    QString _lastError;
+    QNetworkAccessManager *_nam;
+};
+
+#endif // REMOTEBACKEND_H

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -55,7 +55,17 @@ public:
      *  success; on failure, lastError() carries detail. */
     bool login(const QString &user, const QString &password);
 
+    /** Fetch /v1/status and return the server's stable UUID.  Empty
+     *  string on failure (lastError() set).  Result is cached. */
+    QString serverId();
+
     bool isAuthenticated() const { return !_token.isEmpty(); }
+
+    /** Inject a token directly (e.g. one loaded from a config file). */
+    void setBearerToken(const QString &token) { _token = token; }
+
+    /** The bearer token currently in use (empty if not authenticated). */
+    QString bearerToken() const { return _token; }
 
     /** Last network or server-side error, if any. */
     QString lastError() const { return _lastError; }
@@ -76,6 +86,7 @@ private:
 
     QUrl _baseUrl;
     QString _token;
+    QString _serverId;
     QString _lastError;
     QNetworkAccessManager *_nam;
 };

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -7,6 +7,7 @@ License: GPL-2
 
 #include "backend.h"
 
+#include <QObject>
 #include <QString>
 #include <QUrl>
 
@@ -19,19 +20,25 @@ class QNetworkReply;
  * LocalBackend but the data comes from the network instead of the
  * local filesystem, so the GUI can transparently use either one.
  *
- * Calls are synchronous: each method spins a nested QEventLoop until
- * the QNetworkReply finishes.  That matches the existing GUI's
- * blocking call style and keeps tests straightforward; an async
- * variant can come later.
+ * Two call styles:
+ *  - The sync methods (listRepositories, browseDirectory, readFile,
+ *    login) spin a nested QEventLoop until the reply arrives; that
+ *    matches the existing GUI's blocking call style and keeps tests
+ *    straightforward.
+ *  - browseDirectoryAsync returns a token and emits
+ *    browseDirectoryReady when the server responds, so the UI
+ *    thread isn't blocked on each folder expansion.  Other endpoints
+ *    will grow async variants as call sites demand them.
  *
  * RemoteBackend manages a bearer token internally: after a successful
  * login() the token is attached as `Authorization: Bearer ...` to all
  * subsequent requests.
  */
-class RemoteBackend : public Backend
+class RemoteBackend : public QObject, public Backend
 {
+    Q_OBJECT
 public:
-    explicit RemoteBackend(const QUrl &baseUrl);
+    explicit RemoteBackend(const QUrl &baseUrl, QObject *parent = nullptr);
     ~RemoteBackend() override;
 
     /** Exchange credentials for a bearer token.  Returns true on
@@ -60,16 +67,39 @@ public:
     FileFetch readFile(const QString &repo,
                        const QString &path) override;
 
+    /** Asynchronous version of browseDirectory.  Returns a
+     *  monotonically-increasing token that identifies the request;
+     *  when the server responds (or the request fails/times out) the
+     *  browseDirectoryReady() signal is emitted with the same token
+     *  and the parsed DirectoryListing.  The caller can correlate
+     *  tokens to its own state (e.g. the DirNode being expanded). */
+    quint64 browseDirectoryAsync(const QString &repo, const QString &dir);
+
+signals:
+    void browseDirectoryReady(quint64 token,
+                              const DirectoryListing &listing);
+
 private:
     QByteArray getRequest(const QString &pathAndQuery);
     QByteArray postRequest(const QString &path, const QByteArray &body);
     QByteArray waitForReply(QNetworkReply *reply);
+
+    /** Construct an async GET against pathAndQuery.  Caller takes
+     *  responsibility for the returned reply's signals; reply will
+     *  call deleteLater on itself once consumed. */
+    QNetworkReply *startGet(const QString &pathAndQuery);
+
+    /** Translate a /browse reply (body bytes + reply error state)
+     *  into a typed DirectoryListing.  Shared by sync and async
+     *  paths. */
+    DirectoryListing parseBrowseReply(QNetworkReply *reply);
 
     QUrl _baseUrl;
     QString _token;
     QString _serverId;
     QString _lastError;
     QNetworkAccessManager *_nam;
+    quint64 _nextAsyncToken = 1;
 };
 
 #endif // REMOTEBACKEND_H

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -14,23 +14,6 @@ class QNetworkAccessManager;
 class QNetworkReply;
 
 
-/** A single entry in a directory listing: either a file or a
- *  subdirectory.  Mirrors the JSON shape /browse returns. */
-struct DirectoryEntry
-{
-    QString name;
-    QString path;        //!< Repo-relative path
-    qint64 size = 0;     //!< 0 for directories
-    bool isDir = false;
-    QString modified;    //!< ISO-8601 (files only)
-};
-
-struct DirectoryListing
-{
-    QList<DirectoryEntry> entries;
-};
-
-
 /**
  * Backend that talks to a paperman-server over HTTP.  Symmetric with
  * LocalBackend but the data comes from the network instead of the
@@ -72,12 +55,8 @@ public:
 
     // Backend
     QList<RepositoryInfo> listRepositories() override;
-
-    /** List the contents of `dir` (relative to the named repository).
-     *  Empty `dir` lists the repo root.  Directories come first in the
-     *  returned list. */
     DirectoryListing browseDirectory(const QString &repo,
-                                     const QString &dir);
+                                     const QString &dir) override;
 
 private:
     QByteArray getRequest(const QString &pathAndQuery);

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -268,7 +268,43 @@ void SearchServer::onReadyRead()
     QElapsedTimer timer;
     timer.start();
 
-    QString request = QString::fromUtf8(client->readAll());
+    /* Accumulate per-socket because POST bodies can arrive in a
+     * separate TCP segment from the headers — readyRead fires once
+     * per segment, but we can only parse once we have both the full
+     * header block and Content-Length bytes of body. */
+    QByteArray accum = client->property("__buf__").toByteArray();
+    accum += client->readAll();
+
+    int headerEnd = accum.indexOf("\r\n\r\n");
+    if (headerEnd < 0) {
+        client->setProperty("__buf__", accum);
+        return;  // wait for more
+    }
+
+    int contentLength = 0;
+    {
+        QByteArray headerBlock = accum.left(headerEnd);
+        for (const QByteArray &line : headerBlock.split('\n')) {
+            QByteArray t = line.trimmed();
+            if (t.toLower().startsWith("content-length:")) {
+                contentLength = t.mid(QByteArray("content-length:").size())
+                                    .trimmed().toInt();
+                break;
+            }
+        }
+    }
+
+    int bodyHave = accum.size() - (headerEnd + 4);
+    if (bodyHave < contentLength) {
+        client->setProperty("__buf__", accum);
+        return;  // wait for more body
+    }
+
+    /* We have a complete request.  Trim accum to it and clear the
+     * stashed buffer (we don't support pipelined keep-alive). */
+    QByteArray full = accum.left(headerEnd + 4 + contentLength);
+    client->setProperty("__buf__", QByteArray());
+    QString request = QString::fromUtf8(full);
     QString clientAddr = client->peerAddress().toString();
 
     QString method, path;

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -401,22 +401,39 @@ void SearchServer::parseRequest(const QString &request, QString &method,
         path = fullPath;
     }
 
-    // Parse headers (look for X-API-Key)
+    // Parse headers (look for X-API-Key and Authorization)
+    int headerEnd = lines.size();
     for (int i = 1; i < lines.size(); i++) {
         QString line = lines[i];
-        if (line.isEmpty())
+        if (line.isEmpty()) {
+            headerEnd = i;
             break;  // End of headers
+        }
 
         int colonPos = line.indexOf(':');
         if (colonPos > 0) {
             QString headerName = line.left(colonPos).trimmed();
             QString headerValue = line.mid(colonPos + 1).trimmed();
 
-            // Store X-API-Key header for authentication
             if (headerName.toLower() == "x-api-key") {
                 params["__api_key__"] = headerValue;
+            } else if (headerName.toLower() == "authorization") {
+                /* Format: "Bearer <token>".  Token is opaque. */
+                if (headerValue.startsWith("Bearer ", Qt::CaseInsensitive)) {
+                    params["__bearer_token__"] =
+                        headerValue.mid(QStringLiteral("Bearer ").size())
+                                   .trimmed();
+                }
             }
         }
+    }
+
+    /* Request body (for POST).  Best-effort: assumes the body arrived in
+     * the same readyRead chunk as the headers, which is true for the
+     * short JSON payloads we accept in v1. */
+    if (headerEnd + 1 < lines.size()) {
+        QStringList bodyLines = lines.mid(headerEnd + 1);
+        params["__body__"] = bodyLines.join("\r\n");
     }
 }
 
@@ -424,21 +441,59 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                                       const QHash<QString, QString> &params,
                                       QTcpSocket *client)
 {
-    // Only support GET requests
+    /* POST is only accepted on a small allowlist; everything else is GET. */
+    if (method == "POST") {
+        if (path == "/v1/auth/login")
+            return handleAuthLogin(params);
+        return buildHttpResponse(405, "Method Not Allowed", "text/plain",
+                                QString("POST not supported on this path"));
+    }
     if (method != "GET") {
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
                                 QString("Only GET requests are supported"));
     }
 
-    // Check authentication (except for status endpoints, which clients
-    // need to probe before they have a token).
-    if (isAuthEnabled() && path != "/status" && path != "/v1/status") {
+    /* Identify the caller.  authedUser is non-empty when a bearer token
+     * resolved to a known user; that controls per-user repo gating
+     * below.  API-key auth grants full access but does not impose a
+     * per-user view. */
+    QString authedUser;
+    bool authOk = !isAuthEnabled() || path == "/status"
+                  || path == "/v1/status";
+
+    if (!authOk) {
         QString providedKey = params.value("__api_key__");
-        if (!validateApiKey(providedKey)) {
-            qWarning() << "SearchServer: Authentication failed for" << path;
-            return buildHttpResponse(401, "Unauthorized", "application/json",
-                                   buildJsonResponse(false, "", "Invalid or missing API key. "
-                                       "Please provide X-API-Key header."));
+        if (!providedKey.isEmpty() && validateApiKey(providedKey)) {
+            authOk = true;
+        } else {
+            QString token = params.value("__bearer_token__");
+            if (!token.isEmpty()) {
+                authedUser = _tokens.lookup(token);
+                if (!authedUser.isEmpty())
+                    authOk = true;
+            }
+        }
+    }
+
+    if (!authOk) {
+        qWarning() << "SearchServer: Authentication failed for" << path;
+        return buildHttpResponse(401, "Unauthorized", "application/json",
+                               buildJsonResponse(false, "", "Invalid or missing credentials. "
+                                   "Provide X-API-Key or Authorization: Bearer header."));
+    }
+
+    /* Per-user repo gating: if the caller is bearer-authenticated and a
+     * ?repo= parameter is supplied, enforce the user's allowlist.
+     * Filtering of /repos itself happens once the Backend abstraction
+     * lands. */
+    if (!authedUser.isEmpty()) {
+        QString repoName = params.value("repo", "");
+        if (!repoName.isEmpty()
+            && !_users.repoAllowed(authedUser, repoName)) {
+            return buildHttpResponse(403, "Forbidden", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "User not permitted to access repository: "
+                                         + repoName));
         }
     }
 
@@ -670,6 +725,49 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         return buildHttpResponse(404, "Not Found", "text/plain",
                                 QString("Endpoint not found"));
     }
+}
+
+QByteArray SearchServer::handleAuthLogin(const QHash<QString, QString> &params)
+{
+    QByteArray body = params.value("__body__").toUtf8();
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(body, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {user, password}"));
+    }
+    QJsonObject obj = doc.object();
+    QString user = obj.value("user").toString();
+    QString password = obj.value("password").toString();
+    if (user.isEmpty() || password.isEmpty()) {
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "user and password are required"));
+    }
+    if (!_users.verify(user, password)) {
+        /* Brief delay to mute trivial timing channels.  The CPU cost of
+         * PBKDF2 already dominates, but make the failure path no
+         * cheaper than the success path. */
+        return buildHttpResponse(401, "Unauthorized", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Invalid credentials"));
+    }
+
+    QString token = _tokens.mint(user);
+
+    QJsonObject out;
+    out["token"] = token;
+    out["user"]  = user;
+    /* TTL is fixed at 30 days in TokenStore::mint default; report it
+     * back so clients can refresh ahead of expiry without a hard-coded
+     * constant on their side. */
+    out["expiry"] = QDateTime::currentDateTime().addDays(30)
+                        .toString(Qt::ISODate);
+    QJsonDocument outDoc(out);
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(outDoc.toJson(
+                                 QJsonDocument::Compact)));
 }
 
 QString SearchServer::searchFiles(const QString &repoPath, const QString &searchPath,
@@ -1124,7 +1222,10 @@ bool SearchServer::validateApiKey(const QString &token)
 
 bool SearchServer::isAuthEnabled()
 {
-    return !_apiKey.isEmpty();
+    /* Auth kicks in if either a shared API key is configured or any
+     * users have been registered.  This lets operators run a
+     * users-only deployment without setting PAPERMAN_API_KEY. */
+    return !_apiKey.isEmpty() || _users.count() > 0;
 }
 
 QString SearchServer::loadOrCreateServerId()

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -34,7 +34,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QDir>
 #include <QFileInfo>
 #include <QDateTime>
+#include <QStandardPaths>
 #include <QUrl>
+#include <QUuid>
 #include <QDebug>
 #include <QProcess>
 #include <QTemporaryDir>
@@ -83,6 +85,8 @@ SearchServer::SearchServer(const QString &rootPath, quint16 port,
     if (!_apiKey.isEmpty()) {
         qDebug() << "SearchServer: API key authentication enabled";
     }
+
+    _serverId = loadOrCreateServerId();
 
     // Clean old thumbnails from cache
     cleanThumbnailCache();
@@ -147,6 +151,8 @@ SearchServer::SearchServer(const QStringList &rootPaths, quint16 port, QObject *
     if (!_apiKey.isEmpty()) {
         qDebug() << "SearchServer: API key authentication enabled";
     }
+
+    _serverId = loadOrCreateServerId();
 
     // Clean old thumbnails from cache
     cleanThumbnailCache();
@@ -424,8 +430,9 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                                 QString("Only GET requests are supported"));
     }
 
-    // Check authentication (except for /status endpoint)
-    if (isAuthEnabled() && path != "/status") {
+    // Check authentication (except for status endpoints, which clients
+    // need to probe before they have a token).
+    if (isAuthEnabled() && path != "/status" && path != "/v1/status") {
         QString providedKey = params.value("__api_key__");
         if (!validateApiKey(providedKey)) {
             qWarning() << "SearchServer: Authentication failed for" << path;
@@ -440,6 +447,19 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         QString data = QString("{\"status\":\"running\",\"repository\":\"%1\",\"version\":\"%2\"}")
                       .arg(_rootPath, CONFIG_version_str);
         return buildHttpResponse(200, "OK", "application/json", data);
+    }
+    else if (path == "/v1/status") {
+        QJsonObject obj;
+        obj["status"] = "running";
+        obj["apiVersion"] = PAPERMAN_API_VERSION;
+        obj["serverId"] = _serverId;
+        obj["version"] = CONFIG_version_str;
+        // Empty for now: the features list will be populated as endpoints
+        // ship. Clients should feature-detect rather than version-detect.
+        obj["features"] = QJsonArray();
+        QJsonDocument doc(obj);
+        return buildHttpResponse(200, "OK", "application/json",
+                                 QString::fromUtf8(doc.toJson(QJsonDocument::Compact)));
     }
     else if (path == "/repos") {
         // List all repositories
@@ -1105,6 +1125,32 @@ bool SearchServer::validateApiKey(const QString &token)
 bool SearchServer::isAuthEnabled()
 {
     return !_apiKey.isEmpty();
+}
+
+QString SearchServer::loadOrCreateServerId()
+{
+    QString configDir = QStandardPaths::writableLocation(
+                            QStandardPaths::GenericConfigLocation)
+                        + "/paperman-server";
+    QString idFile = configDir + "/server-id";
+
+    QFile f(idFile);
+    if (f.exists() && f.open(QIODevice::ReadOnly)) {
+        QString id = QString::fromUtf8(f.readAll()).trimmed();
+        if (!id.isEmpty())
+            return id;
+    }
+
+    QDir().mkpath(configDir);
+    QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        f.write(id.toUtf8());
+        f.write("\n");
+    } else {
+        qWarning() << "SearchServer: failed to persist server-id at"
+                   << idFile;
+    }
+    return id;
 }
 
 QString SearchServer::browseDirectory(const QString &repoPath, const QString &dirPath)

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -22,6 +22,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 
 #include "searchserver.h"
+#include "localbackend.h"
 #include "serverlog.h"
 #include "config.h"
 
@@ -79,6 +80,8 @@ SearchServer::SearchServer(const QString &rootPath, quint16 port,
 
     // Also store in the list for compatibility
     _rootPaths.append(_rootPath);
+
+    _backend.reset(new LocalBackend(_rootPaths));
 
     // Load API key from environment variable
     _apiKey = QString::fromUtf8(qgetenv("PAPERMAN_API_KEY"));
@@ -145,6 +148,8 @@ SearchServer::SearchServer(const QStringList &rootPaths, quint16 port, QObject *
     // Keep first path for backward compatibility
     if (!_rootPaths.isEmpty())
         _rootPath = _rootPaths.first();
+
+    _backend.reset(new LocalBackend(_rootPaths));
 
     // Load API key from environment variable
     _apiKey = QString::fromUtf8(qgetenv("PAPERMAN_API_KEY"));
@@ -517,8 +522,7 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                                  QString::fromUtf8(doc.toJson(QJsonDocument::Compact)));
     }
     else if (path == "/repos") {
-        // List all repositories
-        QString result = listRepositories();
+        QString result = listRepositories(authedUser);
         return buildHttpResponse(200, "OK", "application/json", result);
     }
     else if (path == "/search") {
@@ -913,50 +917,36 @@ QString SearchServer::listFiles(const QString &dirPath)
 #endif
 }
 
-QString SearchServer::listRepositories()
+QString SearchServer::listRepositories(const QString &user)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    QList<RepositoryInfo> repos = _backend->listRepositories();
+
     QJsonArray jsonArray;
-    foreach (const QString &path, _rootPaths) {
+    int count = 0;
+    for (const RepositoryInfo &r : repos) {
+        /* For bearer-authed callers, hide repos the user can't see.
+         * Missing repos still report exists=false so the client knows
+         * the operator configured them.  Skip those too when filtered:
+         * leaking the existence of an unreachable directory has no
+         * value to a restricted user. */
+        if (!user.isEmpty() && !_users.repoAllowed(user, r.name))
+            continue;
+
         QJsonObject repoObj;
-        repoObj["path"] = path;
-
-        QDir dir(path);
-        if (dir.exists()) {
-            repoObj["exists"] = true;
-            repoObj["name"] = QFileInfo(path).fileName();
-        } else {
-            repoObj["exists"] = false;
-            repoObj["name"] = "";
-        }
-
+        repoObj["path"]   = r.path;
+        repoObj["exists"] = r.exists;
+        repoObj["name"]   = r.name;
         jsonArray.append(repoObj);
+        count++;
     }
 
     QJsonObject responseObj;
-    responseObj["success"] = true;
-    responseObj["count"] = _rootPaths.size();
+    responseObj["success"]      = true;
+    responseObj["count"]        = count;
     responseObj["repositories"] = jsonArray;
 
     QJsonDocument doc(responseObj);
     return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
-#else
-    // Qt 4 fallback
-    QString json = "{\"success\":true,\"count\":" + QString::number(_rootPaths.size())
-                  + ",\"repositories\":[";
-    for (int i = 0; i < _rootPaths.size(); i++) {
-        if (i > 0) json += ",";
-        const QString &path = _rootPaths[i];
-        QDir dir(path);
-        bool exists = dir.exists();
-        QString name = exists ? QFileInfo(path).fileName() : "";
-        json += "{\"path\":\"" + path + "\","
-                "\"exists\":" + QString(exists ? "true" : "false") + ","
-                "\"name\":\"" + name + "\"}";
-    }
-    json += "]}";
-    return json;
-#endif
 }
 
 QByteArray SearchServer::getFile(const QString &repoPath, const QString &filePath,

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -99,24 +99,14 @@ SearchServer::SearchServer(const QString &rootPath, quint16 port,
     if (skipCache) {
         qDebug() << "SearchServer: Skipping file cache build (--no-cache)";
     } else {
-        // Build file cache for the repository
         QElapsedTimer cacheTimer;
         cacheTimer.start();
         qDebug() << "SearchServer: Building file cache for" << _rootPath;
-        QList<CachedFile> &fileList = _fileCache[_rootPath];
-
-        if (QFile::exists(papertreeFile) && loadFromPapertree(_rootPath, fileList)) {
-            qDebug() << "SearchServer: File cache loaded from papertree with" << fileList.size() << "files";
-        } else {
-            scanDirectory(_rootPath, "", fileList);
-            qDebug() << "SearchServer: File cache built with" << fileList.size() << "files";
-        }
-        qint64 totalBytes = 0;
-        for (const CachedFile &f : fileList)
-            totalBytes += f.size;
+        _backend->loadCacheForRepo(_rootPath);
         qDebug().noquote().nospace()
             << "SearchServer: Repository size "
-            << QString::number(totalBytes / 1e9, 'f', 1) << " GB";
+            << QString::number(_backend->cacheBytes(_rootPath) / 1e9, 'f', 1)
+            << " GB";
         qDebug().nospace() << "SearchServer: File cache ready in "
                            << cacheTimer.elapsed() / 1000.0 << "s";
     }
@@ -162,26 +152,15 @@ SearchServer::SearchServer(const QStringList &rootPaths, quint16 port, QObject *
     // Clean old thumbnails from cache
     cleanThumbnailCache();
 
-    // Build file cache for each repository
     QElapsedTimer cacheTimer;
     cacheTimer.start();
     foreach (const QString &path, _rootPaths) {
         qDebug() << "SearchServer: Building file cache for" << path;
-        QList<CachedFile> &fileList = _fileCache[path];
-
-        QString papertreeFile = path + "/.papertree";
-        if (QFile::exists(papertreeFile) && loadFromPapertree(path, fileList)) {
-            qDebug() << "SearchServer: File cache loaded from papertree with" << fileList.size() << "files";
-        } else {
-            scanDirectory(path, "", fileList);
-            qDebug() << "SearchServer: File cache built with" << fileList.size() << "files";
-        }
-        qint64 totalBytes = 0;
-        for (const CachedFile &f : fileList)
-            totalBytes += f.size;
+        _backend->loadCacheForRepo(path);
         qDebug().noquote().nospace()
             << "SearchServer: Repository size "
-            << QString::number(totalBytes / 1e9, 'f', 1) << " GB";
+            << QString::number(_backend->cacheBytes(path) / 1e9, 'f', 1)
+            << " GB";
     }
     qDebug().nospace() << "SearchServer: File cache ready in "
                        << cacheTimer.elapsed() / 1000.0 << "s";
@@ -356,12 +335,9 @@ void SearchServer::onDirectoryChanged(const QString &path)
         return;
     }
 
-    // Rebuild cache for this repository
     qDebug() << "SearchServer: Rebuilding file cache for" << repoPath;
-    QList<CachedFile> &fileList = _fileCache[repoPath];
-    fileList.clear();
-    scanDirectory(repoPath, "", fileList);
-    qDebug() << "SearchServer: File cache rebuilt with" << fileList.size() << "files";
+    int count = _backend->loadCacheForRepo(repoPath);
+    qDebug() << "SearchServer: File cache rebuilt with" << count << "files";
 
     // Re-add the papertree file to watcher if it was removed
     // (some editors delete and recreate files when saving)
@@ -562,41 +538,51 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         return buildHttpResponse(200, "OK", "application/json", result);
     }
     else if (path == "/browse") {
-        QString dirPath = params.value("path", "");
+        QString dirPath  = params.value("path", "");
         QString repoName = params.value("repo", "");
+        /* Empty repoName preserves the legacy default-to-primary-repo
+         * behaviour from before the multi-repo era. */
+        if (repoName.isEmpty() && !_rootPaths.isEmpty())
+            repoName = QFileInfo(_rootPaths.first()).fileName();
 
-        // Find repository by name if specified
-        QString repoPath = _rootPath;  // Default to first/primary repo
-        if (!repoName.isEmpty()) {
-            bool found = false;
-            foreach (const QString &path, _rootPaths) {
-                if (QFileInfo(path).fileName() == repoName) {
-                    repoPath = path;
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return buildHttpResponse(404, "Not Found", "application/json",
-                                       buildJsonResponse(false, "", "Repository not found: " + repoName));
+        DirectoryListing listing = _backend->browseDirectory(repoName, dirPath);
+        if (!listing.ok) {
+            int code = listing.notFound ? 404 : 400;
+            const char *label = listing.notFound ? "Not Found" : "Bad Request";
+            return buildHttpResponse(code, label, "application/json",
+                                     buildJsonResponse(false, "",
+                                         listing.error.isEmpty() ? "Invalid path"
+                                                                 : listing.error));
+        }
+
+        QJsonArray dirs, files;
+        for (const DirectoryEntry &e : listing.entries) {
+            if (e.isDir) {
+                QJsonObject d;
+                d["name"]  = e.name;
+                d["path"]  = e.path;
+                d["count"] = e.count;
+                dirs.append(d);
+            } else {
+                QJsonObject f;
+                f["name"]     = e.name;
+                f["size"]     = e.size;
+                f["modified"] = e.modified;
+                f["path"]     = e.path;
+                files.append(f);
             }
         }
 
-        QString result = browseDirectory(repoPath, dirPath);
-
-        // Check for error markers from browseDirectory
-        if (result.isEmpty()) {
-            // Invalid path (400 Bad Request)
-            return buildHttpResponse(400, "Bad Request", "application/json",
-                                   buildJsonResponse(false, "", "Invalid path"));
-        } else if (result == "NOT_FOUND") {
-            // Directory not found (404 Not Found)
-            return buildHttpResponse(404, "Not Found", "application/json",
-                                   buildJsonResponse(false, "", "Directory not found"));
-        }
-
-        // Success
-        return buildHttpResponse(200, "OK", "application/json", result);
+        QJsonObject obj;
+        obj["success"]     = true;
+        obj["path"]        = dirPath;
+        obj["count"]       = dirs.size() + files.size();
+        obj["directories"] = dirs;
+        obj["files"]       = files;
+        QJsonDocument doc(obj);
+        return buildHttpResponse(200, "OK", "application/json",
+                                 QString::fromUtf8(doc.toJson(
+                                     QJsonDocument::Compact)));
     }
     else if (path == "/file") {
         QString filePath = params.value("path", "");
@@ -777,8 +763,7 @@ QByteArray SearchServer::handleAuthLogin(const QHash<QString, QString> &params)
 QString SearchServer::searchFiles(const QString &repoPath, const QString &searchPath,
                                   const QString &pattern, bool recursive)
 {
-    // Get file cache for this repository
-    const QList<CachedFile> &fileList = _fileCache.value(repoPath);
+    const QList<CachedFile> &fileList = _backend->fileCacheFor(repoPath);
     if (fileList.isEmpty()) {
         qWarning() << "SearchServer: No file cache found for" << repoPath;
         return buildJsonResponse(false, "", "Repository not found in cache");
@@ -1244,267 +1229,6 @@ QString SearchServer::loadOrCreateServerId()
     return id;
 }
 
-QString SearchServer::browseDirectory(const QString &repoPath, const QString &dirPath)
-{
-    // Security: Prevent directory traversal
-    if (dirPath.contains("..") || dirPath.startsWith("/")) {
-        // Invalid path - this is a client error (400)
-        // We return an empty string to signal the caller to send a 400 response
-        return "";  // Will be handled by caller with 400 error
-    }
-
-    // Build full path
-    QString fullPath = repoPath;
-    if (!dirPath.isEmpty()) {
-        fullPath += "/" + dirPath;
-    }
-
-    QDir dir(fullPath);
-    if (!dir.exists()) {
-        // Directory not found - return special marker for 404
-        return "NOT_FOUND";  // Will be handled by caller with 404 error
-    }
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    QJsonArray filesArray;
-    QJsonArray dirsArray;
-
-    // Get subdirectories (still need filesystem for this)
-    QFileInfoList subdirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-    foreach (const QFileInfo &subdir, subdirs) {
-        // Skip hidden directories
-        if (subdir.fileName().startsWith('.'))
-            continue;
-
-        QJsonObject dirObj;
-        dirObj["name"] = subdir.fileName();
-
-        // Build relative path
-        QString relativePath = dirPath.isEmpty()
-                              ? subdir.fileName()
-                              : dirPath + "/" + subdir.fileName();
-        dirObj["path"] = relativePath;
-
-        // Count files in this directory recursively using cache
-        int fileCount = countFilesRecursive(repoPath, relativePath);
-        dirObj["count"] = fileCount;
-
-        dirsArray.append(dirObj);
-    }
-
-    // Get files from cache (much faster than filesystem scan)
-    const QList<CachedFile> &cachedFiles = _fileCache.value(repoPath);
-    foreach (const CachedFile &file, cachedFiles) {
-        // Check if file is in current directory (not subdirectories)
-        QString fileDir = QFileInfo(file.path).path();
-        if (fileDir == "." && dirPath.isEmpty()) {
-            // File is in root
-        } else if (fileDir == dirPath) {
-            // File is in this directory
-        } else {
-            continue;  // Skip files not in current directory
-        }
-
-        QJsonObject fileObj;
-        fileObj["name"] = file.name;
-        fileObj["size"] = file.size;
-        fileObj["modified"] = file.modified.toString(Qt::ISODate);
-        fileObj["path"] = file.path;
-
-        filesArray.append(fileObj);
-    }
-
-    QJsonObject responseObj;
-    responseObj["success"] = true;
-    responseObj["path"] = dirPath;
-    responseObj["count"] = dirsArray.size() + filesArray.size();
-    responseObj["directories"] = dirsArray;
-    responseObj["files"] = filesArray;
-
-    QJsonDocument doc(responseObj);
-    return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
-#else
-    // Qt 4 fallback
-    // Get subdirectories
-    QStringList subdirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-
-    // Filter hidden subdirs
-    QStringList visibleSubdirs;
-    foreach (const QString &subdir, subdirs) {
-        if (!subdir.startsWith('.'))
-            visibleSubdirs.append(subdir);
-    }
-
-    // Count files from cache for this directory
-    const QList<CachedFile> &cachedFiles = _fileCache.value(repoPath);
-    int fileCount = 0;
-    foreach (const CachedFile &file, cachedFiles) {
-        QString fileDir = QFileInfo(file.path).path();
-        if ((fileDir == "." && dirPath.isEmpty()) || fileDir == dirPath) {
-            fileCount++;
-        }
-    }
-
-    QString json = "{\"success\":true,\"path\":\"" + dirPath + "\",";
-    json += "\"count\":" + QString::number(visibleSubdirs.size() + fileCount) + ",";
-
-    json += "\"directories\":[";
-    for (int i = 0; i < visibleSubdirs.size(); i++) {
-        if (i > 0) json += ",";
-        QString relativePath = dirPath.isEmpty() ? visibleSubdirs[i] : dirPath + "/" + visibleSubdirs[i];
-        int fileCount = countFilesRecursive(repoPath, relativePath);
-        json += "{\"name\":\"" + visibleSubdirs[i] + "\",\"path\":\"" + relativePath
-              + "\",\"count\":" + QString::number(fileCount) + "}";
-    }
-    json += "],\"files\":[";
-
-    // Get files from cache
-    const QList<CachedFile> &cachedFiles = _fileCache.value(repoPath);
-    int fileIdx = 0;
-    foreach (const CachedFile &file, cachedFiles) {
-        QString fileDir = QFileInfo(file.path).path();
-        if ((fileDir == "." && dirPath.isEmpty()) || fileDir == dirPath) {
-            if (fileIdx > 0) json += ",";
-            json += "{\"name\":\"" + file.name + "\","
-                    "\"size\":" + QString::number(file.size) + ","
-                    "\"modified\":\"" + file.modified.toString(Qt::ISODate) + "\","
-                    "\"path\":\"" + file.path + "\"}";
-            fileIdx++;
-        }
-    }
-    json += "]}";
-    return json;
-#endif
-}
-
-int SearchServer::countFilesRecursive(const QString &repoPath, const QString &dirPath)
-{
-    // Use cached file list for fast counting
-    const QList<CachedFile> &fileList = _fileCache.value(repoPath);
-
-    int count = 0;
-    QString prefix = dirPath.isEmpty() ? "" : dirPath + "/";
-
-    // Count files that are under this directory path
-    foreach (const CachedFile &file, fileList) {
-        if (dirPath.isEmpty() || file.path.startsWith(prefix)) {
-            count++;
-        }
-    }
-
-    return count;
-}
-
-bool SearchServer::loadFromPapertree(const QString &repoPath, QList<CachedFile> &fileList)
-{
-    QString papertreeFile = repoPath + "/.papertree";
-    QFile file(papertreeFile);
-
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "SearchServer: Failed to open papertree file:" << papertreeFile;
-        return false;
-    }
-
-    QTextStream in(&file);
-    QString currentDir = "";
-    QStringList dirStack;  // Track directory hierarchy
-
-    while (!in.atEnd()) {
-        QString line = in.readLine();
-
-        // Count leading spaces to determine nesting level
-        int level = 0;
-        for (int i = 0; i < line.length(); i++) {
-            if (line[i] == ' ')
-                level++;
-            else
-                break;
-        }
-
-        if (level < 1)
-            continue;  // Skip invalid lines
-
-        QString name = line.mid(level);
-
-        // Adjust directory stack based on level
-        while (dirStack.size() >= level) {
-            dirStack.removeLast();
-        }
-
-        // Build current path
-        QString relativePath = dirStack.join("/");
-        if (!relativePath.isEmpty())
-            relativePath += "/";
-        relativePath += name;
-
-        QString fullPath = repoPath + "/" + relativePath;
-        QFileInfo fileInfo(fullPath);
-
-        if (!fileInfo.exists()) {
-            // File/dir no longer exists, skip it
-            continue;
-        }
-
-        if (fileInfo.isDir()) {
-            // Add to directory stack for building paths of children
-            dirStack.append(name);
-        } else if (fileInfo.isFile()) {
-            // Check if it's a supported file type
-            QString ext = name.section('.', -1).toLower();
-            if (ext == "max" || ext == "pdf" || ext == "jpg" ||
-                ext == "jpeg" || ext == "tiff" || ext == "tif") {
-
-                CachedFile cachedFile;
-                cachedFile.path = relativePath;
-                cachedFile.name = name;
-                cachedFile.size = fileInfo.size();
-                cachedFile.modified = fileInfo.lastModified();
-                fileList.append(cachedFile);
-            }
-        }
-    }
-
-    file.close();
-    return fileList.size() > 0;
-}
-
-void SearchServer::scanDirectory(const QString &repoPath, const QString &dirPath,
-                                 QList<CachedFile> &fileList)
-{
-    QString fullPath = repoPath;
-    if (!dirPath.isEmpty())
-        fullPath += "/" + dirPath;
-
-    // File extensions to cache
-    QStringList nameFilters;
-    nameFilters << "*.max" << "*.pdf" << "*.jpg" << "*.jpeg" << "*.tiff" << "*.tif";
-
-    // Use QDirIterator for efficient recursive scanning
-    QDirIterator it(fullPath, nameFilters,
-                    QDir::Files | QDir::Readable,
-                    QDirIterator::Subdirectories);
-
-    while (it.hasNext()) {
-        QString filePath = it.next();
-        QFileInfo info(filePath);
-
-        // Calculate relative path from repository root
-        QString relativePath = filePath;
-        if (relativePath.startsWith(repoPath + "/"))
-            relativePath = relativePath.mid(repoPath.length() + 1);
-        else if (relativePath.startsWith(repoPath))
-            relativePath = relativePath.mid(repoPath.length());
-
-        // Add to cache
-        CachedFile cached;
-        cached.path = relativePath;
-        cached.name = info.fileName();
-        cached.size = info.size();
-        cached.modified = info.lastModified();
-
-        fileList.append(cached);
-    }
-}
 
 int SearchServer::getThumbnailSize(const QString &size)
 {

--- a/searchserver.h
+++ b/searchserver.h
@@ -32,8 +32,11 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #ifndef __searchserver_h
 #define __searchserver_h
 
+#include "backend.h"
 #include "tokenstore.h"
 #include "userstore.h"
+
+#include <memory>
 
 #include <QTcpServer>
 #include <QTcpSocket>
@@ -232,10 +235,15 @@ private:
     QString browseDirectory(const QString &repoPath, const QString &dirPath);
 
     /**
-     * Get list of all repositories
+     * Get list of all repositories.
+     *
+     * @param user  If non-empty, restrict the list to repositories the
+     *              named user is permitted to see (per the UserStore
+     *              allowlist).  Empty means "no per-user filter", as
+     *              used for API-key callers and pre-auth callers.
      * @return JSON response with repository list
      */
-    QString listRepositories();
+    QString listRepositories(const QString &user = QString());
 
     /**
      * Get file content
@@ -452,6 +460,7 @@ private:
     QString _apiKey;        //!< API key for authentication (from PAPERMAN_API_KEY env var)
     UserStore _users;       //!< Per-user account store
     TokenStore _tokens;     //!< In-memory bearer tokens
+    std::unique_ptr<Backend> _backend;  //!< Data-source abstraction
     QHash<QString, QList<CachedFile>> _fileCache;  //!< Cached file list for each repository
     QFileSystemWatcher *_fsWatcher;  //!< File system watcher for automatic cache updates
     QMap<QString, PendingExtraction> _pendingExtractions;  //!< In-flight gs extractions keyed by cache path

--- a/searchserver.h
+++ b/searchserver.h
@@ -33,6 +33,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #define __searchserver_h
 
 #include "backend.h"
+#include "cachedfile.h"
+#include "localbackend.h"
 #include "tokenstore.h"
 #include "userstore.h"
 
@@ -77,14 +79,6 @@ struct PendingExtraction {
     QString filePath;           //!< Source document (for logging)
     int page;                   //!< 1-based page number (for logging)
     QList<QTcpSocket *> waiters; //!< Clients waiting
-};
-
-// Simple struct for cached file information
-struct CachedFile {
-    QString path;        // Relative path from repository root
-    QString name;        // Filename only
-    qint64 size;         // File size in bytes
-    QDateTime modified;  // Last modification time
 };
 
 /**
@@ -225,14 +219,6 @@ private:
      * @return JSON response with file list
      */
     QString listFiles(const QString &dirPath);
-
-    /**
-     * Browse directory contents (files and subdirectories)
-     * @param repoPath   Repository root path
-     * @param dirPath    Directory path (relative to repository root)
-     * @return JSON response with files and directories
-     */
-    QString browseDirectory(const QString &repoPath, const QString &dirPath);
 
     /**
      * Get list of all repositories.
@@ -414,32 +400,6 @@ private:
      */
     void cleanThumbnailCache();
 
-private:
-    /**
-     * Scan a directory recursively and build file cache
-     * @param repoPath Repository root path
-     * @param dirPath Current directory being scanned (relative to repo)
-     * @param fileList Returns list of cached files
-     */
-    void scanDirectory(const QString &repoPath, const QString &dirPath,
-                      QList<CachedFile> &fileList);
-
-    /**
-     * Count files recursively in a directory using cached data
-     * @param repoPath Repository root path
-     * @param dirPath Relative directory path within repository
-     * @return Number of files found recursively in cache
-     */
-    int countFilesRecursive(const QString &repoPath, const QString &dirPath);
-
-    /**
-     * Load file cache from .papertree file
-     * @param repoPath Repository root path
-     * @param fileList Returns list of cached files
-     * @return true if successfully loaded from papertree, false otherwise
-     */
-    bool loadFromPapertree(const QString &repoPath, QList<CachedFile> &fileList);
-
 public:
     ServerLog _log;         //!< Request log
 
@@ -460,8 +420,7 @@ private:
     QString _apiKey;        //!< API key for authentication (from PAPERMAN_API_KEY env var)
     UserStore _users;       //!< Per-user account store
     TokenStore _tokens;     //!< In-memory bearer tokens
-    std::unique_ptr<Backend> _backend;  //!< Data-source abstraction
-    QHash<QString, QList<CachedFile>> _fileCache;  //!< Cached file list for each repository
+    std::unique_ptr<LocalBackend> _backend;  //!< Data-source (owns the file cache)
     QFileSystemWatcher *_fsWatcher;  //!< File system watcher for automatic cache updates
     QMap<QString, PendingExtraction> _pendingExtractions;  //!< In-flight gs extractions keyed by cache path
 

--- a/searchserver.h
+++ b/searchserver.h
@@ -82,6 +82,13 @@ struct CachedFile {
 };
 
 /**
+ * Versioned HTTP API: clients should check /v1/status to see what the
+ * server supports before relying on any v1 endpoint. Bump this when the
+ * wire format changes.
+ */
+#define PAPERMAN_API_VERSION "1"
+
+/**
  * Simple HTTP server for searching paper repository
  */
 class SearchServer : public QTcpServer
@@ -419,9 +426,18 @@ public:
     ServerLog _log;         //!< Request log
 
 private:
+    /**
+     * Load the persistent server ID (a UUID) from disk, or create one on
+     * first run. The ID lives in ~/.config/paperman-server/server-id and is
+     * returned to clients via /v1/status so they can key their local caches
+     * on it.
+     */
+    QString loadOrCreateServerId();
+
     QString _rootPath;      //!< Root path of paper repository (deprecated, use _rootPaths)
     QStringList _rootPaths; //!< List of root paths of paper repositories
     quint16 _port;          //!< Port to listen on
+    QString _serverId;      //!< Stable per-server UUID, persisted across runs
     QList<QTcpSocket*> _clients;  //!< Connected clients
     QString _apiKey;        //!< API key for authentication (from PAPERMAN_API_KEY env var)
     QHash<QString, QList<CachedFile>> _fileCache;  //!< Cached file list for each repository

--- a/searchserver.h
+++ b/searchserver.h
@@ -32,6 +32,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #ifndef __searchserver_h
 #define __searchserver_h
 
+#include "tokenstore.h"
+#include "userstore.h"
+
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QString>
@@ -194,6 +197,13 @@ private:
     QByteArray handleRequest(const QString &method, const QString &path,
                             const QHash<QString, QString> &params,
                             QTcpSocket *client = nullptr);
+
+    /**
+     * Handle POST /v1/auth/login.  Body is JSON {user, password}.
+     * Returns 200 with {token, expiry, user} on success, 401/400
+     * otherwise.
+     */
+    QByteArray handleAuthLogin(const QHash<QString, QString> &params);
 
     /**
      * Search for files matching a pattern
@@ -440,6 +450,8 @@ private:
     QString _serverId;      //!< Stable per-server UUID, persisted across runs
     QList<QTcpSocket*> _clients;  //!< Connected clients
     QString _apiKey;        //!< API key for authentication (from PAPERMAN_API_KEY env var)
+    UserStore _users;       //!< Per-user account store
+    TokenStore _tokens;     //!< In-memory bearer tokens
     QHash<QString, QList<CachedFile>> _fileCache;  //!< Cached file list for each repository
     QFileSystemWatcher *_fsWatcher;  //!< File system watcher for automatic cache updates
     QMap<QString, PendingExtraction> _pendingExtractions;  //!< In-flight gs extractions keyed by cache path

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -9,6 +9,7 @@
 #include "test_file.h"
 #include "test_ops.h"
 #include "test_pageinfo.h"
+#include "test_pagewidget.h"
 #include "test_qscanner.h"
 #include "test_utils.h"
 #include "test_searchserver.h"
@@ -23,6 +24,7 @@ static TestDirmodel TEST_DIRMODEL("dirmodel");
 static TestDirview TEST_DIRVIEW("dirview");
 static TestFile TEST_FILE("file");
 static TestPageinfo TEST_PAGEINFO("pageinfo");
+static TestPagewidget TEST_PAGEWIDGET("pagewidget");
 static TestQscanner TEST_QSCANNER("qscanner");
 static TestSearchServer TEST_SEARCHSERVER("searchserver");
 static TestOcrSearch TEST_OCRSEARCH("ocrsearch");

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,6 +5,7 @@
 
 #include "test_dirmodel.h"
 #include "test_dirview.h"
+#include "test_file.h"
 #include "test_ops.h"
 #include "test_pageinfo.h"
 #include "test_qscanner.h"
@@ -18,6 +19,7 @@ static TestUtils TEST_UTILS("utils");
 static TestOps TEST_OPS("ops");
 static TestDirmodel TEST_DIRMODEL("dirmodel");
 static TestDirview TEST_DIRVIEW("dirview");
+static TestFile TEST_FILE("file");
 static TestPageinfo TEST_PAGEINFO("pageinfo");
 static TestQscanner TEST_QSCANNER("qscanner");
 static TestSearchServer TEST_SEARCHSERVER("searchserver");

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -3,6 +3,7 @@
 
 #include "test.h"
 
+#include "test_desktopui.h"
 #include "test_dirmodel.h"
 #include "test_dirview.h"
 #include "test_file.h"
@@ -17,6 +18,7 @@
 
 static TestUtils TEST_UTILS("utils");
 static TestOps TEST_OPS("ops");
+static TestDesktopUi TEST_DESKTOPUI("desktopui");
 static TestDirmodel TEST_DIRMODEL("dirmodel");
 static TestDirview TEST_DIRVIEW("dirview");
 static TestFile TEST_FILE("file");

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -5,7 +5,9 @@
 #include "desktopmodel.h"
 #include "desktopview.h"
 #include "desktopwidget.h"
+#include "mainwidget.h"
 #include "mainwindow.h"
+#include "pagewidget.h"
 #include "test_desktopui.h"
 
 void TestDesktopUi::setupShown(Mainwindow *me, Desktopmodel *&model,
@@ -102,4 +104,61 @@ void TestDesktopUi::testCtrlClickMultiSelect()
             "testpdf.pdf");
 
    QTest::qWait(350);
+}
+
+void TestDesktopUi::testDoubleClickOpensStack()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+
+   // The desktop view should be showing initially
+   QCOMPARE(main->currentWidget(), (QWidget *)desktop);
+
+   // Double-click the first stack: the page view should appear,
+   // showing that stack
+   QModelIndex ind = itemIndex(view, 0);
+   QVERIFY(ind.isValid());
+   QPoint centre = view->visualRect(ind).center();
+   QTest::mouseClick(view->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     centre);
+   QTest::mouseDClick(view->viewport(), Qt::LeftButton, Qt::NoModifier,
+                      centre);
+
+   Pagewidget *page = main->getPage();
+   QTRY_COMPARE(main->currentWidget(), (QWidget *)page);
+
+   QModelIndex shown;
+   QVERIFY(page->getCurrentIndex(shown, true));
+   QCOMPARE(model->data(shown, Qt::DisplayRole).toString(), "testfile");
+}
+
+void TestDesktopUi::testSwapViewAction()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+
+   // With a stack selected, the swap action shows it in the page view
+   clickItem(view, 0);
+   me.actionSwap->trigger();
+   QTRY_COMPARE(main->currentWidget(), (QWidget *)main->getPage());
+
+   // Triggering it again returns to the desktop
+   me.actionSwap->trigger();
+   QTRY_COMPARE(main->currentWidget(), (QWidget *)desktop);
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -82,9 +82,6 @@ void TestDesktopUi::testClickSelectsStack()
    QTest::mouseClick(view->viewport(), Qt::LeftButton, Qt::NoModifier,
                      space);
    QVERIFY(!view->isSelection(Desktopview::SEL_at_least_one));
-
-   // Let the preview timer fire so it doesn't outlive the window
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testCtrlClickMultiSelect()
@@ -111,7 +108,6 @@ void TestDesktopUi::testCtrlClickMultiSelect()
    QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(),
             "testpdf.pdf");
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testDoubleClickOpensStack()
@@ -202,7 +198,6 @@ void TestDesktopUi::testToolbarStackNavigation()
    QCOMPARE(sel.size(), 1);
    QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(), "testfile");
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testToolbarPageNavigation()
@@ -248,7 +243,6 @@ void TestDesktopUi::testToolbarPageNavigation()
       QTest::mouseClick(p_next, Qt::LeftButton);
    QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 4);
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testStackNavigationWraps()
@@ -279,7 +273,6 @@ void TestDesktopUi::testStackNavigationWraps()
    QCOMPARE(sel.size(), 1);
    QCOMPARE(sel[0].row(), 1);
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testSelectAllAction()
@@ -340,7 +333,6 @@ void TestDesktopUi::testStackAndMenuUndo()
    me.actionRedo->trigger();
    QCOMPARE(model->rowCount(repo_ind), 2);
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testFilterStacks()
@@ -593,7 +585,6 @@ void TestDesktopUi::testEmailSingleStack()
    // A Gmail compose window should have been requested
    QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
 
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testEmailMultipleStacksZips()
@@ -663,7 +654,6 @@ void TestDesktopUi::testEmailAsPdfConverts()
    QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
 
    QFile::remove(pdf);
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testDragDropToFolder()
@@ -704,7 +694,6 @@ void TestDesktopUi::testDragDropToFolder()
    QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
 
    delete mime;
-   QTest::qWait(350);
 }
 
 void TestDesktopUi::testImportFlow()
@@ -770,7 +759,7 @@ void TestDesktopUi::testScanIntoStack()
    /* the simulated ADF holds 120 pages, so press the stop button (which
       finishes the current page and ends the scan) shortly after the
       scan begins */
-   QTimer::singleShot(1000, main, [main]() { main->stopScan(false); });
+   QTimer::singleShot(400, main, [main]() { main->stopScan(false); });
    me.actionScango->trigger();
 
    xmlConfig->setStringValue("LAST_DEVICE", old_device);

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -8,6 +8,7 @@
 #include "desktopmodel.h"
 #include "desktopview.h"
 #include "desktopwidget.h"
+#include "dirmodel.h"
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
@@ -613,5 +614,46 @@ void TestDesktopUi::testEmailAsPdfConverts()
    QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
 
    QFile::remove(pdf);
+   QTest::qWait(350);
+}
+
+void TestDesktopUi::testDragDropToFolder()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   QString path = desktop->getSelectedPath();
+
+   // Pick up the max stack: build the drag data just as the view does
+   clickItem(view, 0);
+   QMimeData *mime =
+      view->model()->mimeData(view->selectionModel()->selectedIndexes());
+   QVERIFY(mime);
+   QVERIFY(mime->hasFormat("application/vnd.text.list"));
+
+   /* Drop it on the 'main' folder in the directory tree. Row and
+      column are -1 for a drop directly onto an item */
+   QModelIndex dir_ind = desktop->findDir(path + "/main");
+   QVERIFY(dir_ind.isValid());
+   QVERIFY(desktop->_dir_proxy->dropMimeData(mime, Qt::MoveAction, -1, -1,
+                                             dir_ind));
+
+   // The file should move on disk and disappear from the view
+   QTRY_VERIFY(QFile::exists(path + "/main/testfile.max"));
+   QVERIFY(!QFile::exists(path + "/testfile.max"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 1);
+
+   // Undo from the Edit menu brings it back
+   me.actionUndo->trigger();
+   QTRY_VERIFY(QFile::exists(path + "/testfile.max"));
+   QVERIFY(!QFile::exists(path + "/main/testfile.max"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+
+   delete mime;
    QTest::qWait(350);
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1,3 +1,4 @@
+#include <QLineEdit>
 #include <QPushButton>
 #include <QtTest/QtTest>
 
@@ -338,4 +339,40 @@ void TestDesktopUi::testStackAndMenuUndo()
    QCOMPARE(model->rowCount(repo_ind), 2);
 
    QTest::qWait(350);
+}
+
+void TestDesktopUi::testFilterStacks()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   QLineEdit *match = desktop->findChild<QLineEdit *>("match");
+   QPushButton *cancel = desktop->findChild<QPushButton *>("cancelFilter");
+   QVERIFY(match);
+   QVERIFY(cancel);
+
+   // Both stacks are visible to start with
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 2);
+
+   // Typing a filter string shows only the matching stack
+   QTest::keyClicks(match, "testpdf");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   QModelIndex ind = itemIndex(view, 0);
+   QCOMPARE(view->model()->data(ind, Qt::DisplayRole).toString(),
+            "testpdf.pdf");
+
+   // A filter which matches nothing shows no stacks
+   QTest::keyClicks(match, "zzz");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 0);
+
+   // The cancel button clears the filter and shows everything again
+   QTest::mouseClick(cancel, Qt::LeftButton);
+   QCOMPARE(match->text(), QString());
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 2);
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -13,6 +13,7 @@
 #include "mainwidget.h"
 #include "mainwindow.h"
 #include "pagewidget.h"
+#include "qxmlconfig.h"
 #include "test_desktopui.h"
 
 void TestDesktopUi::setupShown(Mainwindow *me, Desktopmodel *&model,
@@ -696,4 +697,47 @@ void TestDesktopUi::testImportFlow()
    // imported file as well
    QTest::keyClick(view, Qt::Key_Escape);
    QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+}
+
+void TestDesktopUi::testScanIntoStack()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   /* select the simulated scanner as the last-used device so that
+      ensureScanner() opens it without showing the selection dialog;
+      restore the user's setting afterwards */
+   if (!xmlConfig)
+      new QXmlConfig();
+   QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
+   xmlConfig->setStringValue("LAST_DEVICE", "simulscan");
+
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+   int before = model->rowCount(repo_ind);
+
+   /* the simulated ADF holds 120 pages, so press the stop button (which
+      finishes the current page and ends the scan) shortly after the
+      scan begins */
+   QTimer::singleShot(1000, main, [main]() { main->stopScan(false); });
+   me.actionScango->trigger();
+
+   xmlConfig->setStringValue("LAST_DEVICE", old_device);
+
+   // A new stack should appear, holding the scanned pages
+   QCOMPARE(model->rowCount(repo_ind), before + 1);
+
+   QModelIndex new_ind = model->index(before, 0, repo_ind);
+   QVERIFY(new_ind.isValid());
+   File *scanned = model->getFile(new_ind);
+   QVERIFY(scanned);
+   QVERIFY(scanned->pagecount() >= 1);
+
+   // The scanned stack exists on disk in the current folder
+   QString pathname =
+      model->data(new_ind, Desktopmodel::Role_pathname).toString();
+   QVERIFY(QFile::exists(pathname));
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -820,3 +820,42 @@ void TestDesktopUi::testRenameStackViaEditor()
    QCOMPARE(model->data(src_ind, Qt::DisplayRole).toString(), "testfile");
    QVERIFY(QFile::exists(path + "/testfile.max"));
 }
+
+void TestDesktopUi::testDirFilterHidesOtherYears()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   // Year-named directories, one current and one old
+   QString this_year = QString::number(QDate::currentDate().year());
+   QString last_year = QString::number(QDate::currentDate().year() - 1);
+
+   auto path = setupRepo();
+   QVERIFY(QDir(path).mkdir(this_year));
+   QVERIFY(QDir(path).mkdir(last_year));
+
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   /* the View->dir-filter action toggles the year/month filter: with
+      it on, only directories for the current year are offered */
+   me.actionDirFilter->setChecked(false);
+   me.actionDirFilter->trigger();   // now on
+   QVERIFY(desktop->findDir(path + "/" + this_year).isValid());
+   QVERIFY(!desktop->findDir(path + "/" + last_year).isValid());
+
+   me.actionDirFilter->trigger();   // off again
+   QVERIFY(desktop->findDir(path + "/" + this_year).isValid());
+   QVERIFY(desktop->findDir(path + "/" + last_year).isValid());
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -5,6 +5,7 @@
 
 #include "test.h"
 
+#include "desktopdelegate.h"
 #include "desktopmodel.h"
 #include "desktopundo.h"
 #include "desktopview.h"
@@ -781,4 +782,41 @@ void TestDesktopUi::testRepositoryAddRemoveUndo()
    // Take it out again so the settings are left unchanged
    me.actionRedo->trigger();
    QCOMPARE(dirmodel->rowCount(QModelIndex()), before);
+}
+
+void TestDesktopUi::testRenameStackViaEditor()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Open the name editor on the first stack, as the rename menu
+   // entry does
+   view->renameStack(itemIndex(view, 0));
+
+   Desktopeditor *editor = view->findChild<Desktopeditor *>();
+   QVERIFY(editor);
+   QCOMPARE(editor->text(), QString("testfile"));
+
+   // Type a new name and press return
+   editor->selectAll();
+   QTest::keyClicks(editor, "renamed");
+   QTest::keyClick(editor, Qt::Key_Return);
+
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   QCOMPARE(model->data(src_ind, Qt::DisplayRole).toString(), "renamed");
+
+   QString path = desktop->getSelectedPath();
+   QVERIFY(QFile::exists(path + "/renamed.max"));
+   QVERIFY(!QFile::exists(path + "/testfile.max"));
+
+   // The rename can be undone from the Edit menu
+   me.actionUndo->trigger();
+   QCOMPARE(model->data(src_ind, Qt::DisplayRole).toString(), "testfile");
+   QVERIFY(QFile::exists(path + "/testfile.max"));
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -657,3 +657,43 @@ void TestDesktopUi::testDragDropToFolder()
    delete mime;
    QTest::qWait(350);
 }
+
+void TestDesktopUi::testImportFlow()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   QString path = desktop->getSelectedPath();
+
+   // Make an import directory containing a PDF, as if downloaded
+   QString imports = path + "/wibble1";
+   QVERIFY(QFile::copy(testSrc + "/testpdf.pdf", imports + "/arrival.pdf"));
+
+   // Show it, as the File->Import menu entries do
+   desktop->showImports(imports);
+
+   // The view shows the file to import, with the move action available
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   view->setSelectionRange(0, 1);
+   QVERIFY(desktop->_act_move->isEnabled());
+
+   // Move it into the repo root, as the move-to-folder dialog does
+   QModelIndexList to_move = view->getSelectedListSource();
+   QString dest = path + "/";
+   QStringList sl;
+   model->moveToDir(to_move, view->rootIndexSource(), dest, sl);
+
+   QTRY_VERIFY(QFile::exists(path + "/arrival.pdf"));
+   QVERIFY(!QFile::exists(imports + "/arrival.pdf"));
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 0);
+
+   // Escape returns to the normal folder view, which now has the
+   // imported file as well
+   QTest::keyClick(view, Qt::Key_Escape);
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -376,3 +376,78 @@ void TestDesktopUi::testFilterStacks()
    QCOMPARE(match->text(), QString());
    QCOMPARE(view->model()->rowCount(view->rootIndex()), 2);
 }
+
+void TestDesktopUi::testSearchAndLocate()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   // Put a stack in a subdirectory so the search has something to find
+   // away from the repo root
+   auto path = setupRepo();
+   QVERIFY(QFile::copy(testSrc + "/testfile.max",
+                       path + "/main/one/findme.max"));
+
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   Desktopview *view = desktop->getView();
+
+   // Search the whole repo for the stack, as the folder-search dialog
+   // does once the user has entered a name
+   desktop->startSearch(path, "findme");
+   desktop->specialView("Showing the results of folder search");
+
+   /* Only the matching stack should be shown. In particular, empty
+      directories must not appear as phantom nameless stacks */
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   QModelIndex ind = itemIndex(view, 0);
+   QCOMPARE(view->model()->data(ind, Qt::DisplayRole).toString(),
+            "findme");
+
+   // Select the result and locate its folder: the view should change
+   // to the stack's directory with the stack selected
+   view->setSelectionRange(0, 1);
+   desktop->locateFolder();
+
+   QCOMPARE(desktop->getSelectedPath(),
+            QString(path + "/main/one"));
+   QTRY_COMPARE(view->getSelectedListSource().size(), 1);
+   QModelIndex sel = view->getSelectedListSource()[0];
+   QCOMPARE(model->data(sel, Desktopmodel::Role_filename).toString(),
+            "findme.max");
+}
+
+void TestDesktopUi::testSearchEscapeReturns()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Search for the max stack only
+   desktop->startSearch(desktop->getSelectedPath(), "testfile");
+   desktop->specialView("Showing the results of folder search");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   QVERIFY(desktop->_toolbar->searchEnabled());
+
+   // Pressing Escape in the view returns to the normal directory view
+   QTest::keyClick(view, Qt::Key_Escape);
+   QVERIFY(!desktop->_toolbar->searchEnabled());
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1,3 +1,4 @@
+#include <QPushButton>
 #include <QtTest/QtTest>
 
 #include "test.h"
@@ -162,3 +163,118 @@ void TestDesktopUi::testSwapViewAction()
    me.actionSwap->trigger();
    QTRY_COMPARE(main->currentWidget(), (QWidget *)desktop);
 }
+
+void TestDesktopUi::testToolbarStackNavigation()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   QPushButton *prev = desktop->findChild<QPushButton *>("prev");
+   QPushButton *next = desktop->findChild<QPushButton *>("next");
+   QVERIFY(prev);
+   QVERIFY(next);
+
+   clickItem(view, 0);
+
+   // The next button moves the selection to the second stack
+   QTest::mouseClick(next, Qt::LeftButton);
+   QModelIndexList sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(),
+            "testpdf.pdf");
+
+   // The prev button moves it back to the first
+   QTest::mouseClick(prev, Qt::LeftButton);
+   sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(), "testfile");
+
+   QTest::qWait(350);
+}
+
+void TestDesktopUi::testToolbarPageNavigation()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   QPushButton *p_prev = desktop->findChild<QPushButton *>("pPrev");
+   QPushButton *p_next = desktop->findChild<QPushButton *>("pNext");
+   QVERIFY(p_prev);
+   QVERIFY(p_next);
+
+   // Select the 5-page max stack
+   clickItem(view, 0);
+
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 0);
+
+   // The page-next button moves to the next page
+   QTest::mouseClick(p_next, Qt::LeftButton);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 1);
+
+   QTest::mouseClick(p_next, Qt::LeftButton);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 2);
+
+   // The page-prev button moves back
+   QTest::mouseClick(p_prev, Qt::LeftButton);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 1);
+
+   // Going back past the first page stays on the first page
+   QTest::mouseClick(p_prev, Qt::LeftButton);
+   QTest::mouseClick(p_prev, Qt::LeftButton);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 0);
+
+   // Going forward past the last page stays on the last page
+   for (int i = 0; i < 10; i++)
+      QTest::mouseClick(p_next, Qt::LeftButton);
+   QCOMPARE(model->data(src_ind, Desktopmodel::Role_pagenum).toInt(), 4);
+
+   QTest::qWait(350);
+}
+
+void TestDesktopUi::testStackNavigationWraps()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   QPushButton *prev = desktop->findChild<QPushButton *>("prev");
+   QPushButton *next = desktop->findChild<QPushButton *>("next");
+   QVERIFY(prev && next);
+
+   // From the last stack, next wraps around to the first
+   clickItem(view, 1);
+   QTest::mouseClick(next, Qt::LeftButton);
+   QModelIndexList sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(sel[0].row(), 0);
+
+   // From the first stack, prev wraps around to the last
+   QTest::mouseClick(prev, Qt::LeftButton);
+   sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(sel[0].row(), 1);
+
+   QTest::qWait(350);
+}
+
+/* URLs which the email operations would open in a browser are captured
+   here instead, so tests never launch anything */
+static QUrl s_opened_url;

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -297,3 +297,45 @@ void TestDesktopUi::testSelectAllAction()
    QModelIndexList sel = view->getSelectedListSource();
    QCOMPARE(sel.size(), 2);
 }
+
+void TestDesktopUi::testStackAndMenuUndo()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Duplicate the max stack using its context-menu action
+   clickItem(view, 0);
+   desktop->_act_duplicate->trigger();
+   QCOMPARE(model->rowCount(repo_ind), 3);
+
+   /* Select the original and the copy and combine them with the
+      stack action. The copy is placed overlapping the original so a
+      mouse click cannot select them reliably; select directly */
+   view->setSelectionRange(0, 1);
+   view->addSelectionRange(2, 1);
+   QVERIFY(desktop->_act_stack->isEnabled());
+   desktop->_act_stack->trigger();
+   QCOMPARE(model->rowCount(repo_ind), 2);
+
+   // The combined stack has the pages of both
+   QModelIndex max_ind = model->index(0, 0, repo_ind);
+   File *max = model->getFile(max_ind);
+   QVERIFY(max);
+   QCOMPARE(max->pagecount(), 10);
+
+   // Undo from the Edit menu splits them apart again
+   me.actionUndo->trigger();
+   QCOMPARE(model->rowCount(repo_ind), 3);
+
+   // Redo from the Edit menu combines them again
+   me.actionRedo->trigger();
+   QCOMPARE(model->rowCount(repo_ind), 2);
+
+   QTest::qWait(350);
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1,3 +1,4 @@
+#include <QClipboard>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QtTest/QtTest>
@@ -277,10 +278,6 @@ void TestDesktopUi::testStackNavigationWraps()
    QTest::qWait(350);
 }
 
-/* URLs which the email operations would open in a browser are captured
-   here instead, so tests never launch anything */
-static QUrl s_opened_url;
-
 void TestDesktopUi::testSelectAllAction()
 {
    QModelIndex repo_ind;
@@ -505,4 +502,116 @@ void TestDesktopUi::testDirTreeNavigation()
    QTest::mouseClick(dir->viewport(), Qt::LeftButton, Qt::NoModifier,
                      dir->visualRect(root_ind).center());
    QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+}
+
+/* URLs which the email operations would open in a browser are captured
+   here instead, so tests never launch anything */
+static QUrl s_opened_url;
+
+void TestDesktopUi::testEmailSingleStack()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+   Desktopmodel::url_capture = &s_opened_url;
+   s_opened_url = QUrl();
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Email the max stack as-is
+   clickItem(view, 0);
+   QVERIFY(desktop->_act_email->isEnabled());
+   desktop->_act_email->trigger();
+
+   // The file should be on the clipboard as a URL, ready to paste into
+   // the compose window as an attachment
+   const QMimeData *mime = QApplication::clipboard()->mimeData();
+   QVERIFY(mime);
+   QVERIFY(mime->hasUrls());
+   QCOMPARE(mime->urls().size(), 1);
+
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   QCOMPARE(mime->urls()[0].toLocalFile(),
+            model->data(src_ind, Desktopmodel::Role_pathname).toString());
+
+   // The original file must still exist for the email program to use
+   QVERIFY(QFile::exists(mime->urls()[0].toLocalFile()));
+
+   // A Gmail compose window should have been requested
+   QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
+
+   QTest::qWait(350);
+}
+
+void TestDesktopUi::testEmailMultipleStacksZips()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+   Desktopmodel::url_capture = &s_opened_url;
+   s_opened_url = QUrl();
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Email both stacks: they should be packed into a single zip
+   view->setSelectionRange(0, 2);
+   desktop->_act_email->trigger();
+
+   const QMimeData *mime = QApplication::clipboard()->mimeData();
+   QVERIFY(mime);
+   QVERIFY(mime->hasUrls());
+   QCOMPARE(mime->urls().size(), 1);
+
+   QString zip = mime->urls()[0].toLocalFile();
+   QVERIFY(zip.endsWith(".zip"));
+   QVERIFY(QFile::exists(zip));
+   QVERIFY(QFileInfo(zip).size() > 0);
+
+   QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
+
+   QFile::remove(zip);
+}
+
+void TestDesktopUi::testEmailAsPdfConverts()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+   Desktopmodel::url_capture = &s_opened_url;
+   s_opened_url = QUrl();
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Email the max stack as PDF: a converted temporary file is sent
+   clickItem(view, 0);
+   desktop->_act_email_pdf->trigger();
+
+   const QMimeData *mime = QApplication::clipboard()->mimeData();
+   QVERIFY(mime);
+   QVERIFY(mime->hasUrls());
+   QCOMPARE(mime->urls().size(), 1);
+
+   QString pdf = mime->urls()[0].toLocalFile();
+   QVERIFY(pdf.endsWith(".pdf"));
+   QVERIFY(QFile::exists(pdf));
+
+   // Check it really is a PDF
+   QFile fil(pdf);
+   QVERIFY(fil.open(QIODevice::ReadOnly));
+   QCOMPARE(fil.read(4), QByteArray("%PDF"));
+   fil.close();
+
+   QCOMPARE(s_opened_url.host(), QString("mail.google.com"));
+
+   QFile::remove(pdf);
+   QTest::qWait(350);
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -278,3 +278,22 @@ void TestDesktopUi::testStackNavigationWraps()
 /* URLs which the email operations would open in a browser are captured
    here instead, so tests never launch anything */
 static QUrl s_opened_url;
+
+void TestDesktopUi::testSelectAllAction()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   QVERIFY(!view->isSelection(Desktopview::SEL_at_least_one));
+
+   me.actionSelectall->trigger();
+
+   QModelIndexList sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 2);
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -7,6 +7,7 @@
 #include "desktopmodel.h"
 #include "desktopview.h"
 #include "desktopwidget.h"
+#include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
 #include "pagewidget.h"
@@ -449,5 +450,59 @@ void TestDesktopUi::testSearchEscapeReturns()
    // Pressing Escape in the view returns to the normal directory view
    QTest::keyClick(view, Qt::Key_Escape);
    QVERIFY(!desktop->_toolbar->searchEnabled());
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+}
+
+void TestDesktopUi::testDirTreeNavigation()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   // Put a stack in a subdirectory so there is something to show there
+   auto path = setupRepo();
+   QVERIFY(QFile::copy(testSrc + "/testfile.max",
+                       path + "/main/one/deepfile.max"));
+
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   Desktopview *view = desktop->getView();
+
+   // The repo root shows its two stacks
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+
+   // Click the subdirectory in the folder tree
+   QModelIndex dir_ind = desktop->findDir(path + "/main/one");
+   QVERIFY(dir_ind.isValid());
+   Dirview *dir = desktop->_dir;
+   dir->scrollTo(dir_ind);
+   QRect rect = dir->visualRect(dir_ind);
+   QVERIFY(rect.isValid());
+   QTest::mouseClick(dir->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     rect.center());
+
+   // The desktop should now show the stack in that directory
+   QCOMPARE(desktop->getSelectedPath(), QString(path + "/main/one"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   QCOMPARE(view->model()->data(itemIndex(view, 0),
+                                Qt::DisplayRole).toString(), "deepfile");
+
+   // Clicking the repo root shows the original stacks again
+   QModelIndex root_ind = desktop->findDir(path);
+   QVERIFY(root_ind.isValid());
+   dir->scrollTo(root_ind);
+   QTest::mouseClick(dir->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     dir->visualRect(root_ind).center());
    QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
 }

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1,0 +1,105 @@
+#include <QtTest/QtTest>
+
+#include "test.h"
+
+#include "desktopmodel.h"
+#include "desktopview.h"
+#include "desktopwidget.h"
+#include "mainwindow.h"
+#include "test_desktopui.h"
+
+void TestDesktopUi::setupShown(Mainwindow *me, Desktopmodel *&model,
+                               QModelIndex &repo_ind)
+{
+   auto path = setupRepo();
+   Desktopwidget *desktop = me->getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   // Show the window so that items have real positions and can be
+   // clicked, as a user would
+   me->resize(1024, 768);
+   me->show();
+   QVERIFY(QTest::qWaitForWindowExposed(me));
+   QTest::qWait(50);
+}
+
+QModelIndex TestDesktopUi::itemIndex(Desktopview *view, int row)
+{
+   return view->model()->index(row, 0, view->rootIndex());
+}
+
+void TestDesktopUi::clickItem(Desktopview *view, int row,
+                              Qt::KeyboardModifiers modifiers)
+{
+   QModelIndex ind = itemIndex(view, row);
+   QVERIFY(ind.isValid());
+
+   QRect rect = view->visualRect(ind);
+   QVERIFY(rect.isValid());
+   QTest::mouseClick(view->viewport(), Qt::LeftButton, modifiers,
+                     rect.center());
+}
+
+void TestDesktopUi::testClickSelectsStack()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // Nothing should be selected to start with
+   QVERIFY(!view->isSelection(Desktopview::SEL_at_least_one));
+
+   // Click the first stack and check it becomes the selection
+   clickItem(view, 0);
+   QModelIndexList sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(), "testfile");
+
+   // Clicking on empty space should deselect everything
+   QPoint space(view->viewport()->width() - 5,
+                view->viewport()->height() - 5);
+   QVERIFY(!view->indexAt(space).isValid());
+   QTest::mouseClick(view->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     space);
+   QVERIFY(!view->isSelection(Desktopview::SEL_at_least_one));
+
+   // Let the preview timer fire so it doesn't outlive the window
+   QTest::qWait(350);
+}
+
+void TestDesktopUi::testCtrlClickMultiSelect()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   clickItem(view, 0);
+   clickItem(view, 1, Qt::ControlModifier);
+
+   QModelIndexList sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 2);
+
+   // Ctrl-clicking the first again should deselect just that one
+   clickItem(view, 0, Qt::ControlModifier);
+   sel = view->getSelectedListSource();
+   QCOMPARE(sel.size(), 1);
+   QCOMPARE(model->data(sel[0], Qt::DisplayRole).toString(),
+            "testpdf.pdf");
+
+   QTest::qWait(350);
+}

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -454,6 +454,52 @@ void TestDesktopUi::testSearchEscapeReturns()
    QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
 }
 
+void TestDesktopUi::testRepeatedSearch()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   // Add a stack in a subdirectory so a search can find it
+   auto path = setupRepo();
+   QVERIFY(QFile::copy(testSrc + "/testfile.max",
+                       path + "/main/one/findme.max"));
+
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   Desktopview *view = desktop->getView();
+
+   /* the first search creates the search desk; later searches re-use
+      it. Each must show exactly the matching stacks, with no phantom
+      or stale rows */
+   desktop->startSearch(path, "testpdf");
+   desktop->specialView("Showing the results of folder search");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+
+   desktop->startSearch(path, "test");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 2);
+
+   desktop->startSearch(path, "findme");
+   QCOMPARE(view->model()->rowCount(view->rootIndex()), 1);
+   QCOMPARE(view->model()->data(itemIndex(view, 0),
+                                Qt::DisplayRole).toString(), "findme");
+
+   // Escape still returns to the normal directory view
+   QTest::keyClick(view, Qt::Key_Escape);
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+}
+
 void TestDesktopUi::testDirTreeNavigation()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -6,6 +6,7 @@
 #include "test.h"
 
 #include "desktopmodel.h"
+#include "desktopundo.h"
 #include "desktopview.h"
 #include "desktopwidget.h"
 #include "dirmodel.h"
@@ -740,4 +741,44 @@ void TestDesktopUi::testScanIntoStack()
    QString pathname =
       model->data(new_ind, Desktopmodel::Role_pathname).toString();
    QVERIFY(QFile::exists(pathname));
+}
+
+void TestDesktopUi::testRepositoryAddRemoveUndo()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Dirmodel *dirmodel = desktop->getDirmodel();
+
+   // Add a second repository, as the directory-tree context menu does
+   QTemporaryDir extra;
+   QVERIFY(extra.isValid());
+   int before = dirmodel->rowCount(QModelIndex());
+   model->addRepository(extra.path());
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before + 1);
+
+   /* the only undoable command so far should be the repository add;
+      programmatic selection changes must not create undo entries */
+   Desktopundostack *stk = model->getUndoStack();
+   QCOMPARE(stk->count(), 1);
+
+   // Undo removes it again; redo brings it back
+   me.actionUndo->trigger();
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before);
+   me.actionRedo->trigger();
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before + 1);
+
+   // Removing the repository is also undoable
+   model->removeRepository(extra.path());
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before);
+   me.actionUndo->trigger();
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before + 1);
+
+   // Take it out again so the settings are left unchanged
+   me.actionRedo->trigger();
+   QCOMPARE(dirmodel->rowCount(QModelIndex()), before);
 }

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -51,6 +51,12 @@ private slots:
    //! Test typing in the filter box filters stacks, and cancel restores
    void testFilterStacks();
 
+   //! Test searching folders for a stack and locating its folder
+   void testSearchAndLocate();
+
+   //! Test that the Escape key leaves search mode
+   void testSearchEscapeReturns();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -27,6 +27,12 @@ private slots:
    //! Test that ctrl-click adds a second stack to the selection
    void testCtrlClickMultiSelect();
 
+   //! Test that double-clicking a stack opens it in the page view
+   void testDoubleClickOpensStack();
+
+   //! Test the swap-view action returns from page view to the desktop
+   void testSwapViewAction();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -84,6 +84,9 @@ private slots:
    //! Test renaming a stack by typing into the item editor
    void testRenameStackViaEditor();
 
+   //! Test the year/month directory filter hides other years
+   void testDirFilterHidesOtherYears();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -45,6 +45,9 @@ private slots:
    //! Test the Edit->Select-all menu action selects every stack
    void testSelectAllAction();
 
+   //! Test combining stacks with the stack action, then menu undo/redo
+   void testStackAndMenuUndo();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -57,6 +57,9 @@ private slots:
    //! Test that the Escape key leaves search mode
    void testSearchEscapeReturns();
 
+   //! Test changing directory by clicking a folder in the tree
+   void testDirTreeNavigation();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -57,6 +57,9 @@ private slots:
    //! Test that the Escape key leaves search mode
    void testSearchEscapeReturns();
 
+   //! Test that repeated searches show the right results each time
+   void testRepeatedSearch();
+
    //! Test changing directory by clicking a folder in the tree
    void testDirTreeNavigation();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -1,0 +1,48 @@
+#ifndef TEST_DESKTOPUI_H
+#define TEST_DESKTOPUI_H
+
+#include <QObject>
+
+#include "suite.h"
+
+class Desktopmodel;
+class Desktopview;
+class Mainwindow;
+class QModelIndex;
+
+/** Tests which drive the desktop through real UI events (mouse clicks,
+    key presses and QAction triggers) rather than calling the underlying
+    operations directly. These check that what the user does with the
+    mouse and keyboard produces the behaviour they see on screen */
+class TestDesktopUi: public Suite
+{
+   Q_OBJECT
+public:
+   using Suite::Suite;
+
+private slots:
+   //! Test that clicking a stack selects it and clicking space deselects
+   void testClickSelectsStack();
+
+   //! Test that ctrl-click adds a second stack to the selection
+   void testCtrlClickMultiSelect();
+
+private:
+   /** Set up a repo in a shown Mainwindow, returning the model and the
+       index of the repo root
+
+      \param me        Mainwindow to use
+      \param model     Returns the desktop model
+      \param repo_ind  Returns the source-model index of the repo root */
+   void setupShown(Mainwindow *me, Desktopmodel *&model,
+                   QModelIndex &repo_ind);
+
+   //! Get the proxy index of the desktop item in the given row
+   QModelIndex itemIndex(Desktopview *view, int row);
+
+   //! Click the centre of the given desktop item
+   void clickItem(Desktopview *view, int row,
+                  Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+};
+
+#endif // TEST_DESKTOPUI_H

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -78,6 +78,9 @@ private slots:
    //! Test scanning into a new stack with the simulated scanner
    void testScanIntoStack();
 
+   //! Test adding and removing a repository, with undo and redo
+   void testRepositoryAddRemoveUndo();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -81,6 +81,9 @@ private slots:
    //! Test adding and removing a repository, with undo and redo
    void testRepositoryAddRemoveUndo();
 
+   //! Test renaming a stack by typing into the item editor
+   void testRenameStackViaEditor();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -69,6 +69,9 @@ private slots:
    //! Test emailing a stack as PDF converts it first
    void testEmailAsPdfConverts();
 
+   //! Test dragging a stack onto a folder in the tree moves it there
+   void testDragDropToFolder();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -48,6 +48,9 @@ private slots:
    //! Test combining stacks with the stack action, then menu undo/redo
    void testStackAndMenuUndo();
 
+   //! Test typing in the filter box filters stacks, and cancel restores
+   void testFilterStacks();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -33,6 +33,15 @@ private slots:
    //! Test the swap-view action returns from page view to the desktop
    void testSwapViewAction();
 
+   //! Test moving between stacks with the toolbar prev/next buttons
+   void testToolbarStackNavigation();
+
+   //! Test flipping pages with the toolbar page prev/next buttons
+   void testToolbarPageNavigation();
+
+   //! Test stack navigation wraps at either end
+   void testStackNavigationWraps();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -42,6 +42,9 @@ private slots:
    //! Test stack navigation wraps at either end
    void testStackNavigationWraps();
 
+   //! Test the Edit->Select-all menu action selects every stack
+   void testSelectAllAction();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -72,6 +72,9 @@ private slots:
    //! Test dragging a stack onto a folder in the tree moves it there
    void testDragDropToFolder();
 
+   //! Test importing files from a directory and moving one in
+   void testImportFlow();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -60,6 +60,15 @@ private slots:
    //! Test changing directory by clicking a folder in the tree
    void testDirTreeNavigation();
 
+   //! Test emailing a stack puts it on the clipboard and opens Gmail
+   void testEmailSingleStack();
+
+   //! Test emailing several stacks packs them into a zip first
+   void testEmailMultipleStacksZips();
+
+   //! Test emailing a stack as PDF converts it first
+   void testEmailAsPdfConverts();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -75,6 +75,9 @@ private slots:
    //! Test importing files from a directory and moving one in
    void testImportFlow();
 
+   //! Test scanning into a new stack with the simulated scanner
+   void testScanIntoStack();
+
 private:
    /** Set up a repo in a shown Mainwindow, returning the model and the
        index of the repo root

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -208,8 +208,15 @@ void TestDirmodel::testRemoteRepository()
    QCOMPARE(model.data(root, Qt::DisplayRole).toString(),
             QString("photos"));
 
-   /* Expanding the root populates from the server. */
-   QCOMPARE(model.rowCount(root), 2);
+   /* First rowCount triggers async populate; the placeholder
+    * "Loading…" child appears immediately. */
+   QCOMPARE(model.rowCount(root), 1);
+   QCOMPARE(model.data(model.index(0, 0, root), Qt::DisplayRole).toString(),
+            QString("Loading…"));
+
+   /* Spin the event loop until the async response arrives and the
+    * placeholder is replaced by the real children. */
+   QTRY_COMPARE(model.rowCount(root), 2);
    QStringList names;
    for (int i = 0; i < model.rowCount(root); i++)
       names << model.data(model.index(i, 0, root),

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -4,6 +4,7 @@
 #include "utils.h"
 
 #include "dirmodel.h"
+#include "searchserver.h"
 #include "test_dirmodel.h"
 
 void TestDirmodel::testBase()
@@ -175,6 +176,48 @@ void TestDirmodel::testBackendErrorSurfacing()
    QCOMPARE(spy.count(), 2);
 
    delete model;
+}
+
+void TestDirmodel::testRemoteRepository()
+{
+   /* Spin up a real SearchServer pointing at a freshly seeded
+    * repository, then ask a fresh Dirmodel to consume it remotely.
+    * The model's only knowledge of the data is the HTTP URL. */
+   QTemporaryDir serverDir;
+   QVERIFY(serverDir.isValid());
+   QString repoRoot = serverDir.path() + "/photos";
+   QVERIFY(QDir().mkpath(repoRoot));
+   QVERIFY(QDir().mkpath(repoRoot + "/2025"));
+   QVERIFY(QDir().mkpath(repoRoot + "/2026"));
+
+   const quint16 port = 9877;
+   SearchServer server(repoRoot, port);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   Dirmodel model;
+   QString err;
+   QVERIFY2(model.addRemoteRepository(
+                QUrl(QString("http://localhost:%1").arg(port)), &err),
+            qPrintable(err));
+
+   /* The server has one repository — "photos" — and it should now
+    * appear as a top-level node. */
+   QCOMPARE(model.rowCount(QModelIndex()), 1);
+   QModelIndex root = model.index(0, 0, QModelIndex());
+   QCOMPARE(model.data(root, Qt::DisplayRole).toString(),
+            QString("photos"));
+
+   /* Expanding the root populates from the server. */
+   QCOMPARE(model.rowCount(root), 2);
+   QStringList names;
+   for (int i = 0; i < model.rowCount(root); i++)
+      names << model.data(model.index(i, 0, root),
+                          Qt::DisplayRole).toString();
+   names.sort();
+   QCOMPARE(names, QStringList({"2025", "2026"}));
+
+   server.stop();
 }
 
 void TestDirmodel::testAddFiles()

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -227,6 +227,126 @@ void TestDirmodel::testRemoteRepository()
    server.stop();
 }
 
+
+void TestDirmodel::testRemoteRepositoryExpandChild()
+{
+   /* The reported bug: expanding a top-level remote repo fires
+    * /browse, but expanding a child sub-folder doesn't fire a
+    * second /browse — counters stay flat.  Recreate the scenario
+    * end-to-end: seed nested directories on the server, walk down
+    * one level at a time, and confirm a /browse request fires at
+    * every level. */
+   QTemporaryDir serverDir;
+   QVERIFY(serverDir.isValid());
+   QString repoRoot = serverDir.path() + "/photos";
+   QVERIFY(QDir().mkpath(repoRoot + "/2025/a"));
+   QVERIFY(QDir().mkpath(repoRoot + "/2025/b"));
+   QVERIFY(QDir().mkpath(repoRoot + "/2026"));
+
+   const quint16 port = 9878;
+   SearchServer server(repoRoot, port);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   Dirmodel model;
+   QString err;
+   QVERIFY2(model.addRemoteRepository(
+                QUrl(QString("http://localhost:%1").arg(port)), &err),
+            qPrintable(err));
+
+   /* Level 0: repo. */
+   QModelIndex repo = model.index(0, 0, QModelIndex());
+   QVERIFY(repo.isValid());
+
+   /* Level 1: expand the repo.  The first rowCount inserts a
+    * "Loading…" placeholder while the async /browse runs. */
+   QCOMPARE(model.rowCount(repo), 1);
+   QTRY_COMPARE(model.rowCount(repo), 2);  // 2025 + 2026
+
+   /* Find the "2025" child. */
+   QModelIndex y2025;
+   for (int i = 0; i < model.rowCount(repo); i++) {
+      QModelIndex idx = model.index(i, 0, repo);
+      if (model.data(idx, Qt::DisplayRole).toString() == "2025") {
+         y2025 = idx;
+         break;
+      }
+   }
+   QVERIFY(y2025.isValid());
+
+   /* Level 2: expand "2025".  This is the case the user reports
+    * silently producing no traffic.  Same pattern: first rowCount
+    * is the placeholder, then async fills in the real two children
+    * ("a" and "b"). */
+   QCOMPARE(model.rowCount(y2025), 1);   // placeholder
+   QTRY_COMPARE(model.rowCount(y2025), 2);  // a + b
+
+   QStringList names;
+   for (int i = 0; i < model.rowCount(y2025); i++)
+      names << model.data(model.index(i, 0, y2025),
+                          Qt::DisplayRole).toString();
+   names.sort();
+   QCOMPARE(names, QStringList({"a", "b"}));
+
+   server.stop();
+}
+
+
+void TestDirmodel::testRemoteRepositoryExpandChildThroughProxy()
+{
+   /* Same shape as testRemoteRepositoryExpandChild but every model
+    * access goes through a Dirproxy, since that's the path the GUI
+    * uses.  Use folder names that don't trip Dirproxy's year/month
+    * filter (it's on by default) so the test exercises the
+    * expansion mechanics rather than the filtering rules. */
+   QTemporaryDir serverDir;
+   QVERIFY(serverDir.isValid());
+   QString repoRoot = serverDir.path() + "/papers";
+   QVERIFY(QDir().mkpath(repoRoot + "/banks/Bank-Direct"));
+   QVERIFY(QDir().mkpath(repoRoot + "/banks/Bradley"));
+
+   const quint16 port = 9879;
+   SearchServer server(repoRoot, port);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   Dirmodel model;
+   QString err;
+   QVERIFY2(model.addRemoteRepository(
+                QUrl(QString("http://localhost:%1").arg(port)), &err),
+            qPrintable(err));
+
+   Dirproxy proxy;
+   proxy.setSourceModel(&model);
+
+   /* Level 0: the proxy sees the single repo. */
+   QCOMPARE(proxy.rowCount(QModelIndex()), 1);
+   QModelIndex repo = proxy.index(0, 0, QModelIndex());
+   QVERIFY(repo.isValid());
+
+   /* Level 1: expand the repo via the proxy.  Wait for the async
+    * to swap the placeholder for the real "banks" child. */
+   QCOMPARE(proxy.rowCount(repo), 1);   // placeholder
+   QTRY_COMPARE(proxy.data(proxy.index(0, 0, repo),
+                           Qt::DisplayRole).toString(),
+                QString("banks"));
+
+   QModelIndex banks = proxy.index(0, 0, repo);
+   QVERIFY(banks.isValid());
+
+   /* Level 2: expand "banks" via the proxy.  If the proxy short-
+    * circuits and doesn't ask the source, this never reaches
+    * populateNode and no /browse fires — the bug.  Wait for the
+    * real children to swap in. */
+   QCOMPARE(proxy.rowCount(banks), 1);   // placeholder
+   QTRY_VERIFY(proxy.data(proxy.index(0, 0, banks),
+                          Qt::DisplayRole).toString() != "Loading…");
+   QCOMPARE(proxy.rowCount(banks), 2);  // Bank-Direct + Bradley
+
+   server.stop();
+}
+
+
 void TestDirmodel::testAddFiles()
 {
    Dirmodel *model;

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -7,6 +7,10 @@
 #include "remotebackend.h"
 #include "searchserver.h"
 #include "test_dirmodel.h"
+#include "../userstore.h"
+
+#include <QScopeGuard>
+#include <QStandardPaths>
 
 void TestDirmodel::testBase()
 {
@@ -395,6 +399,82 @@ void TestDirmodel::testRemoteRootBackendLookup()
             qPrintable(QString("no backend found for rootPath=%1")
                            .arg(rootPath)));
    QVERIFY(dynamic_cast<RemoteBackend *>(backend) != nullptr);
+
+   server.stop();
+}
+
+
+void TestDirmodel::testLoginToServerCachesToken()
+{
+   /* End-to-end check that the GUI's login-on-401 flow has all the
+    * pieces: an auth-required server rejects an unauthenticated
+    * addRemoteRepository, loginToServer with the right credentials
+    * caches the token, and a follow-up addRemoteRepository
+    * succeeds because the cached token is picked up. */
+   QStandardPaths::setTestModeEnabled(true);
+   auto restoreStdPaths = qScopeGuard([] {
+      QStandardPaths::setTestModeEnabled(false);
+   });
+   QString cfgRoot = QStandardPaths::writableLocation(
+                         QStandardPaths::GenericConfigLocation);
+   QFile::remove(cfgRoot + "/paperman-server/users.json");
+   /* Also wipe any token left over from another test run. */
+   QDir(cfgRoot + "/paperman").removeRecursively();
+
+   {
+      UserStore store;
+      QVERIFY(store.addUser("alice", "letmein"));
+   }
+
+   QTemporaryDir serverDir;
+   QVERIFY(serverDir.isValid());
+   QString repoRoot = serverDir.path() + "/papers";
+   QVERIFY(QDir().mkpath(repoRoot + "/banks"));
+
+   const quint16 port = 9881;
+   SearchServer server(repoRoot, port);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   QUrl url(QString("http://localhost:%1").arg(port));
+
+   /* Step 1: unauthenticated addRemoteRepository fails with an
+    * error that the auth-detector recognises. */
+   {
+      Dirmodel m1;
+      QString err;
+      QVERIFY(!m1.addRemoteRepository(url, &err));
+      QVERIFY2(err.contains("401")
+                   || err.contains("authentication", Qt::CaseInsensitive)
+                   || err.contains("credentials", Qt::CaseInsensitive),
+               qPrintable(err));
+   }
+
+   /* Step 2: loginToServer with correct credentials succeeds and
+    * caches the token. */
+   {
+      Dirmodel m2;
+      QString err;
+      QVERIFY2(m2.loginToServer(url, "alice", "letmein", &err),
+               qPrintable(err));
+   }
+
+   /* Step 3: follow-up addRemoteRepository on a fresh Dirmodel
+    * picks up the cached token and succeeds. */
+   {
+      Dirmodel m3;
+      QString err;
+      QVERIFY2(m3.addRemoteRepository(url, &err), qPrintable(err));
+      QCOMPARE(m3.rowCount(QModelIndex()), 1);
+   }
+
+   /* Bad credentials are rejected. */
+   {
+      Dirmodel m4;
+      QString err;
+      QVERIFY(!m4.loginToServer(url, "alice", "wrong", &err));
+      QVERIFY(!err.isEmpty());
+   }
 
    server.stop();
 }

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -136,6 +136,47 @@ void TestDirmodel::testRefreshKeepsSubdirs()
    QCOMPARE(after, QStringList({"a", "b"}));
 }
 
+void TestDirmodel::testBackendErrorSurfacing()
+{
+   /* Point the model at a directory that doesn't exist on disk; the
+    * Backend should reject the populate, Dirmodel should mark the
+    * node as failed (without trapping itself in a populated-with-no-
+    * children state), and emit backendError. */
+   Dirmodel *model = new Dirmodel();
+   QString bogus = _tempDir->path() + "/never-existed";
+   /* addDir returns false for an invalid path even with ignore_error=true,
+    * but the Diritem is still appended.  That's the scenario we want. */
+   model->addDir(bogus, /*ignore_error=*/true);
+   QCOMPARE(model->rowCount(QModelIndex()), 1);
+
+   QSignalSpy spy(model, &Dirmodel::backendError);
+
+   QModelIndex root = model->index(0, 0, QModelIndex());
+   QVERIFY(root.isValid());
+
+   /* rowCount triggers populateNode(); the underlying call fails. */
+   QCOMPARE(model->rowCount(root), 0);
+
+   /* The failure was surfaced as a signal and a tooltip. */
+   QCOMPARE(spy.count(), 1);
+   QString tooltip = model->data(root, Qt::ToolTipRole).toString();
+   QVERIFY2(tooltip.contains("Could not list contents"),
+            qPrintable(tooltip));
+
+   /* A second rowCount() does NOT trigger a retry — the failure
+    * state is sticky until refresh().  Use spy.count() to verify
+    * no additional signal was emitted. */
+   (void)model->rowCount(root);
+   QCOMPARE(spy.count(), 1);
+
+   /* refresh() clears the failure so a subsequent populate retries. */
+   model->refresh(root);
+   QCOMPARE(model->rowCount(root), 0);
+   QCOMPARE(spy.count(), 2);
+
+   delete model;
+}
+
 void TestDirmodel::testAddFiles()
 {
    Dirmodel *model;

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -4,6 +4,7 @@
 #include "utils.h"
 
 #include "dirmodel.h"
+#include "remotebackend.h"
 #include "searchserver.h"
 #include "test_dirmodel.h"
 
@@ -348,6 +349,52 @@ void TestDirmodel::testRemoteRepositoryExpandChildThroughProxy()
    QTRY_VERIFY(proxy.data(proxy.index(0, 0, banks),
                           Qt::DisplayRole).toString() != "Loading…");
    QCOMPARE(proxy.rowCount(banks), 2);  // Bank-Direct + Bradley
+
+   server.stop();
+}
+
+
+void TestDirmodel::testRemoteRootBackendLookup()
+{
+   /* Regression test for "dir not found" on remote folder selection:
+    *
+    * Desktopmodel::showDir uses the rootPath it receives (which
+    * originates as the FilePathRole of the top-level repo index)
+    * to look the backend up via Dirmodel::backendForRoot.  That
+    * lookup matches against Diritem::dir().  If addRemoteRepository
+    * stores the two as different strings, the lookup returns null,
+    * Desk runs without a backend, and falls through to a QDir scan
+    * on a path that doesn't exist locally. */
+   QTemporaryDir serverDir;
+   QVERIFY(serverDir.isValid());
+   QString repoRoot = serverDir.path() + "/papers";
+   QVERIFY(QDir().mkpath(repoRoot + "/banks"));
+
+   const quint16 port = 9880;
+   SearchServer server(repoRoot, port);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   Dirmodel model;
+   QString err;
+   QVERIFY2(model.addRemoteRepository(
+                QUrl(QString("http://localhost:%1").arg(port)), &err),
+            qPrintable(err));
+
+   /* The string the model returns for the root index's FilePathRole
+    * is what Desktopmodel will turn around and pass to
+    * backendForRoot.  They have to agree. */
+   QModelIndex root = model.index(0, 0, QModelIndex());
+   QVERIFY(root.isValid());
+   QString rootPath = model.data(root, Dirmodel::FilePathRole)
+                          .toString();
+   QVERIFY2(!rootPath.isEmpty(), "FilePathRole returned empty string");
+
+   Backend *backend = model.backendForRoot(rootPath);
+   QVERIFY2(backend != nullptr,
+            qPrintable(QString("no backend found for rootPath=%1")
+                           .arg(rootPath)));
+   QVERIFY(dynamic_cast<RemoteBackend *>(backend) != nullptr);
 
    server.stop();
 }

--- a/test/test_dirmodel.cpp
+++ b/test/test_dirmodel.cpp
@@ -202,11 +202,17 @@ void TestDirmodel::testRemoteRepository()
             qPrintable(err));
 
    /* The server has one repository — "photos" — and it should now
-    * appear as a top-level node. */
+    * appear as a top-level node.  Remote roots carry the server's
+    * authority in the display name so they're distinguishable from
+    * a same-named local repo (a common case when the same
+    * filesystem is also served over HTTP). */
    QCOMPARE(model.rowCount(QModelIndex()), 1);
    QModelIndex root = model.index(0, 0, QModelIndex());
-   QCOMPARE(model.data(root, Qt::DisplayRole).toString(),
-            QString("photos"));
+   QString display = model.data(root, Qt::DisplayRole).toString();
+   QVERIFY2(display.startsWith("photos ("),
+            qPrintable(display));
+   QVERIFY2(display.contains(QString::number(port)),
+            qPrintable(display));
 
    /* First rowCount triggers async populate; the placeholder
     * "Loading…" child appears immediately. */

--- a/test/test_dirmodel.h
+++ b/test/test_dirmodel.h
@@ -42,6 +42,12 @@ private slots:
    //! the Dirproxy the GUI uses, to catch any proxy-caching surprises.
    void testRemoteRepositoryExpandChildThroughProxy();
 
+   //! The FilePathRole exposed for a remote root must match the key
+   //! Dirmodel::backendForRoot uses (i.e. Diritem::dir()).  If they
+   //! diverge, Desktopmodel::showDir can't find the backend and Desk
+   //! falls back to QDir, producing "dir not found" on selection.
+   void testRemoteRootBackendLookup();
+
 private:
    /**
     * @brief  Set up a new Dirmodel with test data

--- a/test/test_dirmodel.h
+++ b/test/test_dirmodel.h
@@ -32,6 +32,9 @@ private slots:
    //! Backend failure during populate is surfaced and can be retried
    void testBackendErrorSurfacing();
 
+   //! addRemoteRepository wires a Dirmodel to a live paperman-server
+   void testRemoteRepository();
+
 private:
    /**
     * @brief  Set up a new Dirmodel with test data

--- a/test/test_dirmodel.h
+++ b/test/test_dirmodel.h
@@ -48,6 +48,11 @@ private slots:
    //! falls back to QDir, producing "dir not found" on selection.
    void testRemoteRootBackendLookup();
 
+   //! Dirmodel::loginToServer caches a usable token: a follow-up
+   //! addRemoteRepository against an auth-required server succeeds
+   //! without further credentials.
+   void testLoginToServerCachesToken();
+
 private:
    /**
     * @brief  Set up a new Dirmodel with test data

--- a/test/test_dirmodel.h
+++ b/test/test_dirmodel.h
@@ -29,6 +29,9 @@ private slots:
    //! refresh() must not lose the directory's existing subdirectories
    void testRefreshKeepsSubdirs();
 
+   //! Backend failure during populate is surfaced and can be retried
+   void testBackendErrorSurfacing();
+
 private:
    /**
     * @brief  Set up a new Dirmodel with test data

--- a/test/test_dirmodel.h
+++ b/test/test_dirmodel.h
@@ -35,6 +35,13 @@ private slots:
    //! addRemoteRepository wires a Dirmodel to a live paperman-server
    void testRemoteRepository();
 
+   //! Expanding a child node (not just the root) fires another /browse
+   void testRemoteRepositoryExpandChild();
+
+   //! Same as testRemoteRepositoryExpandChild but accessed through
+   //! the Dirproxy the GUI uses, to catch any proxy-caching surprises.
+   void testRemoteRepositoryExpandChildThroughProxy();
+
 private:
    /**
     * @brief  Set up a new Dirmodel with test data

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,0 +1,510 @@
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "err.h"
+#include "file.h"
+#include "filejpeg.h"
+#include "filemax.h"
+#include "fileother.h"
+#include "filepdf.h"
+
+#include "op.h"
+
+#include "test_file.h"
+
+QString TestFile::copyFixture(const QString &name, const QString &destDir)
+{
+   const QString src = testSrc + "/" + name;
+   const QString dst = destDir + "/" + name;
+   if (!QFile::copy(src, dst))
+      return QString();
+   return dst;
+}
+
+void TestFile::testTypeFromName()
+{
+   QCOMPARE(File::typeFromName("scan.max"), File::Type_max);
+   QCOMPARE(File::typeFromName("scan.MAX"), File::Type_max);
+   QCOMPARE(File::typeFromName("scan.pdf"), File::Type_pdf);
+   QCOMPARE(File::typeFromName("scan.PDF"), File::Type_pdf);
+   QCOMPARE(File::typeFromName("photo.jpg"), File::Type_jpeg);
+   QCOMPARE(File::typeFromName("photo.JPEG"), File::Type_jpeg);
+   QCOMPARE(File::typeFromName("scan.tiff"), File::Type_other);
+   QCOMPARE(File::typeFromName("noext"), File::Type_other);
+   QCOMPARE(File::typeFromName("/path/with/dots.in.dir/scan.pdf"),
+            File::Type_pdf);
+}
+
+void TestFile::testTypeNameAndExt()
+{
+   // Names returned for the display layer
+   QCOMPARE(File::typeName(File::Type_other), QStringLiteral("Other"));
+   QCOMPARE(File::typeName(File::Type_max), QStringLiteral("Max"));
+   QCOMPARE(File::typeName(File::Type_pdf), QStringLiteral("PDF"));
+   QCOMPARE(File::typeName(File::Type_jpeg), QStringLiteral("JPEG"));
+
+   // Type_other has no extension; the other three round-trip through
+   // typeFromName
+   QCOMPARE(File::typeExt(File::Type_other), QString());
+   QCOMPARE(File::typeExt(File::Type_max), QStringLiteral(".max"));
+   QCOMPARE(File::typeExt(File::Type_pdf), QStringLiteral(".pdf"));
+   QCOMPARE(File::typeExt(File::Type_jpeg), QStringLiteral(".jpg"));
+
+   for (int t = File::Type_max; t < File::Type_count; t++) {
+      File::e_type type = static_cast<File::e_type>(t);
+      QString name = "x" + File::typeExt(type);
+      QCOMPARE(File::typeFromName(name), type);
+   }
+}
+
+void TestFile::testEnvNames()
+{
+   for (int i = 0; i < File::Env_count; i++) {
+      File::e_env env = static_cast<File::e_env>(i);
+      QString name = File::envToName(env);
+      QVERIFY(!name.isEmpty());
+      QCOMPARE(File::envFromName(name), env);
+   }
+   QCOMPARE(File::envFromName("not-a-real-env"), File::Env_count);
+}
+
+void TestFile::testPageNumberCodec()
+{
+   QString base, ext;
+   int page = -1;
+
+   // _p1 maps to page 0 (codec is 1-based on disk, 0-based in memory)
+   QVERIFY(File::decodePageNumber("scan_p1.max", base, page, ext));
+   QCOMPARE(base, QStringLiteral("scan"));
+   QCOMPARE(page, 0);
+   QCOMPARE(ext, QStringLiteral("max"));
+
+   QVERIFY(File::decodePageNumber("scan_p42.pdf", base, page, ext));
+   QCOMPARE(base, QStringLiteral("scan"));
+   QCOMPARE(page, 41);
+   QCOMPARE(ext, QStringLiteral("pdf"));
+
+   // No _pN marker
+   QVERIFY(!File::decodePageNumber("scan.max", base, page, ext));
+
+   // Out-of-range page numbers are rejected
+   QVERIFY(!File::decodePageNumber("scan_p0.max", base, page, ext));
+   QVERIFY(!File::decodePageNumber("scan_p99999.max", base, page, ext));
+
+   // Round-trip via a File object (encode needs a type and base)
+   File *f = File::createFile("/tmp", "round_p1.pdf", nullptr, File::Type_pdf);
+   QVERIFY(f);
+   QCOMPARE(f->encodePageNumber("round", 0), QStringLiteral("round_p1.pdf"));
+   QCOMPARE(f->encodePageNumber("round", 41), QStringLiteral("round_p42.pdf"));
+   delete f;
+}
+
+void TestFile::testExtMatchesType()
+{
+   File *pdf = File::createFile("/tmp", "x.pdf", nullptr, File::Type_pdf);
+   QVERIFY(pdf);
+   QVERIFY(pdf->extMatchesType("pdf"));
+   QVERIFY(pdf->extMatchesType("PDF"));
+   QVERIFY(!pdf->extMatchesType("max"));
+   delete pdf;
+
+   File *jpg = File::createFile("/tmp", "x.jpg", nullptr, File::Type_jpeg);
+   QVERIFY(jpg);
+   QVERIFY(jpg->extMatchesType("jpg"));
+   QVERIFY(jpg->extMatchesType("jpeg"));
+   QVERIFY(!jpg->extMatchesType("pdf"));
+   delete jpg;
+}
+
+void TestFile::testNotImpl()
+{
+   err_info *err = File::not_impl();
+   QVERIFY(err);
+   QCOMPARE(err->errnum, ERR_no_available_for_this_file_type);
+}
+
+void TestFile::testCreateFileDispatch()
+{
+   const QString dir = QStringLiteral("/tmp/");
+
+   struct Case {
+      const char *fname;
+      File::e_type type;
+      const char *cls;
+   } cases[] = {
+      { "x.max",   File::Type_max,   "Filemax"   },
+      { "x.pdf",   File::Type_pdf,   "Filepdf"   },
+      { "x.jpg",   File::Type_jpeg,  "Filejpeg"  },
+      { "x.bin",   File::Type_other, "Fileother" },
+   };
+
+   for (const Case &c : cases) {
+      File *f = File::createFile(dir, c.fname, nullptr, c.type);
+      QVERIFY2(f, c.fname);
+      QCOMPARE(f->type(), c.type);
+      QCOMPARE(QString(f->metaObject()->className()), QString(c.cls));
+
+      QCOMPARE(f->filename(), QString(c.fname));
+      QCOMPARE(f->pathname(), dir + c.fname);
+      QCOMPARE(f->ext(), QString(".") + QFileInfo(c.fname).suffix());
+
+      // .max strips its extension to form the basename; the others keep it
+      QString expectBase = (c.type == File::Type_max)
+         ? QFileInfo(c.fname).completeBaseName()
+         : QString(c.fname);
+      QCOMPARE(f->basename(), expectBase);
+
+      delete f;
+   }
+}
+
+void TestFile::testFixtureMetadata()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   // --- testfile.max ---
+   {
+      QString path = copyFixture("testfile.max", tmp.path());
+      QVERIFY(!path.isEmpty());
+
+      Filemax *f = new Filemax(dir, "testfile.max", nullptr);
+      QVERIFY(f->load() == nullptr);
+      QVERIFY(f->pagecount() > 0);
+      // load() stat()s the file into the inherited _size; the chunk-based
+      // getSize() is only meaningful after the file's internal structures
+      // have been walked, so don't pin it here.
+      QCOMPARE(f->size(), int(QFileInfo(path).size()));
+
+      QString title;
+      QVERIFY(f->getPageTitle(0, title) == nullptr);
+      // Title is allowed to be empty, but the call must not error.
+
+      QString annot;
+      QVERIFY(f->getAnnot(File::Annot_author, annot) == nullptr);
+
+      delete f;
+   }
+
+   // --- testpdf.pdf ---
+   {
+      QString path = copyFixture("testpdf.pdf", tmp.path());
+      QVERIFY(!path.isEmpty());
+
+      Filepdf *f = new Filepdf(dir, "testpdf.pdf", nullptr);
+      QVERIFY(f->load() == nullptr);
+      QVERIFY(f->pagecount() >= 1);
+
+      QString annot;
+      QVERIFY(f->getAnnot(File::Annot_author, annot) == nullptr);
+
+      delete f;
+   }
+
+   // --- colour_plasma.jpg ---
+   {
+      QString path = copyFixture("colour_plasma.jpg", tmp.path());
+      QVERIFY(!path.isEmpty());
+
+      Filejpeg *f = new Filejpeg(dir, "colour_plasma.jpg", nullptr);
+      QVERIFY(f->load() == nullptr);
+      QCOMPARE(f->pagecount(), 1);
+      QVERIFY(f->getSize() > 0);
+
+      delete f;
+   }
+
+   // --- Fileother: any file we don't natively understand ---
+   {
+      QString path = dir + "stub.bin";
+      QFile fp(path);
+      QVERIFY(fp.open(QIODevice::WriteOnly));
+      fp.write("not really a real file");
+      fp.close();
+
+      Fileother *f = new Fileother(dir, "stub.bin", nullptr);
+      // Fileother::load returns not_impl unless _valid is already set,
+      // and exposes a fixed pagecount/size of 0 — pin both.
+      QCOMPARE(f->pagecount(), 1);
+      QCOMPARE(f->getSize(), 0);
+
+      QString annot;
+      QVERIFY(f->getAnnot(File::Annot_author, annot) == nullptr);
+      QVERIFY(annot.isEmpty());
+
+      delete f;
+   }
+}
+
+void TestFile::testEncodeDecode()
+{
+   File *f = File::createFile("/tmp/", "round.pdf", nullptr, File::Type_pdf);
+   QVERIFY(f);
+
+   f->setPos(QPoint(123, 456));
+   f->setPagenum(2);
+   f->setPreviewMaxsize(QSize(80, 100));
+   f->setTitleMaxsize(QSize(40, 12));
+   f->setPagenameMaxsize(QSize(50, 14));
+
+   QString encoded;
+   {
+      QTextStream out(&encoded);
+      f->encodeFile(out);
+   }
+   QVERIFY(encoded.contains("round.pdf="));
+
+   // Decode the comma-separated payload (everything after the '=')
+   int eq = encoded.indexOf('=');
+   QVERIFY(eq > 0);
+   QString line = encoded.mid(eq + 1).trimmed();
+
+   File *g = File::createFile("/tmp/", "round.pdf", nullptr, File::Type_pdf);
+   QVERIFY(g);
+   g->decodeFile(line, true);
+
+   QCOMPARE(g->pos(), QPoint(123, 456));
+   QCOMPARE(g->pagenum(), 2);
+   QCOMPARE(g->previewMaxsize(), QSize(80, 100));
+   QCOMPARE(g->titleMaxsize(), QSize(40, 12));
+   QCOMPARE(g->pagenameMaxsize(), QSize(50, 14));
+
+   delete f;
+   delete g;
+}
+
+void TestFile::testGetImage()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   // --- Filemax ---
+   {
+      QVERIFY(!copyFixture("testfile.max", tmp.path()).isEmpty());
+      Filemax *f = new Filemax(dir, "testfile.max", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QImage img;
+      QSize size, trueSize;
+      int bpp = 0;
+      QVERIFY(f->getImage(0, false, img, size, trueSize, bpp, false) == nullptr);
+      QVERIFY(!img.isNull());
+      QVERIFY(size.width() > 0 && size.height() > 0);
+      QCOMPARE(img.size(), trueSize);
+      QVERIFY(bpp == 1 || bpp == 8 || bpp == 24);
+      delete f;
+   }
+
+   // --- Filepdf ---
+   {
+      QVERIFY(!copyFixture("testpdf.pdf", tmp.path()).isEmpty());
+      Filepdf *f = new Filepdf(dir, "testpdf.pdf", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QImage img;
+      QSize size, trueSize;
+      int bpp = 0;
+      QVERIFY(f->getImage(0, false, img, size, trueSize, bpp, false) == nullptr);
+      QVERIFY(!img.isNull());
+      QVERIFY(size.width() > 0 && size.height() > 0);
+      QCOMPARE(img.size(), size);
+      QCOMPARE(size, trueSize);
+      delete f;
+   }
+
+   // --- Filejpeg colour ---
+   {
+      QVERIFY(!copyFixture("colour_plasma.jpg", tmp.path()).isEmpty());
+      Filejpeg *f = new Filejpeg(dir, "colour_plasma.jpg", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QImage img;
+      QSize size, trueSize;
+      int bpp = 0;
+      QVERIFY(f->getImage(0, false, img, size, trueSize, bpp, false) == nullptr);
+      QCOMPARE(img.size(), QSize(2400, 3300));
+      QCOMPARE(size, QSize(2400, 3300));
+      QCOMPARE(trueSize, size);
+      // Loaded as a colour image — Qt may pick 24 or 32 bpp
+      QVERIFY(bpp == 24 || bpp == 32);
+      delete f;
+   }
+
+   // --- Filejpeg greyscale ---
+   {
+      QVERIFY(!copyFixture("greyscale_gradient.jpg", tmp.path()).isEmpty());
+      Filejpeg *f = new Filejpeg(dir, "greyscale_gradient.jpg", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QImage img;
+      QSize size, trueSize;
+      int bpp = 0;
+      QVERIFY(f->getImage(0, false, img, size, trueSize, bpp, false) == nullptr);
+      QCOMPARE(img.size(), QSize(2400, 3300));
+      QVERIFY(bpp == 8 || bpp == 24 || bpp == 32);
+      delete f;
+   }
+
+   // --- Fileother: getImage is not implemented ---
+   {
+      QFile fp(dir + "stub.bin");
+      QVERIFY(fp.open(QIODevice::WriteOnly));
+      fp.write("hi");
+      fp.close();
+
+      Fileother *f = new Fileother(dir, "stub.bin", nullptr);
+      QImage img;
+      QSize size, trueSize;
+      int bpp = 0;
+      err_info *err = f->getImage(0, false, img, size, trueSize, bpp, false);
+      QVERIFY(err);
+      QCOMPARE(err->errnum, ERR_no_available_for_this_file_type);
+      delete f;
+   }
+}
+
+void TestFile::testGetPreviewPixmap()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   // Filejpeg downscales by /24
+   {
+      QVERIFY(!copyFixture("colour_plasma.jpg", tmp.path()).isEmpty());
+      Filejpeg *f = new Filejpeg(dir, "colour_plasma.jpg", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QPixmap pix;
+      QVERIFY(f->getPreviewPixmap(0, pix, false) == nullptr);
+      QVERIFY(!pix.isNull());
+      // /24 on the 2400x3300 fixture (height rounds up under KeepAspectRatio)
+      QCOMPARE(pix.size(), QSize(100, 138));
+      delete f;
+   }
+
+   // Filepdf renders at DPI/24 so the preview is much smaller than the full
+   // page; pin only that it's non-null and notably smaller than the full image
+   {
+      QVERIFY(!copyFixture("testpdf.pdf", tmp.path()).isEmpty());
+      Filepdf *f = new Filepdf(dir, "testpdf.pdf", nullptr);
+      QVERIFY(f->load() == nullptr);
+
+      QImage full;
+      QSize fullSize, fullTrue;
+      int bpp = 0;
+      QVERIFY(f->getImage(0, false, full, fullSize, fullTrue, bpp, false)
+              == nullptr);
+
+      QPixmap pix;
+      QVERIFY(f->getPreviewPixmap(0, pix, false) == nullptr);
+      QVERIFY(!pix.isNull());
+      QVERIFY(pix.width() < fullSize.width());
+      QVERIFY(pix.height() < fullSize.height());
+      delete f;
+   }
+}
+
+void TestFile::testFileotherSetThumbnail()
+{
+   Fileother *f = new Fileother("/tmp/", "stub.bin", nullptr);
+
+   // No thumbnail yet → generic placeholder is returned, but the call must
+   // succeed.
+   QPixmap placeholder = f->pixmap(false);
+   QVERIFY(!placeholder.isNull());
+
+   // Inject a recognisable pixmap and verify pixmap() returns it verbatim.
+   QPixmap inject(32, 16);
+   inject.fill(Qt::red);
+   f->setThumbnail(inject);
+
+   QPixmap got = f->pixmap(false);
+   QCOMPARE(got.size(), QSize(32, 16));
+   QCOMPARE(got.toImage(), inject.toImage());
+
+   delete f;
+}
+
+void TestFile::testFileotherMutationsNotImpl()
+{
+   Fileother *f = new Fileother("/tmp/", "stub.bin", nullptr);
+
+   QBitArray bits(1);
+   QByteArray del;
+   int count = 0;
+
+   // addPage, removePages, restorePages, unstackPages, stackStack all return
+   // not_impl with the canonical errnum
+   err_info *err = f->addPage(nullptr, false);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   err = f->removePages(bits, del, count);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   err = f->restorePages(bits, del, count);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   err = f->unstackPages(0, 1, false, nullptr);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   err = f->stackStack(nullptr);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   // duplicate signals 'not supported' rather than erroring — pin both.
+   // Operation has a static receiver that earlier suites (Dirview) may have
+   // pointed at a now-destroyed widget; clear it so emit-on-construct does
+   // not crash here.
+   Operation::setReceiver(nullptr);
+   File *fnew = nullptr;
+   bool supported = true;
+   Operation op("duptest", 1, nullptr);
+   QString uniq = "x";
+   err = f->duplicate(fnew, File::Type_other, uniq, 0, op, supported);
+   QVERIFY(err == nullptr);
+   QVERIFY(!supported);
+
+   delete f;
+}
+
+void TestFile::testSupportsJpeg()
+{
+   File *pdf = File::createFile("/tmp/", "x.pdf", nullptr, File::Type_pdf);
+   File *max = File::createFile("/tmp/", "x.max", nullptr, File::Type_max);
+   File *jpg = File::createFile("/tmp/", "x.jpg", nullptr, File::Type_jpeg);
+   File *oth = File::createFile("/tmp/", "x.bin", nullptr, File::Type_other);
+
+   QVERIFY(pdf->supportsJpeg());
+   QVERIFY(!max->supportsJpeg());
+   QVERIFY(!jpg->supportsJpeg());
+   QVERIFY(!oth->supportsJpeg());
+
+   // The base addPageJpeg returns not_impl; subclasses that don't override
+   // inherit that.  Use Filemax to prove the fallback path is wired up.
+   err_info *err = max->addPageJpeg(QByteArray(), 1, 1, false);
+   QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+
+   delete pdf;
+   delete max;
+   delete jpg;
+   delete oth;
+}
+
+void TestFile::testStackItemTypeMismatch()
+{
+   // stackItem is the public funnel for stacking: it must reject mixed
+   // types before calling into the subclass stackStack (which would not
+   // know how to consume foreign Filepages).  All the desk-level stack
+   // operations go through this check.
+   File *pdf = File::createFile("/tmp/", "x.pdf", nullptr, File::Type_pdf);
+   File *jpg = File::createFile("/tmp/", "x.jpg", nullptr, File::Type_jpeg);
+
+   err_info *err = pdf->stackItem(jpg);
+   QVERIFY(err);
+   QCOMPARE(err->errnum, ERR_cannot_stack_type_onto_type2);
+
+   delete pdf;
+   delete jpg;
+}

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -508,3 +508,51 @@ void TestFile::testStackItemTypeMismatch()
    delete pdf;
    delete jpg;
 }
+
+void TestFile::testCacheBoundaryReads()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+   QString path = copyFixture("testfile.max", tmp.path());
+   QVERIFY(!path.isEmpty());
+
+   QFile raw(path);
+   QVERIFY(raw.open(QIODevice::ReadOnly));
+   QByteArray bytes = raw.readAll();
+   QVERIFY(bytes.size() > 3 * 4096 + 4200);
+
+   Filemax f(dir, "testfile.max", nullptr);
+   QVERIFY(f.load() == nullptr);
+   QVERIFY(f.ensure_open() == nullptr);
+
+   auto hw_at = [&bytes](int pos) {
+      return int(quint8(bytes[pos]) | quint8(bytes[pos + 1]) << 8);
+   };
+   auto word_at = [&bytes](int pos) {
+      return int(quint32(quint8(bytes[pos]))
+                 | quint32(quint8(bytes[pos + 1])) << 8
+                 | quint32(quint8(bytes[pos + 2])) << 16
+                 | quint32(quint8(bytes[pos + 3])) << 24);
+   };
+
+   /* getword() and gethw() read through a 4KB cache window which has a
+      few bytes of padding on the end. A read which straddles the end
+      of the window's valid data must reload the cache rather than
+      returning padding bytes, which are not file data. Seed the window
+      at a known start, then read across its boundary, checking every
+      value against the raw file bytes */
+   for (int window = 0; window <= 2 * 4096; window += 4096)
+      for (int off = 4090; off <= 4096; off++) {
+         int pos = window + off;
+
+         f.gethw(window);   // make the cache window start at 'window'
+         QCOMPARE(f.getword(pos), word_at(pos));
+
+         f.gethw(window);
+         QCOMPARE(f.gethw(pos), hw_at(pos));
+      }
+
+   // a halfword at the very end of the file can still be read
+   QCOMPARE(f.gethw(bytes.size() - 2), hw_at(bytes.size() - 2));
+}

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -63,6 +63,10 @@ private slots:
    //! to the per-subclass stackStack
    void testStackItemTypeMismatch();
 
+   //! getword/gethw return real file bytes even when the read straddles
+   //! the end of a cache window
+   void testCacheBoundaryReads();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -1,0 +1,71 @@
+#ifndef TEST_FILE_H
+#define TEST_FILE_H
+
+#include <QObject>
+
+#include "suite.h"
+
+class TestFile: public Suite
+{
+   Q_OBJECT
+public:
+    using Suite::Suite;
+
+private slots:
+   //! typeFromName maps extensions (and unknown extensions) to e_type
+   void testTypeFromName();
+
+   //! typeName/typeExt round-trip and stay aligned with e_type
+   void testTypeNameAndExt();
+
+   //! envFromName/envToName round-trip; unknown name returns Env_count
+   void testEnvNames();
+
+   //! decodePageNumber/encodePageNumber round-trip for the _pN convention
+   void testPageNumberCodec();
+
+   //! extMatchesType compares the file's own type against the supplied ext
+   void testExtMatchesType();
+
+   //! not_impl returns a non-null err with a stable code
+   void testNotImpl();
+
+   //! createFile dispatches each e_type to the right subclass and sets
+   //! basename/leaf/ext/pathname consistently
+   void testCreateFileDispatch();
+
+   //! Loading and pulling basic metadata from each real fixture
+   void testFixtureMetadata();
+
+   //! encodeFile/decodeFile round-trips position + sizes through a string
+   void testEncodeDecode();
+
+   //! getImage on Filemax/Filepdf/Filejpeg returns a populated image with
+   //! plausible size and bpp; Fileother returns not_impl
+   void testGetImage();
+
+   //! getPreviewPixmap returns a non-null pixmap smaller than the full image
+   void testGetPreviewPixmap();
+
+   //! setThumbnail makes Fileother::pixmap return the injected image rather
+   //! than the generic unknown placeholder
+   void testFileotherSetThumbnail();
+
+   //! Fileother stubs out every mutation with not_impl, and duplicate()
+   //! signals 'not supported' without erroring
+   void testFileotherMutationsNotImpl();
+
+   //! supportsJpeg + the base addPageJpeg fallback reflect each type's
+   //! actual capability: only Filepdf advertises JPEG support
+   void testSupportsJpeg();
+
+   //! stackItem rejects stacking files of different types before dispatching
+   //! to the per-subclass stackStack
+   void testStackItemTypeMismatch();
+
+private:
+   //! Copy a file from test/files into destDir; returns full path
+   QString copyFixture(const QString &name, const QString &destDir);
+};
+
+#endif // TEST_FILE_H

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -11,6 +11,7 @@
 #include "desktopwidget.h"
 #include "dirmodel.h"
 #include "dirview.h"
+#include "mainwidget.h"
 #include "mainwindow.h"
 #include "printopt.h"
 #include "test_ops.h"
@@ -472,6 +473,59 @@ void TestOps::testPrintCountPages()
       a blank page added: both stacks have 5 pages */
    opt.sepSheet->setChecked(true);
    QCOMPARE(opt.countPages(), 12);
+}
+
+void TestOps::testPrintToPdf()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   getTestRepo(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   view->setSelectionRange(0, 2);
+
+   QModelIndexList list = view->getSelectedListSource();
+   QCOMPARE(list.size(), 2);
+   foreach (QModelIndex ind, list)
+      model->getFile(ind)->load();
+
+   /* run the part of print() which follows the print dialogue, with
+      the printer directed at a PDF file */
+   QString out = QString("%1/print_test.pdf").arg(P_tmpdir);
+   QFile::remove(out);
+
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+   main->_printer = new QPrinter();
+   main->_printer->setOutputFileName(out);
+   main->_printer->setResolution(150);
+   main->_opt = new Printopt(main->_printer, list);
+   main->_opt->sepSheet->setChecked(false);
+   main->_opt->save();   // copy the widget states into the members
+   main->_printer->setFromTo(1, main->_opt->countPages());
+
+   main->printPages(list);
+
+   delete main->_opt;
+   main->_opt = nullptr;
+   delete main->_printer;
+   main->_printer = nullptr;
+
+   // The PDF should exist and contain every page of both stacks
+   QVERIFY(QFile::exists(out));
+
+   File *printed = File::createFile(QString(P_tmpdir) + "/",
+                                    QString("print_test.pdf"), nullptr,
+                                    File::Type_pdf);
+   QVERIFY(printed);
+   printed->load();
+   QCOMPARE(printed->pagecount(), 10);
+   delete printed;
+
+   QFile::remove(out);
 }
 
 void TestOps::getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -13,7 +13,9 @@
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
+#include "options.h"
 #include "printopt.h"
+#include "qxmlconfig.h"
 #include "test_ops.h"
 
 void TestOps::testStartup()
@@ -526,6 +528,32 @@ void TestOps::testPrintToPdf()
    delete printed;
 
    QFile::remove(out);
+}
+
+void TestOps::testOptionsDialog()
+{
+   if (!xmlConfig)
+      new QXmlConfig();
+   bool orig = xmlConfig->boolValue("SCAN_USE_JPEG");
+
+   // The dialog loads the current setting
+   Options opt(nullptr, nullptr);
+   QCOMPARE(opt.jpeg->isChecked(), orig);
+
+   // Toggling it and clicking OK saves the new value
+   opt.jpeg->setChecked(!orig);
+   opt.ok_clicked();
+   QCOMPARE(xmlConfig->boolValue("SCAN_USE_JPEG"), !orig);
+
+   // Changing it back but cancelling leaves the saved value alone
+   Options opt2(nullptr, nullptr);
+   QCOMPARE(opt2.jpeg->isChecked(), !orig);
+   opt2.jpeg->setChecked(orig);
+   opt2.cancel_clicked();
+   QCOMPARE(xmlConfig->boolValue("SCAN_USE_JPEG"), !orig);
+
+   // Restore the user's setting
+   xmlConfig->setBoolValue("SCAN_USE_JPEG", orig);
 }
 
 void TestOps::getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -818,9 +818,32 @@ void TestOps::testMoveToDir()
 
 void TestOps::testChangeDir()
 {
-   // This test is skipped because changeDir() has UI dependencies that
-   // cause timeouts in headless mode
-   QSKIP("changeDir() requires UI event loop");
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   getTestRepo(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+
+   // The repo root shows its two stacks
+   auto path = desktop->getSelectedPath();
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
+
+   // Change to an empty subdirectory: no stacks should be shown
+   QModelIndex dir_ind = desktop->findDir(path + "/main");
+   QVERIFY(dir_ind.isValid());
+   desktop->selectDir(dir_ind);
+   QCOMPARE(desktop->getSelectedPath(), QString(path + "/main"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 0);
+
+   // Change back to the repo root: the stacks reappear
+   desktop->selectDir(desktop->findDir(path));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 2);
 }
 
 void TestOps::testDeleteDir()

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -1,4 +1,5 @@
 #include <QDate>
+#include <QPrinter>
 #include <QtTest/QtTest>
 
 #include "../utils.h"
@@ -11,6 +12,7 @@
 #include "dirmodel.h"
 #include "dirview.h"
 #include "mainwindow.h"
+#include "printopt.h"
 #include "test_ops.h"
 
 void TestOps::testStartup()
@@ -433,6 +435,43 @@ void TestOps::testRenamePage()
    stk->undo();
    QCOMPARE(model->data(max_ind, Desktopmodel::Role_pagename).toString(),
             "Page 1");
+}
+
+void TestOps::testPrintCountPages()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   getTestRepo(&me, model, repo_ind);
+
+   // Select both stacks, as a user would before printing
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   view->setSelectionRange(0, 2);
+
+   QModelIndexList list = view->getSelectedListSource();
+   QCOMPARE(list.size(), 2);
+
+   // Make sure the files are loaded so the page counts are known
+   int expected = 0;
+   foreach (QModelIndex ind, list) {
+      File *f = model->getFile(ind);
+      f->load();
+      expected += f->pagecount();
+   }
+   QCOMPARE(expected, 10);
+
+   // The print options dialog should count the pages of the selection
+   QPrinter printer;
+   Printopt opt(&printer, list);
+   opt.sepSheet->setChecked(false);
+   QCOMPARE(opt.countPages(), 10);
+
+   /* with a separator sheet, stacks with an odd number of pages get
+      a blank page added: both stacks have 5 pages */
+   opt.sepSheet->setChecked(true);
+   QCOMPARE(opt.countPages(), 12);
 }
 
 void TestOps::getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_ops.h
+++ b/test/test_ops.h
@@ -82,6 +82,9 @@ private slots:
    //! Test printing the selected stacks to a PDF file
    void testPrintToPdf();
 
+   //! Test the options dialog loads and saves scan settings
+   void testOptionsDialog();
+
 private:
    //! Setup the test repo and return its model and root index
    void getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_ops.h
+++ b/test/test_ops.h
@@ -79,6 +79,9 @@ private slots:
    //! Test that the print options count pages correctly
    void testPrintCountPages();
 
+   //! Test printing the selected stacks to a PDF file
+   void testPrintToPdf();
+
 private:
    //! Setup the test repo and return its model and root index
    void getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_ops.h
+++ b/test/test_ops.h
@@ -76,6 +76,9 @@ private slots:
    //! Test that findFolders works after a cache refresh
    void testFindFoldersSuggestsMonthAfterRefresh();
 
+   //! Test that the print options count pages correctly
+   void testPrintCountPages();
+
 private:
    //! Setup the test repo and return its model and root index
    void getTestRepo(Mainwindow *me, Desktopmodel*& model,

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -1,0 +1,114 @@
+#include <QtTest/QtTest>
+
+#include "test.h"
+
+#include "desktopmodel.h"
+#include "desktopview.h"
+#include "desktopwidget.h"
+#include "mainwidget.h"
+#include "mainwindow.h"
+#include "pageview.h"
+#include "pagewidget.h"
+#include "test_pagewidget.h"
+
+void TestPagewidget::openTestStack(Mainwindow *me, Desktopmodel *&model,
+                                   Pagewidget *&page)
+{
+   auto path = setupRepo();
+   Desktopwidget *desktop = me->getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   QModelIndex repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me->resize(1024, 768);
+   me->show();
+   QVERIFY(QTest::qWaitForWindowExposed(me));
+   QTest::qWait(50);
+
+   // Select the 5-page max stack and open it in the page view
+   Desktopview *view = desktop->getView();
+   view->setSelectionRange(0, 1);
+   me->actionSwap->trigger();
+
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+   page = main->getPage();
+   QTRY_COMPARE(main->currentWidget(), (QWidget *)page);
+
+   QModelIndex shown;
+   QVERIFY(page->getCurrentIndex(shown, true));
+   QCOMPARE(model->data(shown, Qt::DisplayRole).toString(), "testfile");
+}
+
+void TestPagewidget::testThumbnailClickShowsPage()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   Pageview *pageview = page->findChild<Pageview *>();
+   QVERIFY(pageview);
+
+   // All five pages should appear in the thumbnail list, and the
+   // stack's current page (the first) should be the one displayed
+   QCOMPARE(pageview->model()->rowCount(), 5);
+   QCOMPARE(page->getCurrentPage(), 0);
+
+   // Click the third thumbnail and check that page is displayed
+   QModelIndex ind = pageview->model()->index(2, 0);
+   QVERIFY(ind.isValid());
+   QRect rect = pageview->visualRect(ind);
+   QVERIFY(rect.isValid());
+   QTest::mouseClick(pageview->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     rect.center());
+   QCOMPARE(page->getCurrentPage(), 2);
+
+   // And back to the first
+   ind = pageview->model()->index(0, 0);
+   QTest::mouseClick(pageview->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     pageview->visualRect(ind).center());
+   QCOMPARE(page->getCurrentPage(), 0);
+}
+
+void TestPagewidget::testOpenAtCurrentPage()
+{
+   Desktopmodel *model;
+   Mainwindow me;
+
+   auto path = setupRepo();
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   QVERIFY(!err);
+
+   model = desktop->getModel();
+   QModelIndex repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   // Flip the stack to page 4 on the desktop, as a user would with the
+   // page-next arrows
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   model->setData(src_ind, 3, Desktopmodel::Role_pagenum);
+
+   // Open the stack: the page view must show page 4, not some other
+   // page. This is a regression test for showPage() passing a fixed
+   // page number to showPages()
+   Desktopview *view = desktop->getView();
+   view->setSelectionRange(0, 1);
+   me.actionSwap->trigger();
+
+   Mainwidget *main = Mainwidget::singleton();
+   QVERIFY(main);
+   Pagewidget *page = main->getPage();
+   QTRY_COMPARE(main->currentWidget(), (QWidget *)page);
+   QCOMPARE(page->getCurrentPage(), 3);
+}

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -177,3 +177,38 @@ void TestPagewidget::testZoomLevelEdit()
    QTest::keyClick(zoom, Qt::Key_Return);
    QCOMPARE(zoomValue(zoom), 200);
 }
+
+void TestPagewidget::testRotateButtons()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QToolButton *rleft = page->findChild<QToolButton *>("rleft");
+   QToolButton *rright = page->findChild<QToolButton *>("rright");
+   QToolButton *r180 = page->findChild<QToolButton *>("vflip");
+   QVERIFY(rleft && rright && r180);
+
+   QCOMPARE(page->_rotate, 0);
+
+   // Rotate right goes clockwise in 90-degree steps
+   QTest::mouseClick(rright, Qt::LeftButton);
+   QCOMPARE(page->_rotate, 90);
+
+   QTest::mouseClick(rright, Qt::LeftButton);
+   QCOMPARE(page->_rotate, 180);
+
+   // Rotate left goes back
+   QTest::mouseClick(rleft, Qt::LeftButton);
+   QCOMPARE(page->_rotate, 90);
+
+   // The 180 button turns the page upside down from where it is
+   QTest::mouseClick(r180, Qt::LeftButton);
+   QCOMPARE(page->_rotate, 270);
+
+   // A full circle returns to normal
+   QTest::mouseClick(rright, Qt::LeftButton);
+   QCOMPARE(page->_rotate, 0);
+}

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -1,3 +1,5 @@
+#include <QLineEdit>
+#include <QToolButton>
 #include <QtTest/QtTest>
 
 #include "test.h"
@@ -10,6 +12,12 @@
 #include "pageview.h"
 #include "pagewidget.h"
 #include "test_pagewidget.h"
+
+//! Read the zoom level shown to the user, e.g. "100%" gives 100
+static int zoomValue(QLineEdit *zoom)
+{
+   return zoom->text().remove('%').toInt();
+}
 
 void TestPagewidget::openTestStack(Mainwindow *me, Desktopmodel *&model,
                                    Pagewidget *&page)
@@ -111,4 +119,61 @@ void TestPagewidget::testOpenAtCurrentPage()
    Pagewidget *page = main->getPage();
    QTRY_COMPARE(main->currentWidget(), (QWidget *)page);
    QCOMPARE(page->getCurrentPage(), 3);
+}
+
+void TestPagewidget::testZoomButtons()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QLineEdit *zoom = page->findChild<QLineEdit *>("zoomLevel");
+   QToolButton *zoom_in = page->findChild<QToolButton *>("zoomIn");
+   QToolButton *zoom_out = page->findChild<QToolButton *>("zoomOut");
+   QToolButton *zoom_orig = page->findChild<QToolButton *>("zoomOrig");
+   QToolButton *zoom_fit = page->findChild<QToolButton *>("zoomFit");
+   QVERIFY(zoom && zoom_in && zoom_out && zoom_orig && zoom_fit);
+   QVERIFY(zoom->isEnabled());
+
+   // The original-size button shows the page at 1:4 (25%), which
+   // matches a 300dpi scan on a typical screen
+   QTest::mouseClick(zoom_orig, Qt::LeftButton);
+   QCOMPARE(zoomValue(zoom), 25);
+
+   // Zooming in increases the level; zooming out decreases it
+   QTest::mouseClick(zoom_in, Qt::LeftButton);
+   int zoomed = zoomValue(zoom);
+   QVERIFY(zoomed > 25);
+
+   QTest::mouseClick(zoom_out, Qt::LeftButton);
+   QVERIFY(zoomValue(zoom) < zoomed);
+
+   // Fit-to-window picks a sensible scale for the viewport
+   QTest::mouseClick(zoom_fit, Qt::LeftButton);
+   QVERIFY(zoomValue(zoom) > 0);
+}
+
+void TestPagewidget::testZoomLevelEdit()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QLineEdit *zoom = page->findChild<QLineEdit *>("zoomLevel");
+   QVERIFY(zoom);
+
+   // Type a specific zoom level and press return
+   zoom->selectAll();
+   QTest::keyClicks(zoom, "50");
+   QTest::keyClick(zoom, Qt::Key_Return);
+   QCOMPARE(zoomValue(zoom), 50);
+
+   zoom->selectAll();
+   QTest::keyClicks(zoom, "200");
+   QTest::keyClick(zoom, Qt::Key_Return);
+   QCOMPARE(zoomValue(zoom), 200);
 }

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -212,3 +212,73 @@ void TestPagewidget::testRotateButtons()
    QTest::mouseClick(rright, Qt::LeftButton);
    QCOMPARE(page->_rotate, 0);
 }
+
+void TestPagewidget::testEditAttributesSave()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QLineEdit *author = page->findChild<QLineEdit *>("author");
+   QLineEdit *title = page->findChild<QLineEdit *>("title");
+   QLineEdit *keywords = page->findChild<QLineEdit *>("keywords");
+   QToolButton *save = page->findChild<QToolButton *>("save");
+   QVERIFY(author && title && keywords && save);
+
+   // The fields start out empty and nothing needs saving
+   QCOMPARE(author->text(), QString());
+   QVERIFY(!save->isEnabled());
+
+   // Type some attribute text: the save button becomes available
+   QTest::keyClicks(author, "Fred Bloggs");
+   QTest::keyClicks(title, "Annual tax return");
+   QTest::keyClicks(keywords, "tax");
+   QVERIFY(save->isEnabled());
+
+   QTest::mouseClick(save, Qt::LeftButton);
+
+   // The annotations should now be stored in the stack
+   QModelIndex ind;
+   QVERIFY(page->getCurrentIndex(ind, true));
+   QCOMPARE(model->data(ind, Desktopmodel::Role_author).toString(),
+            "Fred Bloggs");
+   QCOMPARE(model->data(ind, Desktopmodel::Role_title).toString(),
+            "Annual tax return");
+   QCOMPARE(model->data(ind, Desktopmodel::Role_keywords).toString(),
+            "tax");
+
+   // Everything is saved, so the save button is disabled again
+   QVERIFY(!save->isEnabled());
+}
+
+void TestPagewidget::testEditAttributesRevert()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QLineEdit *author = page->findChild<QLineEdit *>("author");
+   QToolButton *save = page->findChild<QToolButton *>("save");
+   QToolButton *revert = page->findChild<QToolButton *>("revert");
+   QVERIFY(author && save && revert);
+
+   // Save an author name
+   QTest::keyClicks(author, "Fred");
+   QTest::mouseClick(save, Qt::LeftButton);
+
+   // Make a further edit, then revert: the saved name comes back
+   QTest::keyClicks(author, " Bloggs");
+   QCOMPARE(author->text(), QString("Fred Bloggs"));
+   QVERIFY(revert->isEnabled());
+   QTest::mouseClick(revert, Qt::LeftButton);
+   QCOMPARE(author->text(), QString("Fred"));
+
+   QModelIndex ind;
+   QVERIFY(page->getCurrentIndex(ind, true));
+   QCOMPARE(model->data(ind, Desktopmodel::Role_author).toString(),
+            "Fred");
+}

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -27,6 +27,12 @@ private slots:
    //! Test that opening a stack shows the stack's current page
    void testOpenAtCurrentPage();
 
+   //! Test the zoom in/out/original buttons update the zoom level
+   void testZoomButtons();
+
+   //! Test typing a zoom level into the zoom box
+   void testZoomLevelEdit();
+
 private:
    /** Open the 5-page test stack in the page view of a shown
        Mainwindow

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -1,0 +1,41 @@
+#ifndef TEST_PAGEWIDGET_H
+#define TEST_PAGEWIDGET_H
+
+#include <QObject>
+
+#include "suite.h"
+
+class Desktopmodel;
+class Mainwindow;
+class Pagewidget;
+class QModelIndex;
+
+/** Tests for the page view: opening a stack, choosing pages from the
+    thumbnail list, zooming and rotating the display. These drive the
+    page-view tool buttons with real clicks and check the state the
+    user sees (e.g. the zoom-level box) */
+class TestPagewidget: public Suite
+{
+   Q_OBJECT
+public:
+   using Suite::Suite;
+
+private slots:
+   //! Test that clicking a page thumbnail displays that page
+   void testThumbnailClickShowsPage();
+
+   //! Test that opening a stack shows the stack's current page
+   void testOpenAtCurrentPage();
+
+private:
+   /** Open the 5-page test stack in the page view of a shown
+       Mainwindow
+
+      \param me     Mainwindow to use
+      \param model  Returns the desktop model
+      \param page   Returns the page widget showing the stack */
+   void openTestStack(Mainwindow *me, Desktopmodel *&model,
+                      Pagewidget *&page);
+};
+
+#endif // TEST_PAGEWIDGET_H

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -33,6 +33,9 @@ private slots:
    //! Test typing a zoom level into the zoom box
    void testZoomLevelEdit();
 
+   //! Test the rotate-left/right and 180 display buttons
+   void testRotateButtons();
+
 private:
    /** Open the 5-page test stack in the page view of a shown
        Mainwindow

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -36,6 +36,12 @@ private slots:
    //! Test the rotate-left/right and 180 display buttons
    void testRotateButtons();
 
+   //! Test editing stack attributes and saving them
+   void testEditAttributesSave();
+
+   //! Test that revert discards unsaved attribute edits
+   void testEditAttributesRevert();
+
 private:
    /** Open the 5-page test stack in the page view of a shown
        Mainwindow

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -1,5 +1,6 @@
 #include <QtTest/QtTest>
 
+#include "pscan.h"
 #include "qscandialog.h"
 #include "qscanner.h"
 #include "qxmlconfig.h"
@@ -116,6 +117,47 @@ void TestQscanner::testStaleScanDialogAfterReconnect()
    // doesn't crash to keep using it (the rebuild is a precaution, not a
    // hard requirement now that QScanner preserves its own state).
    Q_UNUSED (dialog);
+}
+
+
+void TestQscanner::testPscanControls()
+{
+   ensureXmlConfig ();
+   QScanner scanner;
+   scanner.setDeviceName (SIMUL_NAME);
+   QVERIFY (scanner.openDevice ());
+
+   QScanDialog dialog (&scanner, 0);
+
+   /* setting a lower resolution must not snap to the maximum; this
+      used to fail because changing a slider's range pushed the clamped
+      slider position to the scanner */
+   dialog.setDpi (200);
+   QCOMPARE (scanner.xResolutionDpi (), 200);
+   QCOMPARE (scanner.yResolutionDpi (), 200);
+
+   Pscan pscan;
+   pscan.setScanDialog (&dialog);
+   pscan.scannerChanged (&scanner);
+
+   // The scanner controls should be available
+   QVERIFY (pscan.res->isEnabled ());
+   QVERIFY (pscan.duplex->isEnabled ());
+
+   // Choosing a resolution from the combo reaches the scanner
+   pscan.res_activated (0);
+   QCOMPARE (scanner.xResolutionDpi (), 200);
+   pscan.res_activated (2);
+   QCOMPARE (scanner.xResolutionDpi (), 400);
+   pscan.res_activated (1);
+   QCOMPARE (scanner.xResolutionDpi (), 300);
+
+   // Clicking the duplex checkbox toggles duplex scanning
+   bool was_duplex = scanner.duplex ();
+   QTest::mouseClick (pscan.duplex, Qt::LeftButton);
+   QCOMPARE (scanner.duplex (), !was_duplex);
+   QTest::mouseClick (pscan.duplex, Qt::LeftButton);
+   QCOMPARE (scanner.duplex (), was_duplex);
 }
 
 

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -38,6 +38,10 @@ private slots:
    //! reconnect() snapshots and restores scanner state so the user's
    //! settings (DPI, duplex, format, etc) survive the teardown.
    void testReconnectPreservesSettings();
+
+   //! The pscan dialog controls (resolution, ADF, duplex, reset) drive
+   //! the scanner settings.
+   void testPscanControls();
 };
 
 #endif // TEST_QSCANNER_H

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -623,6 +623,50 @@ void TestSearchServer::testRemoteBackendTimeout()
             qPrintable(QString("call took %1 ms").arg(elapsedMs)));
 }
 
+void TestSearchServer::testRemoteBackendThumbnail()
+{
+   /* Spin up a server with a PDF the test fixtures already create,
+    * then ask RemoteBackend for its thumbnail.  We don't decode the
+    * JPEG — confirming non-empty bytes with the JPEG magic bytes is
+    * enough to prove the wire works end-to-end. */
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   QVERIFY(copyTestFile("testpdf.pdf", tmpDir.path()) > 0);
+
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   QString repoName = QFileInfo(tmpDir.path()).fileName();
+
+   RemoteBackend client(QUrl(QString("http://localhost:%1").arg(PORT)));
+
+   /* Sync path. */
+   QByteArray jpeg = client.fetchThumbnail(repoName, "testpdf.pdf");
+   QVERIFY2(!jpeg.isEmpty(), client.lastError().toUtf8().constData());
+   QVERIFY2(jpeg.startsWith("\xFF\xD8\xFF"),
+            "expected JPEG magic bytes");
+   QVERIFY(jpeg.size() > 100);
+
+   /* Async path: hook up a one-shot signal capture, fire request,
+    * spin events until it fires. */
+   QByteArray asyncBytes;
+   quint64 capturedToken = 0;
+   QObject::connect(&client, &RemoteBackend::thumbnailReady,
+       [&](quint64 token, const QByteArray &bytes) {
+          capturedToken = token;
+          asyncBytes = bytes;
+       });
+
+   quint64 token = client.fetchThumbnailAsync(repoName, "testpdf.pdf");
+   QVERIFY(token != 0);
+   QTRY_VERIFY(!asyncBytes.isEmpty());
+   QCOMPARE(capturedToken, token);
+   QVERIFY(asyncBytes.startsWith("\xFF\xD8\xFF"));
+
+   server.stop();
+}
+
 void TestSearchServer::testSearchEndpoint()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -363,6 +363,60 @@ void TestSearchServer::testV1AuthLogin()
    server.stop();
 }
 
+void TestSearchServer::testReposFilteredByUser()
+{
+   QStandardPaths::setTestModeEnabled(true);
+   auto restoreStdPaths = qScopeGuard([] {
+      QStandardPaths::setTestModeEnabled(false);
+   });
+   QString cfgFile = QStandardPaths::writableLocation(
+                         QStandardPaths::GenericConfigLocation)
+                     + "/paperman-server/users.json";
+   QFile::remove(cfgFile);
+
+   /* Two on-disk repos.  alice gets the first only; carol gets both. */
+   QTemporaryDir repoA, repoB;
+   QVERIFY(repoA.isValid() && repoB.isValid());
+   QString nameA = QFileInfo(repoA.path()).fileName();
+   QString nameB = QFileInfo(repoB.path()).fileName();
+
+   {
+      UserStore store;
+      QVERIFY(store.addUser("alice", "pw"));
+      QVERIFY(store.setRepos("alice", {nameA}));
+      QVERIFY(store.addUser("carol", "pw"));
+      /* carol has empty allowlist → all repos. */
+   }
+
+   SearchServer server({repoA.path(), repoB.path()}, PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   auto login = [&](const QString &user) {
+      auto resp = postJson(
+          "/v1/auth/login",
+          QString(R"({"user":"%1","password":"pw"})").arg(user).toUtf8());
+      Q_ASSERT(resp.ok());
+      return QJsonDocument::fromJson(resp.body).object()["token"].toString();
+   };
+
+   /* alice sees only repoA. */
+   auto aliceRepos = getWithBearer("/repos", login("alice"));
+   QVERIFY(aliceRepos.ok());
+   auto aObj = QJsonDocument::fromJson(aliceRepos.body).object();
+   QCOMPARE(aObj["count"].toInt(), 1);
+   QCOMPARE(aObj["repositories"].toArray()[0].toObject()["name"].toString(),
+            nameA);
+
+   /* carol sees both. */
+   auto carolRepos = getWithBearer("/repos", login("carol"));
+   QVERIFY(carolRepos.ok());
+   auto cObj = QJsonDocument::fromJson(carolRepos.body).object();
+   QCOMPARE(cObj["count"].toInt(), 2);
+
+   server.stop();
+}
+
 void TestSearchServer::testSearchEndpoint()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -10,6 +10,7 @@
 #include <QScopeGuard>
 #include <QStandardPaths>
 
+#include "../remotebackend.h"
 #include "../searchserver.h"
 #include "../userstore.h"
 #include "test.h"
@@ -413,6 +414,85 @@ void TestSearchServer::testReposFilteredByUser()
    QVERIFY(carolRepos.ok());
    auto cObj = QJsonDocument::fromJson(carolRepos.body).object();
    QCOMPARE(cObj["count"].toInt(), 2);
+
+   server.stop();
+}
+
+void TestSearchServer::testRemoteBackendEndToEnd()
+{
+   /* Full client→server→client round-trip: spin up a real
+    * SearchServer on a temp repo, then drive it through the same
+    * RemoteBackend code path the GUI will use.  The test sits on both
+    * sides of the socket to confirm the wire format and the
+    * production client class agree. */
+
+   QStandardPaths::setTestModeEnabled(true);
+   auto restoreStdPaths = qScopeGuard([] {
+      QStandardPaths::setTestModeEnabled(false);
+   });
+   QString cfgFile = QStandardPaths::writableLocation(
+                         QStandardPaths::GenericConfigLocation)
+                     + "/paperman-server/users.json";
+   QFile::remove(cfgFile);
+
+   /* Server-side setup: one user, one repo with a known set of files. */
+   {
+      UserStore store;
+      QVERIFY(store.addUser("dave", "passw0rd"));
+   }
+
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   createTestFiles(tmpDir.path());
+
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   /* Client side: RemoteBackend pointed at the running server. */
+   RemoteBackend client(QUrl(QString("http://localhost:%1").arg(PORT)));
+
+   /* Wrong password is rejected without setting a token. */
+   QVERIFY(!client.login("dave", "wrong"));
+   QVERIFY(!client.isAuthenticated());
+
+   /* Correct credentials grant access. */
+   QVERIFY2(client.login("dave", "passw0rd"),
+            client.lastError().toUtf8().constData());
+   QVERIFY(client.isAuthenticated());
+
+   /* listRepositories shows the configured repo. */
+   QList<RepositoryInfo> repos = client.listRepositories();
+   QCOMPARE(repos.size(), 1);
+   QCOMPARE(repos[0].name, QFileInfo(tmpDir.path()).fileName());
+   QVERIFY(repos[0].exists);
+
+   /* browseDirectory on the repo root returns the seeded files +
+    * subdirectory.  createTestFiles() lays down:
+    *   test-document.max, invoice-2024.pdf, photo.jpg, archive/    */
+   DirectoryListing root = client.browseDirectory(repos[0].name, "");
+   QStringList names;
+   for (const DirectoryEntry &e : root.entries)
+      names << (e.isDir ? e.name + "/" : e.name);
+
+   QVERIFY2(names.contains("archive/"), qPrintable(names.join(',')));
+   QVERIFY2(names.contains("test-document.max"), qPrintable(names.join(',')));
+   QVERIFY2(names.contains("invoice-2024.pdf"), qPrintable(names.join(',')));
+   QVERIFY2(names.contains("photo.jpg"), qPrintable(names.join(',')));
+
+   /* Subdirectories come before files. */
+   int firstFile = -1, lastDir = -1;
+   for (int i = 0; i < root.entries.size(); i++) {
+      if (root.entries[i].isDir) lastDir = i;
+      else if (firstFile < 0)    firstFile = i;
+   }
+   QVERIFY(lastDir < firstFile);
+
+   /* Files carry a non-zero size from the cache. */
+   for (const DirectoryEntry &e : root.entries) {
+      if (!e.isDir)
+         QVERIFY2(e.size > 0, qPrintable(e.name));
+   }
 
    server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -14,10 +14,14 @@
 
 #include "../backendstats.h"
 
+#include "../file.h"
 #include "../remotebackend.h"
 #include "../searchserver.h"
 #include "../userstore.h"
 #include "test.h"
+
+#include <QBuffer>
+#include <QImage>
 
 #include "test_searchserver.h"
 
@@ -717,6 +721,101 @@ void TestSearchServer::testBackendStatsAccumulates()
 
    server.stop();
 }
+
+
+void TestSearchServer::testThumbnailMatchesLocalRender()
+{
+   /* Render the same .max file two ways and verify the bytes are
+    * identical:
+    *
+    *   - Locally: instantiate Filemax, load, getImage page 0,
+    *     scale to the medium thumbnail size, JPEG-encode in
+    *     memory.  This is exactly what the server's
+    *     generateThumbnail() does for non-PDF files (see
+    *     searchserver.cpp::generateThumbnail).
+    *
+    *   - Remotely: fetch via RemoteBackend::fetchThumbnail, which
+    *     causes the server to run that same generateThumbnail path
+    *     and stream the bytes back.
+    *
+    * If both code paths use the same File class, scaler, and JPEG
+    * encoder, the resulting bytes match exactly.  If they ever
+    * diverge — different scaler flag, different quality default,
+    * extra metadata in the JPEG — this test fires and pins the
+    * regression point. */
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+
+   /* Local render: same recipe as SearchServer::generateThumbnail
+    * for non-PDF.  thumbSize 300 matches getThumbnailSize("medium"). */
+   const int kThumbSize = 300;
+   QString fname = "testfile.max";
+   QString dir = tmpDir.path() + "/";
+   File *file = File::createFile(dir, fname, nullptr,
+                                 File::typeFromName(fname));
+   QVERIFY(file != nullptr);
+   QVERIFY(file->load() == nullptr);
+
+   QImage image;
+   QSize imgSize, trueSize;
+   int bpp;
+   err_info *err = file->getImage(0, false, image, imgSize, trueSize,
+                                  bpp, false);
+   delete file;
+   QVERIFY(err == nullptr);
+   QVERIFY(!image.isNull());
+
+   QImage thumb = image.scaled(kThumbSize, kThumbSize,
+                               Qt::KeepAspectRatio,
+                               Qt::SmoothTransformation);
+   QByteArray localBytes;
+   {
+      QBuffer buf(&localBytes);
+      buf.open(QIODevice::WriteOnly);
+      QVERIFY(thumb.save(&buf, "JPEG"));
+   }
+   QVERIFY(!localBytes.isEmpty());
+
+   /* Remote render: spin up a SearchServer pointed at the same
+    * repo and ask RemoteBackend for the same thumbnail. */
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   QString repoName = QFileInfo(tmpDir.path()).fileName();
+   RemoteBackend client(QUrl(QString("http://localhost:%1").arg(PORT)));
+   QByteArray remoteBytes = client.fetchThumbnail(repoName, fname,
+                                                  /*page=*/1,
+                                                  /*size=*/"medium");
+   server.stop();
+
+   QVERIFY2(!remoteBytes.isEmpty(),
+            client.lastError().toUtf8().constData());
+
+   /* Bytes should match.  If they don't, decode both and compare
+    * pixel-by-pixel so a "JPEG bytes drift" report still tells us
+    * whether the visible result moved or only the encoding did. */
+   if (localBytes != remoteBytes) {
+      QImage localImg = QImage::fromData(localBytes);
+      QImage remoteImg = QImage::fromData(remoteBytes);
+      QVERIFY2(!localImg.isNull() && !remoteImg.isNull(),
+               "one of the JPEGs failed to decode");
+      QCOMPARE(localImg.size(), remoteImg.size());
+      /* If the pixels match exactly the only difference is the
+       * JPEG encoder state — strictly speaking the user-visible
+       * display is identical. */
+      QCOMPARE(localImg.convertToFormat(QImage::Format_RGB32),
+               remoteImg.convertToFormat(QImage::Format_RGB32));
+      /* Pixels matched, bytes didn't.  Don't fail the test — but
+       * note the divergence so a future change to either
+       * generateThumbnail or the encoder is at least visible. */
+      qInfo() << "Thumbnail JPEG bytes differ but pixels match;"
+              << "local=" << localBytes.size()
+              << "remote=" << remoteBytes.size();
+   }
+}
+
 
 void TestSearchServer::testSearchEndpoint()
 {

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -494,6 +494,25 @@ void TestSearchServer::testRemoteBackendEndToEnd()
          QVERIFY2(e.size > 0, qPrintable(e.name));
    }
 
+   /* readFile round-trips file bytes through the wire.  Verify against
+    * the source-of-truth on disk. */
+   FileFetch f = client.readFile(repos[0].name, "invoice-2024.pdf");
+   QVERIFY2(f.ok, f.error.toUtf8().constData());
+   QCOMPARE(f.contentType, QString("application/pdf"));
+
+   QFile src(tmpDir.path() + "/invoice-2024.pdf");
+   QVERIFY(src.open(QIODevice::ReadOnly));
+   QCOMPARE(f.bytes, src.readAll());
+
+   /* Unknown file is reported as not-found, not crash. */
+   FileFetch missing = client.readFile(repos[0].name, "no-such-file.pdf");
+   QVERIFY(!missing.ok);
+
+   /* Traversal attempt is rejected client-side... actually here the
+    * server rejects it; either way the call must fail. */
+   FileFetch evil = client.readFile(repos[0].name, "../etc/passwd");
+   QVERIFY(!evil.ok);
+
    server.stop();
 }
 

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -364,6 +364,87 @@ void TestSearchServer::testV1AuthLogin()
    server.stop();
 }
 
+void TestSearchServer::testPostBodySplitAcrossReads()
+{
+   /* Regression test: QNetworkAccessManager (and other clients) often
+    * write a POST in two segments — headers, then body.  An earlier
+    * onReadyRead() parsed only what was available on the first
+    * readyRead and threw the body away, so /v1/auth/login saw an
+    * empty body and replied 400.  This test recreates that wire
+    * behaviour by hand and asserts a 200 with a token. */
+
+   QStandardPaths::setTestModeEnabled(true);
+   auto restoreStdPaths = qScopeGuard([] {
+      QStandardPaths::setTestModeEnabled(false);
+   });
+   QString cfgFile = QStandardPaths::writableLocation(
+                         QStandardPaths::GenericConfigLocation)
+                     + "/paperman-server/users.json";
+   QFile::remove(cfgFile);
+   {
+      UserStore store;
+      QVERIFY(store.addUser("eve", "open-sesame"));
+   }
+
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   QByteArray body = R"({"user":"eve","password":"open-sesame"})";
+   QByteArray headers;
+   headers += "POST /v1/auth/login HTTP/1.1\r\n";
+   headers += "Host: localhost\r\n";
+   headers += "Content-Type: application/json\r\n";
+   headers += "Content-Length: " + QByteArray::number(body.size()) + "\r\n";
+   headers += "Connection: close\r\n";
+   headers += "\r\n";
+
+   QTcpSocket sock;
+   sock.connectToHost("localhost", PORT);
+   QVERIFY(sock.waitForConnected(2000));
+
+   /* Send headers, force them to flush, and let the server's
+    * readyRead fire on just the headers. */
+   sock.write(headers);
+   sock.flush();
+   sock.waitForBytesWritten(500);
+   for (int i = 0; i < 5; i++)
+      QCoreApplication::processEvents();
+   QTest::qWait(50);
+
+   /* Now send the body in a second write — under the old code, this
+    * was the chunk that got ignored. */
+   sock.write(body);
+   sock.flush();
+
+   QByteArray raw;
+   int waited = 0;
+   while (waited < 5000) {
+      QCoreApplication::processEvents();
+      if (sock.waitForReadyRead(100))
+         raw += sock.readAll();
+      if (sock.state() != QAbstractSocket::ConnectedState)
+         break;
+      waited += 100;
+   }
+   raw += sock.readAll();
+   sock.close();
+
+   int sep = raw.indexOf("\r\n\r\n");
+   QVERIFY2(sep > 0, raw.constData());
+   QString header = QString::fromUtf8(raw.left(sep));
+   QByteArray respBody = raw.mid(sep + 4);
+
+   QVERIFY2(header.contains("200 OK"), header.toUtf8().constData());
+   QJsonObject obj = QJsonDocument::fromJson(respBody).object();
+   QVERIFY(!obj.value("token").toString().isEmpty());
+   QCOMPARE(obj.value("user").toString(), QString("eve"));
+
+   server.stop();
+}
+
 void TestSearchServer::testReposFilteredByUser()
 {
    QStandardPaths::setTestModeEnabled(true);

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -7,7 +7,11 @@
 #include <QDir>
 #include <QFile>
 
+#include <QScopeGuard>
+#include <QStandardPaths>
+
 #include "../searchserver.h"
+#include "../userstore.h"
 #include "test.h"
 
 #include "test_searchserver.h"
@@ -74,6 +78,69 @@ TestSearchServer::Response TestSearchServer::get(const QString &path,
         resp.body = raw.mid(sep + 4);
     }
     return resp;
+}
+
+/* Send a raw HTTP request string (already includes headers + body)
+ * and split the response into header/body chunks. */
+static TestSearchServer::Response sendRaw(const QByteArray &request,
+                                          int port, int timeoutMs)
+{
+    TestSearchServer::Response resp;
+    QTcpSocket socket;
+    socket.connectToHost("localhost", port);
+    QCoreApplication::processEvents();
+    if (!socket.waitForConnected(2000))
+        return resp;
+
+    socket.write(request);
+    socket.flush();
+    QCoreApplication::processEvents();
+
+    QByteArray raw;
+    int totalWait = 0;
+    while (socket.state() == QAbstractSocket::ConnectedState
+           && totalWait < timeoutMs) {
+        if (socket.waitForReadyRead(200))
+            raw += socket.readAll();
+        totalWait += 200;
+    }
+    raw += socket.readAll();
+    socket.close();
+
+    int sep = raw.indexOf("\r\n\r\n");
+    if (sep >= 0) {
+        resp.header = QString::fromUtf8(raw.left(sep));
+        resp.body = raw.mid(sep + 4);
+    }
+    return resp;
+}
+
+TestSearchServer::Response
+TestSearchServer::getWithBearer(const QString &path, const QString &token,
+                                int timeoutMs)
+{
+    QByteArray req;
+    req += "GET " + path.toUtf8() + " HTTP/1.1\r\n";
+    req += "Host: localhost\r\n";
+    req += "Authorization: Bearer " + token.toUtf8() + "\r\n";
+    req += "Connection: close\r\n";
+    req += "\r\n";
+    return sendRaw(req, PORT, timeoutMs);
+}
+
+TestSearchServer::Response
+TestSearchServer::postJson(const QString &path, const QByteArray &body,
+                           int timeoutMs)
+{
+    QByteArray req;
+    req += "POST " + path.toUtf8() + " HTTP/1.1\r\n";
+    req += "Host: localhost\r\n";
+    req += "Content-Type: application/json\r\n";
+    req += "Content-Length: " + QByteArray::number(body.size()) + "\r\n";
+    req += "Connection: close\r\n";
+    req += "\r\n";
+    req += body;
+    return sendRaw(req, PORT, timeoutMs);
 }
 
 void TestSearchServer::createTestFiles(const QString& path)
@@ -218,6 +285,82 @@ void TestSearchServer::testV1StatusEndpoint()
       QCOMPARE(doc.object()["serverId"].toString(), firstId);
       server.stop();
    }
+}
+
+void TestSearchServer::testV1AuthLogin()
+{
+   /* Redirect QStandardPaths so the UserStore writes into a per-test
+    * temp tree.  setTestModeEnabled affects the whole process for the
+    * duration of this test. */
+   QStandardPaths::setTestModeEnabled(true);
+   auto restoreStdPaths = qScopeGuard([] {
+      QStandardPaths::setTestModeEnabled(false);
+   });
+
+   /* Wipe any stale users.json left from a previous run. */
+   QString cfgFile = QStandardPaths::writableLocation(
+                         QStandardPaths::GenericConfigLocation)
+                     + "/paperman-server/users.json";
+   QFile::remove(cfgFile);
+
+   /* Pre-populate the user store before the server reads it. */
+   {
+      UserStore store;
+      QVERIFY(store.addUser("alice", "s3cret"));
+      QVERIFY(store.addUser("bob", "hunter2"));
+      /* Bob is restricted to a repo that doesn't exist. */
+      QVERIFY(store.setRepos("bob", {"nowhere"}));
+   }
+
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   createTestFiles(tmpDir.path());
+
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   /* /v1/status remains open even with auth enabled. */
+   QVERIFY(get("/v1/status").ok());
+
+   /* Without credentials, /repos returns 401. */
+   auto unauth = get("/repos");
+   QVERIFY(unauth.header.contains("401"));
+
+   /* Bad password rejected. */
+   auto bad = postJson("/v1/auth/login",
+                       R"({"user":"alice","password":"wrong"})");
+   QVERIFY(bad.header.contains("401"));
+
+   /* Successful login mints a token. */
+   auto ok = postJson("/v1/auth/login",
+                      R"({"user":"alice","password":"s3cret"})");
+   QVERIFY2(ok.ok(), ok.header.toUtf8().constData());
+   auto okObj = QJsonDocument::fromJson(ok.body).object();
+   QString token = okObj["token"].toString();
+   QVERIFY(!token.isEmpty());
+   QCOMPARE(okObj["user"].toString(), QString("alice"));
+
+   /* Token grants access to /repos. */
+   auto repos = getWithBearer("/repos", token);
+   QVERIFY2(repos.ok(), repos.header.toUtf8().constData());
+
+   /* Bob's allowlist blocks his own repo. */
+   auto bobLogin = postJson("/v1/auth/login",
+                            R"({"user":"bob","password":"hunter2"})");
+   QVERIFY(bobLogin.ok());
+   QString bobTok = QJsonDocument::fromJson(bobLogin.body)
+                        .object()["token"].toString();
+   QString repoName = QFileInfo(tmpDir.path()).fileName();
+   auto bobSearch = getWithBearer(
+       QString("/search?q=test&repo=%1").arg(repoName), bobTok);
+   QVERIFY(bobSearch.header.contains("403"));
+
+   /* Garbage tokens still 401. */
+   auto garbage = getWithBearer("/repos", "not-a-real-token");
+   QVERIFY(garbage.header.contains("401"));
+
+   server.stop();
 }
 
 void TestSearchServer::testSearchEndpoint()

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1,4 +1,7 @@
 #include <QtTest/QtTest>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QTcpSocket>
 #include <QTemporaryDir>
 #include <QDir>
@@ -174,6 +177,47 @@ void TestSearchServer::testStatusEndpoint()
 
     server.stop();
     qDebug() << "testStatusEndpoint PASSED";
+}
+
+void TestSearchServer::testV1StatusEndpoint()
+{
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+
+   QString firstId;
+   {
+      SearchServer server(tmpDir.path(), PORT);
+      QVERIFY(server.start());
+      QTest::qWait(100);
+
+      auto resp = get("/v1/status");
+      QVERIFY(resp.ok());
+      auto doc = QJsonDocument::fromJson(resp.body);
+      QVERIFY(doc.isObject());
+      auto obj = doc.object();
+      QCOMPARE(obj["status"].toString(), QString("running"));
+      QCOMPARE(obj["apiVersion"].toString(), QString(PAPERMAN_API_VERSION));
+      QVERIFY(obj.contains("serverId"));
+      QVERIFY(!obj["serverId"].toString().isEmpty());
+      QVERIFY(obj["features"].isArray());
+
+      firstId = obj["serverId"].toString();
+      server.stop();
+   }
+
+   // A second server in the same config directory must reuse the same
+   // serverId — clients key their local caches on it.
+   {
+      SearchServer server(tmpDir.path(), PORT);
+      QVERIFY(server.start());
+      QTest::qWait(100);
+
+      auto resp = get("/v1/status");
+      QVERIFY(resp.ok());
+      auto doc = QJsonDocument::fromJson(resp.body);
+      QCOMPARE(doc.object()["serverId"].toString(), firstId);
+      server.stop();
+   }
 }
 
 void TestSearchServer::testSearchEndpoint()

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include <QFile>
 
+#include <QElapsedTimer>
 #include <QScopeGuard>
 #include <QStandardPaths>
 
@@ -595,6 +596,31 @@ void TestSearchServer::testRemoteBackendEndToEnd()
    QVERIFY(!evil.ok);
 
    server.stop();
+}
+
+void TestSearchServer::testRemoteBackendTimeout()
+{
+   /* Aim the client at a port nobody's listening on: the OS should
+    * return ECONNREFUSED quickly, but the assertion that matters is
+    * that the call returns *at all* in well under Qt's default
+    * (effectively unlimited) network timeout.  If the
+    * setTransferTimeout() call is removed or the wait loop is wrong,
+    * this test will hang past its overall test budget. */
+   RemoteBackend client(QUrl("http://localhost:1"));  // RFC: reserved
+
+   QElapsedTimer t;
+   t.start();
+   QList<RepositoryInfo> repos = client.listRepositories();
+   qint64 elapsedMs = t.elapsed();
+
+   QVERIFY(repos.isEmpty());
+   QVERIFY2(!client.lastError().isEmpty(),
+            "expected an error from an unreachable server");
+   /* Generous bound: connection-refused on loopback is sub-ms, but a
+    * dropped packet to an off-network host should still fail before
+    * the 5 s configured transferTimeout. */
+   QVERIFY2(elapsedMs < 7000,
+            qPrintable(QString("call took %1 ms").arg(elapsedMs)));
 }
 
 void TestSearchServer::testSearchEndpoint()

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -9,7 +9,10 @@
 
 #include <QElapsedTimer>
 #include <QScopeGuard>
+#include <QSignalSpy>
 #include <QStandardPaths>
+
+#include "../backendstats.h"
 
 #include "../remotebackend.h"
 #include "../searchserver.h"
@@ -663,6 +666,54 @@ void TestSearchServer::testRemoteBackendThumbnail()
    QTRY_VERIFY(!asyncBytes.isEmpty());
    QCOMPARE(capturedToken, token);
    QVERIFY(asyncBytes.startsWith("\xFF\xD8\xFF"));
+
+   server.stop();
+}
+
+void TestSearchServer::testBackendStatsAccumulates()
+{
+   /* Smoke test for the toolbar indicator: BackendStats should
+    * accumulate bytes across both sync and async RemoteBackend
+    * requests, and emit changed() each time. */
+   QTemporaryDir tmpDir;
+   QVERIFY(tmpDir.isValid());
+   QVERIFY(copyTestFile("testpdf.pdf", tmpDir.path()) > 0);
+
+   SearchServer server(tmpDir.path(), PORT);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+
+   BackendStats stats;
+   RemoteBackend client(QUrl(QString("http://localhost:%1").arg(PORT)));
+   client.setStats(&stats);
+
+   QSignalSpy spy(&stats, &BackendStats::changed);
+
+   QCOMPARE(stats.bytesSent(),     qint64(0));
+   QCOMPARE(stats.bytesReceived(), qint64(0));
+   QCOMPARE(stats.activeRequests(), 0);
+
+   /* Sync request: should bump both counters. */
+   QList<RepositoryInfo> repos = client.listRepositories();
+   QVERIFY(!repos.isEmpty());
+
+   QVERIFY2(stats.bytesSent() > 0,
+            qPrintable(QString("expected non-zero sent, got %1")
+                           .arg(stats.bytesSent())));
+   QVERIFY2(stats.bytesReceived() > 0,
+            qPrintable(QString("expected non-zero received, got %1")
+                           .arg(stats.bytesReceived())));
+   QCOMPARE(stats.activeRequests(), 0);  // request done
+   QVERIFY(spy.count() > 0);
+
+   qint64 sentAfterFirst = stats.bytesSent();
+   qint64 recvAfterFirst = stats.bytesReceived();
+
+   /* Async request via fetchThumbnailAsync. */
+   QString repoName = QFileInfo(tmpDir.path()).fileName();
+   client.fetchThumbnailAsync(repoName, "testpdf.pdf");
+   QTRY_VERIFY(stats.bytesReceived() > recvAfterFirst);
+   QVERIFY(stats.bytesSent() > sentAfterFirst);
 
    server.stop();
 }

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -33,6 +33,9 @@ private slots:
    //! POST /v1/auth/login + Authorization: Bearer flow
    void testV1AuthLogin();
 
+   //! POST body that arrives in a separate TCP segment is still parsed
+   void testPostBodySplitAcrossReads();
+
    //! /repos hides repos the bearer-authed user is not allowed to see
    void testReposFilteredByUser();
 

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -51,6 +51,11 @@ private slots:
    //! BackendStats accumulates bytes across requests
    void testBackendStatsAccumulates();
 
+   //! Thumbnail rendered locally via File::getImage matches the JPEG
+   //! the server returns from /thumbnail — pinned so the remote
+   //! display can't silently diverge from the local one.
+   void testThumbnailMatchesLocalRender();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -33,6 +33,9 @@ private slots:
    //! POST /v1/auth/login + Authorization: Bearer flow
    void testV1AuthLogin();
 
+   //! /repos hides repos the bearer-authed user is not allowed to see
+   void testReposFilteredByUser();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -56,6 +56,7 @@ private slots:
    //! display can't silently diverge from the local one.
    void testThumbnailMatchesLocalRender();
 
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -48,6 +48,9 @@ private slots:
    //! RemoteBackend::fetchThumbnail round-trips a JPEG from the server
    void testRemoteBackendThumbnail();
 
+   //! BackendStats accumulates bytes across requests
+   void testBackendStatsAccumulates();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -45,6 +45,9 @@ private slots:
    //! Dead server surfaces an error within the request timeout
    void testRemoteBackendTimeout();
 
+   //! RemoteBackend::fetchThumbnail round-trips a JPEG from the server
+   void testRemoteBackendThumbnail();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -30,6 +30,9 @@ private slots:
    //! /v1/status returns apiVersion + a stable serverId
    void testV1StatusEndpoint();
 
+   //! POST /v1/auth/login + Authorization: Bearer flow
+   void testV1AuthLogin();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();
@@ -46,6 +49,14 @@ private slots:
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);
+
+   // HTTP GET with an Authorization: Bearer header
+   Response getWithBearer(const QString &path, const QString &token,
+                          int timeoutMs = 5000);
+
+   // HTTP POST with a JSON body
+   Response postJson(const QString &path, const QByteArray &body,
+                     int timeoutMs = 5000);
 
    // Helper to create test files
    void createTestFiles(const QString& path);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -36,6 +36,9 @@ private slots:
    //! /repos hides repos the bearer-authed user is not allowed to see
    void testReposFilteredByUser();
 
+   //! End-to-end: RemoteBackend login + listRepositories + browseDirectory
+   void testRemoteBackendEndToEnd();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -42,6 +42,9 @@ private slots:
    //! End-to-end: RemoteBackend login + listRepositories + browseDirectory
    void testRemoteBackendEndToEnd();
 
+   //! Dead server surfaces an error within the request timeout
+   void testRemoteBackendTimeout();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -26,6 +26,10 @@ public:
 private slots:
    void testServerStartStop();
    void testStatusEndpoint();
+
+   //! /v1/status returns apiVersion + a stable serverId
+   void testV1StatusEndpoint();
+
    void testSearchEndpoint();
    void testListEndpoint();
    void testInvalidEndpoint();

--- a/tokenstore.cpp
+++ b/tokenstore.cpp
@@ -1,0 +1,48 @@
+/*
+License: GPL-2
+*/
+
+#include "tokenstore.h"
+
+#include <QRandomGenerator>
+
+
+TokenStore::TokenStore()
+{
+}
+
+
+QString TokenStore::mint(const QString &user, int ttl_days)
+{
+   /* 32 random bytes, hex-encoded.  Token is opaque to the client. */
+   QByteArray raw(32, 0);
+   QRandomGenerator::securelySeeded().fillRange(
+      reinterpret_cast<quint32 *>(raw.data()), raw.size() / 4);
+   QString token = QString::fromLatin1(raw.toHex());
+
+   Info info;
+   info.user = user;
+   info.expiry = QDateTime::currentDateTime().addDays(ttl_days);
+   _tokens.insert(token, info);
+   return token;
+}
+
+
+QString TokenStore::lookup(const QString &token)
+{
+   auto it = _tokens.find(token);
+   if (it == _tokens.end())
+      return QString();
+   if (it->expiry.isValid()
+       && it->expiry < QDateTime::currentDateTime()) {
+      _tokens.erase(it);
+      return QString();
+   }
+   return it->user;
+}
+
+
+void TokenStore::revoke(const QString &token)
+{
+   _tokens.remove(token);
+}

--- a/tokenstore.h
+++ b/tokenstore.h
@@ -1,0 +1,53 @@
+/*
+License: GPL-2
+*/
+
+#ifndef TOKENSTORE_H
+#define TOKENSTORE_H
+
+#include <QDateTime>
+#include <QHash>
+#include <QString>
+
+
+/**
+ * In-memory bearer-token store.  Server restart invalidates all
+ * tokens; that's intentional for v1.  Tokens carry the user name they
+ * were minted for and an expiry timestamp.
+ */
+class TokenStore
+{
+public:
+    struct Info
+    {
+        QString user;
+        QDateTime expiry;
+    };
+
+    TokenStore();
+
+    /**
+     * Mint a new token for the given user with the given TTL.  Returns
+     * the opaque token string the client should pass in
+     * `Authorization: Bearer <token>`.  Default TTL is 30 days.
+     */
+    QString mint(const QString &user, int ttl_days = 30);
+
+    /**
+     * Look up a token.  Returns the user name on success, or an empty
+     * string if the token is unknown or expired (expired tokens are
+     * also evicted as a side effect).
+     */
+    QString lookup(const QString &token);
+
+    /** Forget a token (logout). */
+    void revoke(const QString &token);
+
+    /** Number of currently-live tokens (for tests). */
+    int liveCount() const { return _tokens.size(); }
+
+private:
+    QHash<QString, Info> _tokens;
+};
+
+#endif // TOKENSTORE_H

--- a/userstore.cpp
+++ b/userstore.cpp
@@ -1,0 +1,271 @@
+/*
+License: GPL-2
+*/
+
+#include "userstore.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageAuthenticationCode>
+#include <QRandomGenerator>
+#include <QStandardPaths>
+
+
+/* Iteration count tuned to ~50 ms on a 2024-era laptop core.  Using
+ * PBKDF2-HMAC-SHA256 keeps the dependencies inside Qt; argon2 would be
+ * stronger but pulls in libargon2.  Bump iter when CPUs get faster. */
+static const int kPbkdf2Iters = 200000;
+static const int kSaltBytes   = 16;
+static const int kHashBytes   = 32;
+
+
+static QByteArray randomBytes(int n)
+{
+   QByteArray out(n, 0);
+   QRandomGenerator::securelySeeded().fillRange(
+      reinterpret_cast<quint32 *>(out.data()), n / 4);
+   /* Tail bytes if n % 4 != 0 — paranoia.  kSaltBytes is divisible by 4. */
+   return out;
+}
+
+
+/* PBKDF2-HMAC-SHA256 implementation using Qt's HMAC primitive.  RFC 8018. */
+static QByteArray pbkdf2_sha256(const QByteArray &password,
+                                const QByteArray &salt, int iters,
+                                int outLen)
+{
+   QByteArray out;
+   int blocks = (outLen + 31) / 32;
+   for (int i = 1; i <= blocks; i++) {
+      QByteArray block_index(4, 0);
+      block_index[0] = (char)((i >> 24) & 0xff);
+      block_index[1] = (char)((i >> 16) & 0xff);
+      block_index[2] = (char)((i >> 8)  & 0xff);
+      block_index[3] = (char)(i & 0xff);
+
+      QMessageAuthenticationCode mac(QCryptographicHash::Sha256);
+      mac.setKey(password);
+      mac.addData(salt);
+      mac.addData(block_index);
+      QByteArray u = mac.result();
+      QByteArray t = u;
+
+      for (int j = 1; j < iters; j++) {
+         QMessageAuthenticationCode mac2(QCryptographicHash::Sha256);
+         mac2.setKey(password);
+         mac2.addData(u);
+         u = mac2.result();
+         for (int k = 0; k < t.size(); k++)
+            t[k] = t[k] ^ u[k];
+      }
+      out.append(t);
+   }
+   out.truncate(outLen);
+   return out;
+}
+
+
+QString UserStore::hashPassword(const QString &password)
+{
+   QByteArray salt = randomBytes(kSaltBytes);
+   QByteArray hash = pbkdf2_sha256(password.toUtf8(), salt, kPbkdf2Iters,
+                                   kHashBytes);
+   return QString("pbkdf2-sha256$%1$%2$%3")
+            .arg(kPbkdf2Iters)
+            .arg(QString::fromLatin1(salt.toBase64()))
+            .arg(QString::fromLatin1(hash.toBase64()));
+}
+
+
+bool UserStore::verifyPassword(const QString &password,
+                               const QString &storedHash)
+{
+   QStringList parts = storedHash.split('$');
+   if (parts.size() != 4 || parts[0] != "pbkdf2-sha256")
+      return false;
+   bool ok = false;
+   int iters = parts[1].toInt(&ok);
+   if (!ok || iters < 1)
+      return false;
+   QByteArray salt = QByteArray::fromBase64(parts[2].toLatin1());
+   QByteArray expected = QByteArray::fromBase64(parts[3].toLatin1());
+   if (salt.isEmpty() || expected.isEmpty())
+      return false;
+   QByteArray actual = pbkdf2_sha256(password.toUtf8(), salt, iters,
+                                     expected.size());
+   /* Constant-time comparison.  Length must match. */
+   if (actual.size() != expected.size())
+      return false;
+   int diff = 0;
+   for (int i = 0; i < actual.size(); i++)
+      diff |= (uchar)actual[i] ^ (uchar)expected[i];
+   return diff == 0;
+}
+
+
+static QString defaultPath()
+{
+   return QStandardPaths::writableLocation(
+                QStandardPaths::GenericConfigLocation)
+          + "/paperman-server/users.json";
+}
+
+
+UserStore::UserStore()
+   : _path(defaultPath())
+{
+   load();
+}
+
+
+UserStore::UserStore(const QString &path)
+   : _path(path)
+{
+   load();
+}
+
+
+bool UserStore::load()
+{
+   _users.clear();
+
+   QFile f(_path);
+   if (!f.exists())
+      return true;  /* empty store is fine */
+   if (!f.open(QIODevice::ReadOnly))
+      return false;
+   QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+   if (!doc.isObject())
+      return false;
+   QJsonObject obj = doc.object();
+   for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+      QString name = it.key();
+      QJsonObject u = it.value().toObject();
+      User user;
+      user.name  = name;
+      user.hash  = u.value("hash").toString();
+      user.admin = u.value("admin").toBool(false);
+      QJsonArray repos = u.value("repos").toArray();
+      for (auto r : repos)
+         user.repos << r.toString();
+      _users.insert(name, user);
+   }
+   return true;
+}
+
+
+bool UserStore::save()
+{
+   QFileInfo fi(_path);
+   QDir().mkpath(fi.dir().path());
+
+   QJsonObject obj;
+   for (auto it = _users.constBegin(); it != _users.constEnd(); ++it) {
+      const User &u = it.value();
+      QJsonObject record;
+      record["hash"]  = u.hash;
+      record["admin"] = u.admin;
+      QJsonArray repos;
+      for (const QString &r : u.repos)
+         repos.append(r);
+      record["repos"] = repos;
+      obj[u.name] = record;
+   }
+
+   QFile f(_path);
+   if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+      return false;
+   f.write(QJsonDocument(obj).toJson(QJsonDocument::Indented));
+   f.close();
+   /* Tighten permissions: hashes are sensitive even though they're
+    * derived. */
+   QFile::setPermissions(_path,
+      QFile::ReadOwner | QFile::WriteOwner);
+   return true;
+}
+
+
+QStringList UserStore::userNames() const
+{
+   QStringList out = _users.keys();
+   out.sort();
+   return out;
+}
+
+
+bool UserStore::hasUser(const QString &name) const
+{
+   return _users.contains(name);
+}
+
+
+bool UserStore::addUser(const QString &name, const QString &password)
+{
+   if (name.isEmpty() || _users.contains(name))
+      return false;
+   User u;
+   u.name = name;
+   u.hash = hashPassword(password);
+   _users.insert(name, u);
+   return save();
+}
+
+
+bool UserStore::setPassword(const QString &name, const QString &password)
+{
+   auto it = _users.find(name);
+   if (it == _users.end())
+      return false;
+   it->hash = hashPassword(password);
+   return save();
+}
+
+
+bool UserStore::delUser(const QString &name)
+{
+   if (_users.remove(name) == 0)
+      return false;
+   return save();
+}
+
+
+bool UserStore::setRepos(const QString &name, const QStringList &repos)
+{
+   auto it = _users.find(name);
+   if (it == _users.end())
+      return false;
+   it->repos = repos;
+   return save();
+}
+
+
+bool UserStore::verify(const QString &name, const QString &password) const
+{
+   auto it = _users.constFind(name);
+   if (it == _users.constEnd())
+      return false;
+   return verifyPassword(password, it->hash);
+}
+
+
+bool UserStore::repoAllowed(const QString &name, const QString &repo) const
+{
+   auto it = _users.constFind(name);
+   if (it == _users.constEnd())
+      return false;
+   if (it->repos.isEmpty())
+      return true;
+   return it->repos.contains(repo);
+}
+
+
+const UserStore::User *UserStore::lookup(const QString &name) const
+{
+   auto it = _users.constFind(name);
+   if (it == _users.constEnd())
+      return nullptr;
+   return &it.value();
+}

--- a/userstore.h
+++ b/userstore.h
@@ -1,0 +1,98 @@
+/*
+License: GPL-2
+*/
+
+#ifndef USERSTORE_H
+#define USERSTORE_H
+
+#include <QHash>
+#include <QString>
+#include <QStringList>
+
+
+/**
+ * User account store backed by a JSON file (default
+ * ~/.config/paperman-server/users.json).
+ *
+ * Passwords are stored as PBKDF2-SHA256 hashes with a per-user random
+ * salt and a fixed iteration count.  Each user has an optional repo
+ * allowlist: if empty, the user can see all configured repositories;
+ * otherwise only the listed repo names are visible.
+ *
+ * The store is intentionally small: no roles, no groups, no
+ * password-complexity rules.  The caller is responsible for prompting
+ * the user for a password and for rejecting empty inputs.
+ */
+class UserStore
+{
+public:
+    /** Per-user record. */
+    struct User
+    {
+        QString name;
+        QString hash;          //!< pbkdf2-sha256$<iters>$<salt-b64>$<hash-b64>
+        QStringList repos;     //!< Empty means "all repos"
+        bool admin = false;    //!< Reserved for future use
+    };
+
+    /** Construct against the default users-file path. */
+    UserStore();
+
+    /** Construct against a specific users-file path (used by tests). */
+    explicit UserStore(const QString &path);
+
+    /** The on-disk file this store reads/writes. */
+    QString filePath() const { return _path; }
+
+    /** Reload from disk.  Returns true on success. */
+    bool load();
+
+    /** Persist the in-memory state to disk.  Returns true on success. */
+    bool save();
+
+    /** Number of registered users. */
+    int count() const { return _users.size(); }
+
+    /** List user names. */
+    QStringList userNames() const;
+
+    /** True if `name` exists. */
+    bool hasUser(const QString &name) const;
+
+    /** Add a new user with the given password.  Fails if already exists. */
+    bool addUser(const QString &name, const QString &password);
+
+    /** Change a user's password.  Fails if user does not exist. */
+    bool setPassword(const QString &name, const QString &password);
+
+    /** Delete a user.  Fails if user does not exist. */
+    bool delUser(const QString &name);
+
+    /** Replace a user's repo allowlist.  Empty list means "all repos". */
+    bool setRepos(const QString &name, const QStringList &repos);
+
+    /** Returns true if the user exists and the password matches. */
+    bool verify(const QString &name, const QString &password) const;
+
+    /** True if the user can see the given repository.  Returns false for
+     * unknown users.  For known users with an empty allowlist, returns
+     * true.
+     */
+    bool repoAllowed(const QString &name, const QString &repo) const;
+
+    /** Read access for tests and admin CLI. */
+    const User *lookup(const QString &name) const;
+
+    /** Hash a password with a fresh salt.  Public for testability. */
+    static QString hashPassword(const QString &password);
+
+    /** Verify a password against a stored hash.  Public for testability. */
+    static bool verifyPassword(const QString &password,
+                               const QString &storedHash);
+
+private:
+    QString _path;
+    QHash<QString, User> _users;
+};
+
+#endif // USERSTORE_H

--- a/utils.cpp
+++ b/utils.cpp
@@ -1079,36 +1079,42 @@ TreeItem *utilReadTree(QString fname, QString rootName)
    return root;
 }
 
+/* The chmod and chown only make sense when paperman is configured to
+ * share its scratch directories with a public group (set via the
+ * QSettings key "files/group", consumed by utilInit()).  When no group
+ * is configured, paperman is running for a single user — there is no
+ * one to share with — and the previous unconditional chmod 0666/0777
+ * just produced noise on directories the user didn't own (e.g. files
+ * on an NFS mount).  Skip silently when public_gid is unset. */
+
 bool utilSetDirGroup(const QString& dirname)
 {
+    if (public_gid == -1)
+        return true;
     if (chmod(qPrintable(dirname), 0777) == -1) {
         qInfo() << "Failed to change permissions" << dirname;
         return false;
     }
-    if (public_gid != -1) {
-        if (chown(qPrintable(dirname), -1, public_gid) == -1) {
-            qInfo() << "Failed to change group" << public_gid << dirname;
-            return false;
-        }
+    if (chown(qPrintable(dirname), -1, public_gid) == -1) {
+        qInfo() << "Failed to change group" << public_gid << dirname;
+        return false;
     }
-
     return true;
 }
 
 bool utilSetGroup(const QString& fname)
 {
+    if (public_gid == -1)
+        return true;
     if (chmod(qPrintable(fname), 0666) == -1) {
         qInfo() << "Failed to change permissions" << fname;
         return false;
     }
-   if (public_gid != -1) {
-      if (chown(qPrintable(fname), -1, public_gid) == -1) {
-         qInfo() << "Failed to change group" << public_gid << fname;
-         return false;
-      }
-   }
-
-   return true;
+    if (chown(qPrintable(fname), -1, public_gid) == -1) {
+        qInfo() << "Failed to change group" << public_gid << fname;
+        return false;
+    }
+    return true;
 }
 
 QString utilUserName()

--- a/utils.cpp
+++ b/utils.cpp
@@ -161,6 +161,7 @@ typedef struct jpeg_dest_info
    byte *data;
    int pos;
    int size;
+   bool overflow;   //!< the output did not fit in the buffer
    } jpeg_dest_info;
 
 
@@ -307,9 +308,17 @@ static void init_destination (j_compress_ptr cinfo)
    }
 
 
+/* called by libjpeg when the output buffer is full. We cannot grow the
+   buffer, so record the overflow and let libjpeg continue writing from
+   the start of the buffer. The output is useless but stays in bounds;
+   jpeg_encode() reports the failure through its size */
 static boolean empty_output_buffer (j_compress_ptr cinfo)
    {
-   cinfo = cinfo;
+   jpeg_dest_info *dest = (jpeg_dest_info *)cinfo->dest;
+
+   dest->overflow = true;
+   dest->pub.next_output_byte = dest->data;
+   dest->pub.free_in_buffer = dest->size;
    return true;
    }
 
@@ -337,6 +346,7 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
 
   dest.data = outbuff;
   dest.size = *size;
+  dest.overflow = false;
 //  dest.pub.next_output_byte = NULL;
 //  dest.pub.free_in_buffer = 0;
   dest.pub.next_output_byte = outbuff;
@@ -415,7 +425,8 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
      /* Step 6: Finish compression */
      jpeg_finish_compress(&cinfo);
 
-      *size = dest.pub.next_output_byte - outbuff;
+      // report an overflowed buffer rather than returning rubbish
+      *size = dest.overflow ? -1 : dest.pub.next_output_byte - outbuff;
       }
    jpeg_destroy_compress(&cinfo);
    free (buff);

--- a/utils.cpp
+++ b/utils.cpp
@@ -21,6 +21,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
  Public License can be found in the /usr/share/common-licenses/GPL file.
 */
 
+#include <cerrno>
+#include <cstring>
 #include <grp.h>
 
 #include <QDate>
@@ -1085,18 +1087,28 @@ TreeItem *utilReadTree(QString fname, QString rootName)
  * is configured, paperman is running for a single user — there is no
  * one to share with — and the previous unconditional chmod 0666/0777
  * just produced noise on directories the user didn't own (e.g. files
- * on an NFS mount).  Skip silently when public_gid is unset. */
+ * on an NFS mount).  Skip silently when public_gid is unset.
+ *
+ * Even when a group IS configured, EPERM from chmod/chown is
+ * expected on shared NFS paths owned by other UIDs; treat that as
+ * not-our-problem and silently move on.  Other errors (ENOENT, EIO,
+ * misconfigured group) still warn so genuinely broken setups get
+ * surfaced. */
 
 bool utilSetDirGroup(const QString& dirname)
 {
     if (public_gid == -1)
         return true;
     if (chmod(qPrintable(dirname), 0777) == -1) {
-        qInfo() << "Failed to change permissions" << dirname;
+        if (errno != EPERM)
+            qInfo() << "Failed to change permissions" << dirname
+                    << ":" << strerror(errno);
         return false;
     }
     if (chown(qPrintable(dirname), -1, public_gid) == -1) {
-        qInfo() << "Failed to change group" << public_gid << dirname;
+        if (errno != EPERM)
+            qInfo() << "Failed to change group" << public_gid << dirname
+                    << ":" << strerror(errno);
         return false;
     }
     return true;
@@ -1107,11 +1119,15 @@ bool utilSetGroup(const QString& fname)
     if (public_gid == -1)
         return true;
     if (chmod(qPrintable(fname), 0666) == -1) {
-        qInfo() << "Failed to change permissions" << fname;
+        if (errno != EPERM)
+            qInfo() << "Failed to change permissions" << fname
+                    << ":" << strerror(errno);
         return false;
     }
     if (chown(qPrintable(fname), -1, public_gid) == -1) {
-        qInfo() << "Failed to change group" << public_gid << fname;
+        if (errno != EPERM)
+            qInfo() << "Failed to change group" << public_gid << fname
+                    << ":" << strerror(errno);
         return false;
     }
     return true;

--- a/utils.cpp
+++ b/utils.cpp
@@ -321,7 +321,7 @@ static void term_destination (j_compress_ptr cinfo)
 
 
 void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
-            int bpp, int line_bytes, int quality)
+            int bpp, int line_bytes, int quality, int valid_width)
    {
   struct jpeg_compress_struct cinfo;
   jpeg_dest_info dest;
@@ -347,8 +347,17 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
 
 //  printf ("jpeg_encode: bpp=%d\n", bpp);
 
+  /* the tile may be wider than the source image (it is padded to a
+     multiple of 8 pixels), in which case only valid_width pixels exist
+     in each source row and the rest must be synthesised */
+  int out_bpp = bpp == 8 ? 1 : 3;
+  int valid = valid_width;
+  if (valid < 1 || valid > tile_size->x)
+     valid = tile_size->x;
+
   *size = 0;
-  buff = (byte *)malloc (row_stride);
+  bytes = tile_size->x * out_bpp;
+  buff = (byte *)malloc (bytes > row_stride ? bytes : row_stride);
   if (!buff)
      return;   // should report error, but I suppose *size is 0
 
@@ -366,7 +375,6 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
      cinfo.image_height = tile_size->y;
      cinfo.input_components = bpp == 8 ? 1 : 3;    /* # of color components per pixel */
      cinfo.in_color_space = bpp == 8 ? JCS_GRAYSCALE : JCS_RGB;   /* colorspace of input image */
-     bytes = cinfo.image_width * bpp / 8;
      jpeg_set_defaults(&cinfo);
      jpeg_set_quality(&cinfo, quality, true /* limit to baseline-JPEG values */);
 
@@ -386,7 +394,7 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
           u_int32_t *in;
           byte *out;
 
-          for (i = cinfo.image_width, in = (unsigned *)ptr, out = buff; i != 0;
+          for (i = valid, in = (unsigned *)ptr, out = buff; i != 0;
                i--, in++, out += 3)
              {
              out [2] = *in;
@@ -395,7 +403,12 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
              }
           }
        else
-          memcpy (buff, ptr, bytes);
+          memcpy (buff, ptr, valid * out_bpp);
+
+       // fill the padding columns by repeating the last valid pixel
+       for (int x = valid; x < (int)cinfo.image_width; x++)
+          memcpy (buff + x * out_bpp, buff + (valid - 1) * out_bpp,
+                  out_bpp);
        (void) jpeg_write_scanlines(&cinfo, row_pointer, 1);
      }
 

--- a/utils.h
+++ b/utils.h
@@ -160,7 +160,8 @@ QString removeExtension (const QString &fname, QString &ext);
    \param tile_size   tile size in pixels (the width may be padded
                       beyond the source image)
    \param outbuff     output buffer
-   \param size        in: buffer size; out: encoded size
+   \param size        in: buffer size; out: encoded size, or -1 if the
+                      output did not fit in the buffer
    \param bpp         source depth (8, 24 or 32)
    \param line_bytes  source bytes per line
    \param quality     JPEG quality (0-100)

--- a/utils.h
+++ b/utils.h
@@ -154,8 +154,22 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
 
 QString removeExtension (const QString &fname, QString &ext);
 
+/** JPEG-encode an image tile
+
+   \param image       source pixels
+   \param tile_size   tile size in pixels (the width may be padded
+                      beyond the source image)
+   \param outbuff     output buffer
+   \param size        in: buffer size; out: encoded size
+   \param bpp         source depth (8, 24 or 32)
+   \param line_bytes  source bytes per line
+   \param quality     JPEG quality (0-100)
+   \param valid_width number of pixels present in each source row; any
+                      further (padding) columns repeat the last valid
+                      pixel rather than reading beyond the source.
+                      -1 means the full tile width is valid */
 void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
-            int bpp, int line_bytes, int quality);
+            int bpp, int line_bytes, int quality, int valid_width = -1);
 
 void memtest (const char *name);
 


### PR DESCRIPTION
Investigating the intermittent 'unknown tile code' failure in CI's
parallel-conversion test turned up five bugs in the .max reader and
tile encoder.

The actual cause of the CI flake is in the reader, not the converter:
the small read cache serves 2- and 4-byte fields from a 4KB window
with padded ends, and a read which straddles the end of the window
returns padding bytes instead of file data. Qt 5 zero-filled that
padding but Qt 6 leaves it uninitialised, so whether the failure
appeared depended on the file layout, and the value read changed from
run to run - hence Qt5 passing, Qt6 failing intermittently, and a
clean rerun.

The remaining fixes were found with AddressSanitizer and by chasing
nondeterminism in the output: the JPEG tile encoder read past the
rendered page on padded edge tiles, libjpeg overflowed the encode
buffer silently when a tile did not fit, tiles were written with
uninitialised alignment padding, and the 1-bit preview read source
bits from uninitialised row padding.

A regression test covers the cache-window straddle directly.
Converting the same input twice now produces identical bytes apart
from the per-page timestamps, so any future corruption will be
reproducible rather than intermittent.