### PR TITLE
Fix the parallel-conversion corruption and make output deterministic

### DIFF
--- a/err.cpp
+++ b/err.cpp
@@ -56,6 +56,7 @@ static const char *err_msg [ERR_count] =
    "Bermuda chunk corrupt at %x",
    "G4 compression failed",
    "G4 decompression failed",
+   "JPEG compression failed",
    "Could not create directory '%s'",
    "Could not write image to '%s' as %s",
    "Could not read multi-page images from file '%s'",

--- a/err.h
+++ b/err.h
@@ -68,6 +68,7 @@ enum
    ERR_bermuda_chunk_corrupt1,
    ERR_g4_compression_failed,
    ERR_g4_decompression_failed,
+   ERR_jpeg_compression_failed,
    ERR_could_not_create_directory1,
    ERR_could_not_write_image_to_as2,
    ERR_could_not_read_multipage_images1,

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -734,9 +734,9 @@ err_info *Filemax::max_cache_data (cache_info &cache, int pos,
    {
    int n;
 
-   // Allocate extra padding so that callers which read a 4-byte word
-   // near the end of the buffer (e.g. decode_compressed_tile) do not
-   // overflow.  Qt zero-fills the extra bytes.
+   /* Allocate extra padding so that callers which read a 4-byte word
+      near the end of the buffer (e.g. decode_compressed_tile) do not
+      overflow */
    cache.buff.resize (size + 4);
 
    // read the data
@@ -751,9 +751,16 @@ err_info *Filemax::max_cache_data (cache_info &cache, int pos,
                _size);
       }
 
+   /* Zero everything fread() did not fill, including the padding. Qt 5
+      zero-filled the bytes added by resize() but Qt 6 leaves them
+      uninitialised, so a caller reading into the padding would see
+      values which change from run to run */
+   memset (cache.buff.data () + n, 0, cache.buff.size () - n);
+
    if (datap)
       *datap = (byte *)cache.buff.data ();
    cache.pos = pos;
+   cache.len = n;
    return NULL;
    }
 
@@ -764,9 +771,14 @@ byte *Filemax::max_check_scache (int pos)
    err_info *err = NULL;
 
 #define CACHE_4K_SIZE  4096
-   // if the cache has the wrong data, load it
-   if (pos < _scache.pos || (pos + 4 > _scache.pos + _scache.buff.size ()))
-      err = max_cache_data (_scache, pos, CACHE_4K_SIZE, 4, NULL);
+   /* Reload the cache unless all 4 bytes lie within the valid data.
+      Checking against the valid length matters: the buffer is padded,
+      and a read which straddles the end of the data would otherwise
+      return padding bytes instead of the real file contents. A minimum
+      of 2 allows a halfword read at the very end of the file, where
+      the padding is zeroed */
+   if (pos < _scache.pos || pos + 4 > _scache.pos + _scache.len)
+      err = max_cache_data (_scache, pos, CACHE_4K_SIZE, 2, NULL);
 
    // return the data
    if (err)
@@ -812,6 +824,7 @@ void Filemax::max_clear_cache (cache_info &cache, int pos, int size)
       {
       cache.buff.clear ();
       cache.pos = 0;
+      cache.len = 0;
       }
    }
 

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -4156,10 +4156,10 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
          break;
       }
 
-   // get size, rounding up to word boundary
-//   *sizep = out - encode->buff;
+   /* round up to a word boundary, zeroing the padding so that no
+      uninitialised bytes are written to the file */
    while (size & 3)
-      size++;
+      out [size++] = '\0';
    *sizep = size;
    return NULL;
    }
@@ -4186,7 +4186,7 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
       size plus headroom */
    encode.size = chunk.tile_size.x * chunk.tile_size.y *
          (bpp == 1 ? 1 : 4) + 1024;
-   encode.buff = (byte *)malloc (encode.size);
+   encode.buff = (byte *)malloc (encode.size + 8);
    if (!encode.buff)
       return ERR (-ENOMEM);
 

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -1511,7 +1511,8 @@ position in the image of the top left of the tile
    \param stride     image stride (line_bytes) value, pass as -1 to use
                             chunk->line_bytes */
 static byte *get_tile_size (chunk_info &chunk, int x, int y, cpoint *tile_size,
-                  int *tilenum, int stride, int tile_stride)
+                  int *tilenum, int stride, int tile_stride,
+                  int *valid_xp = NULL)
    {
    byte *ptr;
 
@@ -1531,6 +1532,13 @@ static byte *get_tile_size (chunk_info &chunk, int x, int y, cpoint *tile_size,
    tile_size->x = chunk.image_size.x - chunk.tile_size.x * x;
    if (tile_size->x > chunk.tile_size.x)
       tile_size->x = chunk.tile_size.x;
+
+   /* the tile width is padded to a multiple of 8 pixels, so it can
+      extend past the right edge of the image. Return the unpadded
+      width so that the encoder does not read pixels which don't
+      exist */
+   if (valid_xp)
+      *valid_xp = tile_size->x;
    tile_size->x = (tile_size->x + 7) & ~7;
    *tilenum = chunk.tile_extent.x * y + x;  // tile sequence number
    return ptr;
@@ -4118,7 +4126,7 @@ static err_info *encode_g4 (byte *out, int tile_line_bytes, byte *end,
 
 err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
               byte *ptr, cpoint *tile_size, int stride, int bpp,
-              int tile_line_bytes, int debug_max_steps)
+              int tile_line_bytes, int debug_max_steps, int valid_x)
    {
    byte *out = encode.buff, *end = encode.buff + encode.size;
    int size;
@@ -4142,7 +4150,7 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
       case 32 :
          size = encode.size;
          jpeg_encode (ptr, tile_size, out, &size, bpp, stride,
-              JPEG_QUALITY);
+              JPEG_QUALITY, valid_x);
          break;
       }
 
@@ -4186,10 +4194,11 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
          {
          int tilenum;
          int tile_line_bytes;
+         int valid_x;
 
          // recalculate tile_line_bytes each time
          ptr = get_tile_size (chunk, x, y, &tile_size, &tilenum, stride,
-                  encode.tile_line_bytes);
+                  encode.tile_line_bytes, &valid_x);
 
          calc_tile_bytes (tile_size.x, chunk.image_size.x, bpp,
                     &tile_line_bytes, &temp, false);
@@ -4202,7 +4211,7 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
             debug2 (("encoding tile %d (%d, %d), bpp %d, size %d x %d (0x%x x 0x%d)\n", tilenum, x, y,
                   bpp, tile_size.x, tile_size.y, tile_size.x, tile_size.y));
             e = encode_tile (chunk, encode, &size, ptr, &tile_size, stride,
-                  bpp, tile_line_bytes, debug.max_steps);
+                  bpp, tile_line_bytes, debug.max_steps, valid_x);
             if (e)
                {
                printf ("encode_tile() failed, tile %d\n", tilenum);

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -3034,13 +3034,18 @@ static int scale_2bpp (byte *image, cpoint *image_size, byte *preview,
          assert (in >= image && in <= image + image_line_bytes * (image_size->y - 1));
          mask = 1;
 
-         // calculate the value for each preview pixel
+         /* calculate the value for each preview pixel. The preview
+            width is padded to a multiple of 4 pixels, so the source
+            position can pass the right edge of the image: treat those
+            pixels as white rather than reading bits from the row
+            padding, which holds uninitialised data */
          for (x = 0; x < preview_size->x; x++)
             {
             sum = 0;
             for (xsub = 0; xsub < PREVIEW_SCALE; xsub++)
                {
-               sum += *in & mask ? 255 : 0;
+               if (x * PREVIEW_SCALE + xsub < image_size->x)
+                  sum += *in & mask ? 255 : 0;
                mask <<= 1;
                if (mask == 0x100)
                   {

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -4151,6 +4151,8 @@ err_info *encode_tile (chunk_info &chunk, encode_info &encode, int *sizep,
          size = encode.size;
          jpeg_encode (ptr, tile_size, out, &size, bpp, stride,
               JPEG_QUALITY, valid_x);
+         if (size < 0)
+            return err_make (ERRFN, ERR_jpeg_compression_failed);
          break;
       }
 
@@ -4179,8 +4181,11 @@ static int build_tiledata (chunk_info &chunk, int stride, int bpp,
 
    debug2 (("image size %d x %d\n", chunk.image_size.x, chunk.image_size.y));
 
-   // allocate enough memory for encoding each tile
-   encode.size = chunk.tile_size.x * chunk.tile_size.y;  // should be enough
+   /* allocate enough memory for encoding each tile. A JPEG of a noisy
+      tile can be larger than the raw pixels, so allow the full pixel
+      size plus headroom */
+   encode.size = chunk.tile_size.x * chunk.tile_size.y *
+         (bpp == 1 ? 1 : 4) + 1024;
    encode.buff = (byte *)malloc (encode.size);
    if (!encode.buff)
       return ERR (-ENOMEM);

--- a/filemax.h
+++ b/filemax.h
@@ -66,6 +66,7 @@ typedef struct cache_info
 //   int alloced;   //!< amount alloced to cache
 //   int size;      //!< size of cache
    int pos;       //!< file position of data in cache
+   int len;       //!< number of valid bytes in the cache
    } cache_info;
 
 

--- a/filemax.h
+++ b/filemax.h
@@ -147,6 +147,7 @@ typedef struct page_info
 class Filemax : public File
    {
    Q_OBJECT
+   friend class TestFile;
 
 public:
    Filemax (const QString &dir, const QString &filename, Desk *desk);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -508,3 +508,51 @@ void TestFile::testStackItemTypeMismatch()
    delete pdf;
    delete jpg;
 }
+
+void TestFile::testCacheBoundaryReads()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+   QString path = copyFixture("testfile.max", tmp.path());
+   QVERIFY(!path.isEmpty());
+
+   QFile raw(path);
+   QVERIFY(raw.open(QIODevice::ReadOnly));
+   QByteArray bytes = raw.readAll();
+   QVERIFY(bytes.size() > 3 * 4096 + 4200);
+
+   Filemax f(dir, "testfile.max", nullptr);
+   QVERIFY(f.load() == nullptr);
+   QVERIFY(f.ensure_open() == nullptr);
+
+   auto hw_at = [&bytes](int pos) {
+      return int(quint8(bytes[pos]) | quint8(bytes[pos + 1]) << 8);
+   };
+   auto word_at = [&bytes](int pos) {
+      return int(quint32(quint8(bytes[pos]))
+                 | quint32(quint8(bytes[pos + 1])) << 8
+                 | quint32(quint8(bytes[pos + 2])) << 16
+                 | quint32(quint8(bytes[pos + 3])) << 24);
+   };
+
+   /* getword() and gethw() read through a 4KB cache window which has a
+      few bytes of padding on the end. A read which straddles the end
+      of the window's valid data must reload the cache rather than
+      returning padding bytes, which are not file data. Seed the window
+      at a known start, then read across its boundary, checking every
+      value against the raw file bytes */
+   for (int window = 0; window <= 2 * 4096; window += 4096)
+      for (int off = 4090; off <= 4096; off++) {
+         int pos = window + off;
+
+         f.gethw(window);   // make the cache window start at 'window'
+         QCOMPARE(f.getword(pos), word_at(pos));
+
+         f.gethw(window);
+         QCOMPARE(f.gethw(pos), hw_at(pos));
+      }
+
+   // a halfword at the very end of the file can still be read
+   QCOMPARE(f.gethw(bytes.size() - 2), hw_at(bytes.size() - 2));
+}

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -63,6 +63,10 @@ private slots:
    //! to the per-subclass stackStack
    void testStackItemTypeMismatch();
 
+   //! getword/gethw return real file bytes even when the read straddles
+   //! the end of a cache window
+   void testCacheBoundaryReads();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/utils.cpp
+++ b/utils.cpp
@@ -161,6 +161,7 @@ typedef struct jpeg_dest_info
    byte *data;
    int pos;
    int size;
+   bool overflow;   //!< the output did not fit in the buffer
    } jpeg_dest_info;
 
 
@@ -307,9 +308,17 @@ static void init_destination (j_compress_ptr cinfo)
    }
 
 
+/* called by libjpeg when the output buffer is full. We cannot grow the
+   buffer, so record the overflow and let libjpeg continue writing from
+   the start of the buffer. The output is useless but stays in bounds;
+   jpeg_encode() reports the failure through its size */
 static boolean empty_output_buffer (j_compress_ptr cinfo)
    {
-   cinfo = cinfo;
+   jpeg_dest_info *dest = (jpeg_dest_info *)cinfo->dest;
+
+   dest->overflow = true;
+   dest->pub.next_output_byte = dest->data;
+   dest->pub.free_in_buffer = dest->size;
    return true;
    }
 
@@ -337,6 +346,7 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
 
   dest.data = outbuff;
   dest.size = *size;
+  dest.overflow = false;
 //  dest.pub.next_output_byte = NULL;
 //  dest.pub.free_in_buffer = 0;
   dest.pub.next_output_byte = outbuff;
@@ -415,7 +425,8 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
      /* Step 6: Finish compression */
      jpeg_finish_compress(&cinfo);
 
-      *size = dest.pub.next_output_byte - outbuff;
+      // report an overflowed buffer rather than returning rubbish
+      *size = dest.overflow ? -1 : dest.pub.next_output_byte - outbuff;
       }
    jpeg_destroy_compress(&cinfo);
    free (buff);

--- a/utils.cpp
+++ b/utils.cpp
@@ -321,7 +321,7 @@ static void term_destination (j_compress_ptr cinfo)
 
 
 void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
-            int bpp, int line_bytes, int quality)
+            int bpp, int line_bytes, int quality, int valid_width)
    {
   struct jpeg_compress_struct cinfo;
   jpeg_dest_info dest;
@@ -347,8 +347,17 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
 
 //  printf ("jpeg_encode: bpp=%d\n", bpp);
 
+  /* the tile may be wider than the source image (it is padded to a
+     multiple of 8 pixels), in which case only valid_width pixels exist
+     in each source row and the rest must be synthesised */
+  int out_bpp = bpp == 8 ? 1 : 3;
+  int valid = valid_width;
+  if (valid < 1 || valid > tile_size->x)
+     valid = tile_size->x;
+
   *size = 0;
-  buff = (byte *)malloc (row_stride);
+  bytes = tile_size->x * out_bpp;
+  buff = (byte *)malloc (bytes > row_stride ? bytes : row_stride);
   if (!buff)
      return;   // should report error, but I suppose *size is 0
 
@@ -366,7 +375,6 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
      cinfo.image_height = tile_size->y;
      cinfo.input_components = bpp == 8 ? 1 : 3;    /* # of color components per pixel */
      cinfo.in_color_space = bpp == 8 ? JCS_GRAYSCALE : JCS_RGB;   /* colorspace of input image */
-     bytes = cinfo.image_width * bpp / 8;
      jpeg_set_defaults(&cinfo);
      jpeg_set_quality(&cinfo, quality, true /* limit to baseline-JPEG values */);
 
@@ -386,7 +394,7 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
           u_int32_t *in;
           byte *out;
 
-          for (i = cinfo.image_width, in = (unsigned *)ptr, out = buff; i != 0;
+          for (i = valid, in = (unsigned *)ptr, out = buff; i != 0;
                i--, in++, out += 3)
              {
              out [2] = *in;
@@ -395,7 +403,12 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
              }
           }
        else
-          memcpy (buff, ptr, bytes);
+          memcpy (buff, ptr, valid * out_bpp);
+
+       // fill the padding columns by repeating the last valid pixel
+       for (int x = valid; x < (int)cinfo.image_width; x++)
+          memcpy (buff + x * out_bpp, buff + (valid - 1) * out_bpp,
+                  out_bpp);
        (void) jpeg_write_scanlines(&cinfo, row_pointer, 1);
      }
 

--- a/utils.h
+++ b/utils.h
@@ -160,7 +160,8 @@ QString removeExtension (const QString &fname, QString &ext);
    \param tile_size   tile size in pixels (the width may be padded
                       beyond the source image)
    \param outbuff     output buffer
-   \param size        in: buffer size; out: encoded size
+   \param size        in: buffer size; out: encoded size, or -1 if the
+                      output did not fit in the buffer
    \param bpp         source depth (8, 24 or 32)
    \param line_bytes  source bytes per line
    \param quality     JPEG quality (0-100)

--- a/utils.h
+++ b/utils.h
@@ -154,8 +154,22 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
 
 QString removeExtension (const QString &fname, QString &ext);
 
+/** JPEG-encode an image tile
+
+   \param image       source pixels
+   \param tile_size   tile size in pixels (the width may be padded
+                      beyond the source image)
+   \param outbuff     output buffer
+   \param size        in: buffer size; out: encoded size
+   \param bpp         source depth (8, 24 or 32)
+   \param line_bytes  source bytes per line
+   \param quality     JPEG quality (0-100)
+   \param valid_width number of pixels present in each source row; any
+                      further (padding) columns repeat the last valid
+                      pixel rather than reading beyond the source.
+                      -1 means the full tile width is valid */
 void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
-            int bpp, int line_bytes, int quality);
+            int bpp, int line_bytes, int quality, int valid_width = -1);
 
 void memtest (const char *name);
 


### PR DESCRIPTION
Investigating the intermittent 'unknown tile code' failure in CI's
parallel-conversion test turned up five bugs in the .max reader and
tile encoder.

The actual cause of the CI flake is in the reader, not the converter:
the small read cache serves 2- and 4-byte fields from a 4KB window
with padded ends, and a read which straddles the end of the window
returns padding bytes instead of file data. Qt 5 zero-filled that
padding but Qt 6 leaves it uninitialised, so whether the failure
appeared depended on the file layout, and the value read changed from
run to run - hence Qt5 passing, Qt6 failing intermittently, and a
clean rerun.

The remaining fixes were found with AddressSanitizer and by chasing
nondeterminism in the output: the JPEG tile encoder read past the
rendered page on padded edge tiles, libjpeg overflowed the encode
buffer silently when a tile did not fit, tiles were written with
uninitialised alignment padding, and the 1-bit preview read source
bits from uninitialised row padding.

A regression test covers the cache-window straddle directly.
Converting the same input twice now produces identical bytes apart
from the per-page timestamps, so any future corruption will be
reproducible rather than intermittent.

(Replaces #75, which GitHub would not run checks for.)