### PR TITLE
Find folders from other years when searching by name

### DIFF
--- a/dirmodel.cpp
+++ b/dirmodel.cpp
@@ -1278,7 +1278,11 @@ QStringList Dirmodel::findFolders(const QString& text, const QString& dirPath,
 
    QDate date = QDate::currentDate();
 
-   return utilDetectMatches(date, matches, missing);
+   /* when the user has typed something, include directories dated with
+      another year or month: a search for a folder by name must find it
+      even if it is old. With nothing typed the list is a suggestion of
+      current folders, so old dates are left out */
+   return utilDetectMatches(date, matches, missing, !text.isEmpty());
 }
 
 const TreeItem *Dirmodel::findDir(const TreeItem *parent, QString path)

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -440,6 +440,37 @@ void TestOps::testRenamePage()
             "Page 1");
 }
 
+void TestOps::testFindFoldersOtherYear()
+{
+   Mainwindow me;
+
+   /* a folder which carries a year in its name must still be found
+      when the user searches for it by name, even though the year is
+      not the current one */
+   auto path = setupRepo();
+   QDir dir(path);
+   Q_ASSERT(dir.mkpath("digs/palace/landscaping 2024"));
+
+   Desktopwidget *desktop = me.getDesktop();
+   err_info *err = desktop->addDir(path);
+   Q_ASSERT(!err);
+
+   Dirmodel *dirmodel = desktop->getDirmodel();
+   QModelIndex root = dirmodel->index(path);
+   QCOMPARE(root.isValid(), true);
+
+   QStringList missing;
+   QStringList folders = dirmodel->findFolders("landscaping", path, root,
+                                               missing, nullptr);
+   QCOMPARE(folders.size(), 1);
+   QVERIFY(folders[0].contains("digs/palace/landscaping 2024"));
+
+   /* with nothing typed, other-year folders are still left out so that
+      the suggestion list is not flooded with old directories */
+   folders = dirmodel->findFolders("", path, root, missing, nullptr);
+   QVERIFY(!folders.join(",").contains("landscaping"));
+}
+
 void TestOps::testPrintCountPages()
 {
    QModelIndex repo_ind;

--- a/test/test_ops.h
+++ b/test/test_ops.h
@@ -76,6 +76,9 @@ private slots:
    //! Test that findFolders works after a cache refresh
    void testFindFoldersSuggestsMonthAfterRefresh();
 
+   //! Test that findFolders finds folders for other years by name
+   void testFindFoldersOtherYear();
+
    //! Test that the print options count pages correctly
    void testPrintCountPages();
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -739,7 +739,8 @@ int utilDetectMonth(const QString& fname, int& foundPos)
 }
 
 QStringList utilDetectMatches(const QDate& date, QStringList& matches,
-                              QStringList& missing)
+                              QStringList& missing,
+                              bool keep_other_dates)
 {
    QStringList to_sort, suggests;
 
@@ -774,7 +775,12 @@ QStringList utilDetectMatches(const QDate& date, QStringList& matches,
          suggests << suggest;
 
       if (skip)
-         ;
+         {
+         /* the directory is dated with another year or month: keep it,
+            after everything else, if the caller asked for that */
+         if (keep_other_dates)
+            to_sort << "4" + item;
+         }
       else if (year && month)
          to_sort << "1" + item;
       else if (year && !month)

--- a/utils.h
+++ b/utils.h
@@ -260,10 +260,14 @@ int utilDetectMonth(const QString& fname, int& foundPos);
  * @param matches  Returns a sorted list of matches
  * @param missing  Returns a list of directories which could be created to make
  *                 a better match
+ * @param keep_other_dates  Include directories dated with another year or
+ *                 month, ranked after the rest. Without this they are
+ *                 dropped, which suits suggestion lists but not searches
  * @return List of matches in order of quality
  */
 QStringList utilDetectMatches(const QDate& date, QStringList& matches,
-                              QStringList& missing);
+                              QStringList& missing,
+                              bool keep_other_dates = false);
 
 /**
  * @brief Check if a particular drop event is supported by Paperman


### PR DESCRIPTION
Searching for a folder by name in the Folder field does not find it
if the folder name carries a year other than the current one - for
example searching for 'landscaping' fails to suggest the existing
'digs/palace/landscaping 2024', because utilDetectMatches() drops
every directory whose detected year is not current.

Keep such directories when the user has typed something, ranked after
the current-year matches; an empty search still leaves old years out
so the suggestion list is not flooded. Verified against the
homepaper repository's directory tree, plus a regression test.