### PR TITLE
Identify the user by uid for the per-user cache

### DIFF
--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,5 +1,8 @@
 #include <QtTest/QtTest>
 
+#include <pwd.h>
+#include <unistd.h>
+
 #include "../filemax.h"
 #include "../utils.h"
 #include "test.h"
@@ -441,4 +444,15 @@ void TestUtils::testPreviewFromJpeg()
    QVERIFY2(csize > 50, qPrintable(
       QString("compressed preview too small: %1").arg(csize)));
    QCOMPARE(csize, 1412);
+}
+
+void TestUtils::testUserName()
+{
+   /* the user name must be found even with no controlling terminal
+      (tests, cron, IDE launches). If it silently comes back empty the
+      per-user .papertree cache filename loses its suffix and a stale,
+      shared cache file is read instead */
+   struct passwd *pw = getpwuid(getuid());
+   QVERIFY(pw != nullptr);
+   QCOMPARE(utilUserName(), QString(pw->pw_name));
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -16,6 +16,9 @@ public:
     using Suite::Suite;
 
 private slots:
+   //! Test that the user name is found without a controlling terminal
+   void testUserName();
+
    void testDetectYear();
    void testDetectMonth();
    void testDetectMatches();

--- a/utils.cpp
+++ b/utils.cpp
@@ -1159,13 +1159,21 @@ bool utilSetGroup(const QString& fname)
 
 QString utilUserName()
 {
-   QString user;
    char username[80];
 
-   if (getlogin_r(username, sizeof(username)))
-      return "";
+   /* identify the user by uid: getlogin_r() needs a controlling
+      terminal and fails under cron, IDE launches and tests, which
+      would silently drop the per-user suffix from the .papertree
+      cache filename and read a stale, shared cache instead */
+   struct passwd *pw = getpwuid (getuid ());
+   if (pw && pw->pw_name && *pw->pw_name)
+      return pw->pw_name;
 
-   return username;
+   // fall back to the login name on the controlling terminal
+   if (!getlogin_r (username, sizeof (username)))
+      return username;
+
+   return "";
 }
 
 void utilInit(const QString& group)


### PR DESCRIPTION
utilUserName() relies on getlogin_r(), which fails without a
controlling terminal (cron, IDE launches, tests). The name then
comes back empty, the per-user suffix is dropped from the .papertree
cache filename, and paperman reads a shared, usually stale cache
instead of the user's own - the homepaper repo has such a stray
unsuffixed cache a month older than the per-user ones.

Use getpwuid() first, which depends only on the uid, keeping
getlogin_r() as a fallback, with a regression test that runs in the
terminal-less test environment.