### PR TITLE
Make the rotate and flip actions work

### DIFF
--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -943,7 +943,7 @@ signals:
        rotated), so views showing it can redisplay
 
       \param index    source model index of the stack
-      \param pagenum  page whose image changed */
+      \param pagenum  page whose image changed, or -1 for every page */
    void pageContentChanged (const QModelIndex &index, int pagenum);
    /** indicate that we are about to start scanning into an item
 

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -512,7 +512,7 @@ public:
    /** transform (rotate or mirror) a page of a stack, with undo
 
       \param index    source model index of stack
-      \param pagenum  page to transform
+      \param pagenum  page to transform, or -1 for every page
       \param op       transform to apply */
    void transformPage (const QModelIndex &index, int pagenum,
          File::e_transform op);
@@ -732,7 +732,7 @@ protected:
    /** transform (rotate or mirror) a page of a stack
 
       \param index    index of stack
-      \param pagenum  page to transform
+      \param pagenum  page to transform, or -1 for every page
       \param op       transform to apply */
    err_info *opTransformPage (const QModelIndex &index, int pagenum,
          File::e_transform op);

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -100,6 +100,7 @@ class Desktopmodel : public QAbstractItemModel
    friend class UCChangeDir;
    friend class UCRenameStack;
    friend class UCRenamePage;
+   friend class UCTransformPage;
    friend class UCDeletePages;
    friend class UCUpdateAnnot;
    friend class UCAddRepository;
@@ -508,6 +509,14 @@ public:
       \param newname new name for page */
    void renamePage (const QModelIndex &index, QString newname);
 
+   /** transform (rotate or mirror) a page of a stack, with undo
+
+      \param index    source model index of stack
+      \param pagenum  page to transform
+      \param op       transform to apply */
+   void transformPage (const QModelIndex &index, int pagenum,
+         File::e_transform op);
+
    /** add a new repository to the list. Supports undo.
 
      \param dirPath  path to repository */
@@ -719,6 +728,14 @@ protected:
       \param newname the new name to be given
       \returns       error, or NULL if none */
    err_info *opRenamePage (const QModelIndex &index, int pagenum, QString &newname);
+
+   /** transform (rotate or mirror) a page of a stack
+
+      \param index    index of stack
+      \param pagenum  page to transform
+      \param op       transform to apply */
+   err_info *opTransformPage (const QModelIndex &index, int pagenum,
+         File::e_transform op);
 
    /** delete a list of pages from a stack.
 

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -939,6 +939,12 @@ public:
          QBitArray &page, bool allow_undo);
 
 signals:
+   /** emitted when the image of a page has changed (e.g. it has been
+       rotated), so views showing it can redisplay
+
+      \param index    source model index of the stack
+      \param pagenum  page whose image changed */
+   void pageContentChanged (const QModelIndex &index, int pagenum);
    /** indicate that we are about to start scanning into an item
 
       \index   item we are scanning into */

--- a/desktopundo.cpp
+++ b/desktopundo.cpp
@@ -409,6 +409,38 @@ void UCRenameStack::undo (void)
    }
 
 
+UCTransformPage::UCTransformPage (Desktopmodel *model, const QModelIndex &ind,
+      int pagenum, File::e_transform op)
+      : Desktopundocmd (model)
+   {
+   _dir = model->deskToDirname (ind.parent ());
+   _fname = model->data (ind, Desktopmodel::Role_filename).toString ();
+   _pagenum = pagenum;
+   _op = op;
+   setText (QApplication::translate("UCTransformPage",
+      "Transform page"));
+   }
+
+
+void UCTransformPage::redo (void)
+   {
+   QModelIndex parent = _model->deskFromDirname (_dir);
+   QModelIndex ind = _model->index (_fname, parent);
+
+   complain (_model->opTransformPage (ind, _pagenum, _op));
+   }
+
+
+void UCTransformPage::undo (void)
+   {
+   QModelIndex parent = _model->deskFromDirname (_dir);
+   QModelIndex ind = _model->index (_fname, parent);
+
+   complain (_model->opTransformPage (ind, _pagenum,
+         File::transformInverse (_op)));
+   }
+
+
 UCRenamePage::UCRenamePage (Desktopmodel *model, const QModelIndex &ind,
       QString newname)
       : Desktopundocmd (model)

--- a/desktopundo.cpp
+++ b/desktopundo.cpp
@@ -418,7 +418,7 @@ UCTransformPage::UCTransformPage (Desktopmodel *model, const QModelIndex &ind,
    _pagenum = pagenum;
    _op = op;
    setText (QApplication::translate("UCTransformPage",
-      "Transform page"));
+      pagenum == -1 ? "Transform stack" : "Transform page"));
    }
 
 

--- a/desktopundo.h
+++ b/desktopundo.h
@@ -319,6 +319,29 @@ private:
    };
 
 
+/** transform (rotate or mirror) a page of a stack */
+
+class UCTransformPage : public Desktopundocmd
+   {
+public:
+   /** create an undo record for transforming a page, and execute it
+
+      \param model    model to work with
+      \param ind      model index of stack
+      \param pagenum  page to transform
+      \param op       transform to apply */
+   UCTransformPage (Desktopmodel *model, const QModelIndex &ind, int pagenum,
+         File::e_transform op);
+   void redo();
+   void undo();
+private:
+   QString _dir;       //!< desk directory
+   QString _fname;     //!< filename of stack
+   int _pagenum;       //!< the page number to transform
+   File::e_transform _op;   //!< the transform to apply
+   };
+
+
 /** update stack annotations. To redo this we write the updatein the
 maxdesk layer. To undo we write the old details */
 

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -1169,13 +1169,19 @@ void Desktopwidget::openStack (const QModelIndex &index)
 
 /* the image of a page has changed (e.g. it has been rotated):
    redisplay it if it is in the preview pane */
-void Desktopwidget::slotPageContentChanged (const QModelIndex &index, int)
+void Desktopwidget::slotPageContentChanged (const QModelIndex &index,
+      int pagenum)
    {
    QModelIndex ind = index;
 
    _modelconv->indexToProxy (_contents, ind);
-   if (ind.isValid () && ind == _update_index)
+   if (!ind.isValid () || ind != _update_index)
+      return;
+
+   if (pagenum == -1)   // every page changed, so rebuild the whole view
       _page->showPages (ind.model (), ind, 0, -1, -1, true);
+   else
+      _page->refreshPage (pagenum);
    }
 
 

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -172,6 +172,9 @@ Desktopwidget::Desktopwidget (QWidget *parent)
    connect (_delegate, SIGNAL (itemDoubleClicked (const QModelIndex &)),
       this, SLOT (openStack (const QModelIndex &)));
 
+   connect (_contents,
+            SIGNAL (pageContentChanged (const QModelIndex &, int)),
+            this, SLOT (slotPageContentChanged (const QModelIndex &, int)));
    connect (_contents, SIGNAL (undoChanged ()),
       this, SIGNAL (undoChanged ()));
    connect (_contents, SIGNAL (dirChanged (QString&, QModelIndex&)),
@@ -1145,6 +1148,18 @@ void Desktopwidget::slotUpdateDone ()
 void Desktopwidget::openStack (const QModelIndex &index)
    {
    emit showPage (index);
+   }
+
+
+/* the image of a page has changed (e.g. it has been rotated):
+   redisplay it if it is in the preview pane */
+void Desktopwidget::slotPageContentChanged (const QModelIndex &index, int)
+   {
+   QModelIndex ind = index;
+
+   _modelconv->indexToProxy (_contents, ind);
+   if (ind.isValid () && ind == _update_index)
+      _page->showPages (ind.model (), ind, 0, -1, -1, true);
    }
 
 

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -66,6 +66,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "folderlist.h"
 #include "op.h"
 #include "desk.h"
+#include "mainwidget.h"
 #include "mainwindow.h"
 #include "maxview.h"
 #include "pagewidget.h"
@@ -123,6 +124,17 @@ Desktopwidget::Desktopwidget (QWidget *parent)
    connect(_toolbar->prev, SIGNAL(clicked()), this, SLOT(stackLeft()));
    connect(_toolbar->next, SIGNAL(clicked()), this, SLOT(stackRight()));
 
+   // transform the selected stacks (the rotate/flip menu shortcuts
+   // share these handlers in Mainwidget)
+   connect(_toolbar->rleft, &QPushButton::clicked,
+           this, [this]() { _main->rotate(-90); });
+   connect(_toolbar->rright, &QPushButton::clicked,
+           this, [this]() { _main->rotate(90); });
+   connect(_toolbar->hflip, &QPushButton::clicked,
+           this, [this]() { _main->flip(true); });
+   connect(_toolbar->vflip, &QPushButton::clicked,
+           this, [this]() { _main->flip(false); });
+
    connect(_toolbar->pressed_esc, SIGNAL(triggered()),
            this, SLOT(resetFilter()));
    connect(_toolbar->cancelFilter, SIGNAL(clicked()),
@@ -140,6 +152,10 @@ Desktopwidget::Desktopwidget (QWidget *parent)
    QVBoxLayout *lay = new QVBoxLayout (group);
    lay->setContentsMargins (0, 0, 0, 0);
    lay->setSpacing (2);
+   /* don't let the toolbar's many buttons set a minimum width for the
+      desktop pane, since that would squeeze the folder tree out of the
+      splitter; the toolbar just clips if space is really short */
+   _toolbar->setSizePolicy (QSizePolicy::Ignored, QSizePolicy::Fixed);
    lay->addWidget (_toolbar);
    lay->addWidget (_view);
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -392,6 +392,9 @@ private slots:
 
    void updatePreview (void);
 
+   /** redisplay a page in the preview pane if its image has changed */
+   void slotPageContentChanged (const QModelIndex &index, int pagenum);
+
    //! duplicate the selected items
    void duplicate (void);
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -491,6 +491,26 @@ err_info *Desktopmodel::opRenamePage (const QModelIndex &index, int pagenum, QSt
    }
 
 
+err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
+      int pagenum, File::e_transform op)
+   {
+   _modelconv->assertIsSource (0, &index, 0);
+   File *f = getFile (index);
+   err_info *e = NULL;
+
+   if (f)
+      {
+      if (pagenum >= 0 && pagenum < f->pagecount ()) // which it should be!
+         {
+         e = f->transformPage (pagenum, op);
+         f->setPagenum (pagenum);
+         }
+      buildItem (index);
+      }
+   return e;
+   }
+
+
 err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool &can_delete)
 {
    can_delete = true;

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -506,6 +506,8 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          f->setPagenum (pagenum);
          }
       buildItem (index);
+      if (!e)
+         emit pageContentChanged (index, pagenum);
       }
    return e;
    }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -513,7 +513,13 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          // transform every page of the stack
          for (int page = 0; !e && page < f->pagecount (); page++)
             e = f->transformPage (page, op);
+
+         /* the page view refreshes through pageContentChanged(), so
+            mark the item update as minor to avoid it also doing a full
+            rebuild, which loses the page selection */
+         _minor_change = true;
          buildItem (index);
+         _minor_change = false;
          if (!e)
             emit pageContentChanged (index, -1);
          }
@@ -521,7 +527,9 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          {
          e = f->transformPage (pagenum, op);
          f->setPagenum (pagenum);
+         _minor_change = true;
          buildItem (index);
+         _minor_change = false;
          if (!e)
             emit pageContentChanged (index, pagenum);
          }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -511,10 +511,12 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          if (!e)
             emit pageContentChanged (index, pagenum);
          }
+      else if (!f->pagecount ())
+         /* an empty stack has nothing to transform; this also happens
+            for stacks whose pages are not accessible, such as those in
+            a remote repository */
+         e = err_make (ERRFN, ERR_stack_has_no_pages);
       else
-         /* no such page: this happens for files whose pages are not
-            accessible, such as stacks in a remote repository. Report
-            it rather than silently doing nothing */
          e = f->not_impl ();
       }
    return e;

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -503,7 +503,21 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
       /* the file may not have been loaded yet, in which case it reports
          no pages and the transform would be silently skipped */
       f->load ();
-      if (pagenum >= 0 && pagenum < f->pagecount ()) // which it should be!
+      if (!f->pagecount ())
+         /* an empty stack has nothing to transform; this also happens
+            for stacks whose pages are not accessible, such as those in
+            a remote repository */
+         e = err_make (ERRFN, ERR_stack_has_no_pages);
+      else if (pagenum == -1)
+         {
+         // transform every page of the stack
+         for (int page = 0; !e && page < f->pagecount (); page++)
+            e = f->transformPage (page, op);
+         buildItem (index);
+         if (!e)
+            emit pageContentChanged (index, f->pagenum ());
+         }
+      else if (pagenum >= 0 && pagenum < f->pagecount ())
          {
          e = f->transformPage (pagenum, op);
          f->setPagenum (pagenum);
@@ -511,11 +525,6 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          if (!e)
             emit pageContentChanged (index, pagenum);
          }
-      else if (!f->pagecount ())
-         /* an empty stack has nothing to transform; this also happens
-            for stacks whose pages are not accessible, such as those in
-            a remote repository */
-         e = err_make (ERRFN, ERR_stack_has_no_pages);
       else
          e = f->not_impl ();
       }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -500,14 +500,17 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
 
    if (f)
       {
+      /* the file may not have been loaded yet, in which case it reports
+         no pages and the transform would be silently skipped */
+      f->load ();
       if (pagenum >= 0 && pagenum < f->pagecount ()) // which it should be!
          {
          e = f->transformPage (pagenum, op);
          f->setPagenum (pagenum);
+         buildItem (index);
+         if (!e)
+            emit pageContentChanged (index, pagenum);
          }
-      buildItem (index);
-      if (!e)
-         emit pageContentChanged (index, pagenum);
       }
    return e;
    }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -511,6 +511,11 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          if (!e)
             emit pageContentChanged (index, pagenum);
          }
+      else
+         /* no such page: this happens for files whose pages are not
+            accessible, such as stacks in a remote repository. Report
+            it rather than silently doing nothing */
+         e = f->not_impl ();
       }
    return e;
    }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -515,7 +515,7 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
             e = f->transformPage (page, op);
          buildItem (index);
          if (!e)
-            emit pageContentChanged (index, f->pagenum ());
+            emit pageContentChanged (index, -1);
          }
       else if (pagenum >= 0 && pagenum < f->pagecount ())
          {

--- a/dmuserop.cpp
+++ b/dmuserop.cpp
@@ -185,6 +185,15 @@ void Desktopmodel::renameStack (const QModelIndex &index, QString newname)
    }
 
 
+void Desktopmodel::transformPage (const QModelIndex &index, int pagenum,
+      File::e_transform op)
+   {
+   _modelconv->assertIsSource (0, &index, 0);
+
+   _undo->push (new UCTransformPage (this, index, pagenum, op));
+   }
+
+
 void Desktopmodel::renamePage (const QModelIndex &index, QString newname)
    {
    _modelconv->assertIsSource (0, &index, 0);

--- a/err.cpp
+++ b/err.cpp
@@ -57,6 +57,7 @@ static const char *err_msg [ERR_count] =
    "G4 compression failed",
    "G4 decompression failed",
    "JPEG compression failed",
+   "The stack has no pages",
    "Could not create directory '%s'",
    "Could not write image to '%s' as %s",
    "Could not read multi-page images from file '%s'",

--- a/err.h
+++ b/err.h
@@ -69,6 +69,7 @@ enum
    ERR_g4_compression_failed,
    ERR_g4_decompression_failed,
    ERR_jpeg_compression_failed,
+   ERR_stack_has_no_pages,
    ERR_could_not_create_directory1,
    ERR_could_not_write_image_to_as2,
    ERR_could_not_read_multipage_images1,

--- a/file.cpp
+++ b/file.cpp
@@ -31,6 +31,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QFile>
 #include <QFileInfo>
 #include <QPainter>
+#include <QTransform>
 #include <QPixmap>
 #include <QTextStream>
 #include <QtConcurrent>
@@ -772,6 +773,39 @@ err_info *File::unstackItems (int pagenum, int pagecount, bool remove,
    return NULL;
    }
 #endif
+
+
+File::e_transform File::transformInverse (e_transform op)
+   {
+   switch (op)
+      {
+      case Transform_rotate90 :
+         return Transform_rotate270;
+      case Transform_rotate270 :
+         return Transform_rotate90;
+      default :
+         return op;   // the others undo themselves
+      }
+   }
+
+
+QImage File::transformImage (const QImage &image, e_transform op)
+   {
+   switch (op)
+      {
+      case Transform_rotate90 :
+         return image.transformed (QTransform ().rotate (90));
+      case Transform_rotate180 :
+         return image.transformed (QTransform ().rotate (180));
+      case Transform_rotate270 :
+         return image.transformed (QTransform ().rotate (270));
+      case Transform_hflip :
+         return image.mirrored (true, false);
+      case Transform_vflip :
+         return image.mirrored (false, true);
+      }
+   return image;
+   }
 
 
 err_info *File::not_impl (void)

--- a/file.h
+++ b/file.h
@@ -264,6 +264,30 @@ public:
 
    virtual err_info *renamePage (int pagenum, QString &name) = 0;
 
+   /** transformations which can be applied to a page image */
+   enum e_transform
+      {
+      Transform_rotate90,     //!< rotate 90 degrees clockwise
+      Transform_rotate180,    //!< rotate 180 degrees
+      Transform_rotate270,    //!< rotate 90 degrees anticlockwise
+      Transform_hflip,        //!< mirror left to right
+      Transform_vflip         //!< mirror top to bottom
+      };
+
+   /** returns the transform which undoes the given one */
+   static e_transform transformInverse (e_transform op);
+
+   /** apply a transform to an image */
+   static QImage transformImage (const QImage &image, e_transform op);
+
+   /** transform the image of a page, modifying the file
+
+      \param pagenum  page to transform
+      \param op       transformation to apply
+      
+eturns error, or NULL if ok */
+   virtual err_info *transformPage (int pagenum, e_transform op) = 0;
+
    virtual err_info *getImageInfo (int pagenum, QSize &size,
          QSize &true_size, int &bpp, int &image_size, int &compressed_size,
          QDateTime &timestamp) = 0;

--- a/filejpeg.cpp
+++ b/filejpeg.cpp
@@ -427,6 +427,18 @@ err_info *Filejpeg::getImage (int pagenum, bool,
 
 
 
+err_info *Filejpeg::transformPage (int pagenum, e_transform op)
+   {
+   QImage image;
+
+   CALL (load ());
+   CALL (loadPage (pagenum, image));
+
+   _pages [pagenum]->setImage (transformImage (image, op));
+   return _pages [pagenum]->flush (_dir);
+   }
+
+
 // operations on files
 
 err_info *Filejpeg::addPage (const Filepage *mp, bool do_flush)

--- a/filejpeg.h
+++ b/filejpeg.h
@@ -99,6 +99,8 @@ public:
 
    // operations on files
 
+   virtual err_info *transformPage (int pagenum, e_transform op);
+
    virtual err_info *addPage (const Filepage *mp, bool flush);
 
    virtual err_info *removePages (QBitArray &pages,

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -6044,6 +6044,12 @@ err_info *Filemax::transformPage (int pagenum, e_transform op)
    CALL (find_page (pagenum, info));
    CALL (getImage (pagenum, false, image, size, trueSize, bpp, false));
 
+   /* mono images are decoded with the width padded to a multiple of 32,
+      so crop back to the real page size to avoid the padding columns
+      growing the page with each transform */
+   if (image.size () != size)
+      image = image.copy (QRect (QPoint (0, 0), size));
+
    QImage out = transformImage (image, op);
 
    // the transform can promote the image, e.g. mono to 8 bit

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -4545,15 +4545,15 @@ static int add_image_header (chunk_info &chunk, byte *buf)
 
 err_info *Filemax::max_replace_page (page_info &page, Filemaxpage &mp)
    {
-   page_info newpage;
-
-   page_init (page);
-   page.titlestr = mp.name ();
+   /* give the page a fresh chunkid, matching what addPage() does. The
+      page keeps its existing chunk positions: insert_chunk() reuses
+      each one where the new data fits and relocates it where not. The
+      text chunk is untouched, so any OCR text survives */
+   CALL (ensure_open ());
    page.chunkid = _chunkid_next;
-   CALL (max_setup_page (newpage, mp));
-   free_page (page);
-   page = newpage;
-   return flush ();
+   page.titlestr = mp.name ();
+   CALL (max_setup_page (page, mp));
+   return flush ();   // this also closes the file
    }
 
 err_info *Filemaxpage::compress (void)

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -6033,6 +6033,37 @@ err_info *Filemax::getImage (int pagenum, bool,
    }
 
 
+err_info *Filemax::transformPage (int pagenum, e_transform op)
+   {
+   QImage image;
+   QSize size, trueSize;
+   int bpp;
+   page_info *info;
+
+   load ();
+   CALL (find_page (pagenum, info));
+   CALL (getImage (pagenum, false, image, size, trueSize, bpp, false));
+
+   QImage out = transformImage (image, op);
+
+   // the transform can promote the image, e.g. mono to 8 bit
+   if (out.depth () > bpp)
+      out = utilReduceDepth (out, bpp);
+
+   // keep the page's title and timestamp
+   Filemaxpage page;
+   QByteArray ba = QByteArray::fromRawData ((const char *)out.bits (),
+         out.sizeInBytes ());
+   page.addData (out.width (), out.height (), out.depth (),
+         out.bytesPerLine (), info->titlestr, false, false, pagenum, ba,
+         ba.size ());
+   page._timestamp = info->timestamp;
+   CALL (page.compress ());
+
+   return max_replace_page (*info, page);
+   }
+
+
 err_info *Filemax::getPreviewInfo (int pagenum, QSize &Size, int &bpp)
    {
    QString title;

--- a/filemax.h
+++ b/filemax.h
@@ -184,6 +184,8 @@ public:
 
    virtual err_info *renamePage (int pagenum, QString &name);
 
+   virtual err_info *transformPage (int pagenum, e_transform op);
+
    err_info *getImageInfo (int pagenum, QSize &size,
          QSize &true_size, int &bpp, int &image_size, int &compressed_size,
          QDateTime &timestamp);

--- a/fileother.cpp
+++ b/fileother.cpp
@@ -126,6 +126,12 @@ err_info *Fileother::renamePage (int, QString &)
    }
 
 
+err_info *Fileother::transformPage (int, e_transform)
+   {
+   return not_impl ();
+   }
+
+
 
 
 err_info *Fileother::getImageInfo (int, QSize &,

--- a/fileother.h
+++ b/fileother.h
@@ -73,6 +73,8 @@ public:
 
    virtual err_info *renamePage (int pagenum, QString &name);
 
+   virtual err_info *transformPage (int pagenum, e_transform op);
+
    err_info *getImageInfo (int pagenum, QSize &size,
          QSize &true_size, int &bpp, int &image_size, int &compressed_size,
          QDateTime &timestamp);

--- a/filepdf.cpp
+++ b/filepdf.cpp
@@ -158,6 +158,30 @@ err_info *Filepdf::renamePage (int, QString &)
    }
 
 
+err_info *Filepdf::transformPage (int pagenum, e_transform op)
+   {
+   int degrees;
+
+   switch (op)
+      {
+      case Transform_rotate90 :
+         degrees = 90;
+         break;
+      case Transform_rotate180 :
+         degrees = 180;
+         break;
+      case Transform_rotate270 :
+         degrees = 270;
+         break;
+      default :
+         // mirroring cannot be expressed with the page /Rotate key
+         return not_impl ();
+      }
+   CALL (load ());
+   return _pdfio->rotatePage (pagenum, degrees);
+   }
+
+
 err_info *Filepdf::getImageInfo (int pagenum, QSize &size,
       QSize &true_size, int &bpp, int &image_size, int &compressed_size,
       QDateTime &timestamp)

--- a/filepdf.h
+++ b/filepdf.h
@@ -84,6 +84,8 @@ public:
 
    virtual err_info *renamePage (int pagenum, QString &name);
 
+   virtual err_info *transformPage (int pagenum, e_transform op);
+
    err_info *getImageInfo (int pagenum, QSize &size,
          QSize &true_size, int &bpp, int &image_size, int &compressed_size,
          QDateTime &timestamp);

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -120,6 +120,9 @@ Mainwidget::Mainwidget (QWidget *parent, const char *name)
 
    connect (_desktop, SIGNAL (showPage (const QModelIndex &)),
       this, SLOT (showPage (const QModelIndex &)));
+   connect (_desktop->getModel (),
+      SIGNAL (pageContentChanged (const QModelIndex &, int)),
+      this, SLOT (slotPageContentChanged (const QModelIndex &, int)));
 
    connect (_page->_returnToDesktop, SIGNAL (triggered()), this, SLOT (showDesktop ()));
 
@@ -1292,6 +1295,19 @@ err_info *Mainwidget::operation (Desk::operation_t type, int ival)
    }
 
 
+/* redisplay a page if its image has changed (e.g. rotated, including
+   by undo and redo) and it is currently being shown */
+void Mainwidget::slotPageContentChanged (const QModelIndex &index,
+      int pagenum)
+   {
+   QModelIndex ind;
+
+   if (currentWidget () == _page && _page->getCurrentIndex (ind, true)
+       && ind == index && _page->getCurrentPage () == pagenum)
+      _page->showPages (_desktop->getModel (), index, 0, -1, pagenum, true);
+   }
+
+
 /* transform the target pages: in the page view this is the page being
    shown; on the desktop it is the current page of each selected stack */
 void Mainwidget::transformPages (File::e_transform op)
@@ -1304,27 +1320,19 @@ void Mainwidget::transformPages (File::e_transform op)
 
       if (!_page->getCurrentIndex (ind, true))
          return;
-      model->transformPage (ind, _page->getCurrentPage (), op);
 
-      // show the transformed page
-      _page->showPages (model, ind, 0, -1, _page->getCurrentPage (), true);
+      // slotPageContentChanged() redisplays the page
+      model->transformPage (ind, _page->getCurrentPage (), op);
       }
    else
       {
       QModelIndexList list = _view->getSelectedListSource ();
 
+      /* the desktop's preview pane refreshes through the model's
+         pageContentChanged() signal */
       foreach (QModelIndex ind, list)
          model->transformPage (ind,
                model->data (ind, Desktopmodel::Role_pagenum).toInt (), op);
-
-      // update the preview pane with the first transformed stack
-      if (!list.isEmpty ())
-         {
-         QModelIndex ind = list [0];
-
-         _desktop->getModelconv ()->indexToProxy (model, ind);
-         _desktop->slotItemPreview (ind, 0, true);
-         }
       }
    }
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1328,11 +1328,11 @@ void Mainwidget::transformPages (File::e_transform op)
       {
       QModelIndexList list = _view->getSelectedListSource ();
 
-      /* the desktop's preview pane refreshes through the model's
-         pageContentChanged() signal */
+      /* transform every page of each selected stack. The previews and
+         the desktop's preview pane refresh through buildItem() and the
+         model's pageContentChanged() signal */
       foreach (QModelIndex ind, list)
-         model->transformPage (ind,
-               model->data (ind, Desktopmodel::Role_pagenum).toInt (), op);
+         model->transformPage (ind, -1, op);
       }
    }
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1302,9 +1302,14 @@ void Mainwidget::slotPageContentChanged (const QModelIndex &index,
    {
    QModelIndex ind;
 
-   if (currentWidget () == _page && _page->getCurrentIndex (ind, true)
-       && ind == index && _page->getCurrentPage () == pagenum)
-      _page->showPages (_desktop->getModel (), index, 0, -1, pagenum, true);
+   if (currentWidget () != _page || !_page->getCurrentIndex (ind, true)
+       || ind != index)
+      return;
+
+   if (pagenum == -1)   // every page changed, so rebuild the whole view
+      _page->showPages (_desktop->getModel (), index, 0, -1, -1, true);
+   else
+      _page->refreshPage (pagenum);
    }
 
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -1292,15 +1292,54 @@ err_info *Mainwidget::operation (Desk::operation_t type, int ival)
    }
 
 
+/* transform the target pages: in the page view this is the page being
+   shown; on the desktop it is the current page of each selected stack */
+void Mainwidget::transformPages (File::e_transform op)
+   {
+   Desktopmodel *model = _desktop->getModel ();
+
+   if (currentWidget () == _page)
+      {
+      QModelIndex ind;
+
+      if (!_page->getCurrentIndex (ind, true))
+         return;
+      model->transformPage (ind, _page->getCurrentPage (), op);
+
+      // show the transformed page
+      _page->showPages (model, ind, 0, -1, _page->getCurrentPage (), true);
+      }
+   else
+      {
+      QModelIndexList list = _view->getSelectedListSource ();
+
+      foreach (QModelIndex ind, list)
+         model->transformPage (ind,
+               model->data (ind, Desktopmodel::Role_pagenum).toInt (), op);
+
+      // update the preview pane with the first transformed stack
+      if (!list.isEmpty ())
+         {
+         QModelIndex ind = list [0];
+
+         _desktop->getModelconv ()->indexToProxy (model, ind);
+         _desktop->slotItemPreview (ind, 0, true);
+         }
+      }
+   }
+
+
 void Mainwidget::rotate (int degrees)
 {
-   complain(operation (Desk::op_rotate, degrees));
+   transformPages (degrees == 90 ? File::Transform_rotate90
+         : degrees == 180 || degrees == -180 ? File::Transform_rotate180
+         : File::Transform_rotate270);
 }
 
 
 void Mainwidget::flip (bool horiz)
 {
-   complain(operation(horiz ? Desk::op_hflip : Desk::op_vflip, 0));
+   transformPages (horiz ? File::Transform_hflip : File::Transform_vflip);
 }
 
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -249,6 +249,9 @@ public slots:
 private slots:
    void scanDialogClosed (void);
 
+   /** redisplay a page if its image has changed and it is shown */
+   void slotPageContentChanged (const QModelIndex &index, int pagenum);
+
    //! called when pending changes to the ScanDialog are complete (these happen while scanning)
    void slotPendingDone (void);
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -52,6 +52,7 @@ struct print_info;
 #include <QStackedWidget>
 
 #include "desk.h"
+#include "file.h"
 #include "qwidget.h"
 #include "options.h"
 
@@ -226,6 +227,10 @@ public slots:
    void resizeAll ();
 
    void rotate (int degrees);
+
+   /** transform the current page of the selection (or the page being
+       shown in the page view) */
+   void transformPages (File::e_transform op);
 
    void flip (bool horiz);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -182,6 +182,11 @@
     <addaction name="actionSearch"/>
     <addaction name="separator"/>
     <addaction name="actionSelectall"/>
+    <addaction name="separator"/>
+    <addaction name="actionRleft"/>
+    <addaction name="actionRright"/>
+    <addaction name="actionHflip"/>
+    <addaction name="actionVflip"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -206,11 +211,6 @@
    <addaction name="actionOptions"/>
    <addaction name="actionScango"/>
    <addaction name="actionPscan"/>
-   <addaction name="separator"/>
-   <addaction name="actionRleft"/>
-   <addaction name="actionRright"/>
-   <addaction name="actionHflip"/>
-   <addaction name="actionVflip"/>
   </widget>
   <action name="actionPrint">
    <property name="icon">
@@ -479,9 +479,6 @@
    <property name="toolTip">
     <string>Flip each page in the stack horizontally</string>
    </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
   </action>
   <action name="actionVflip">
    <property name="icon">
@@ -493,9 +490,6 @@
    </property>
    <property name="toolTip">
     <string>Flip each page in the stack vertically</string>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
    </property>
   </action>
   <action name="actionResize_all">

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -106,6 +106,19 @@ void Pagemodel::reset (const Desktopmodel *model, const QModelIndex &index,
    }
 
 
+void Pagemodel::updatePage (int pagenum)
+   {
+   int row = pagenum - _start;
+
+   if (row < 0 || row >= _row_count)
+      return;
+   _pages [row].invalidate ();
+
+   QModelIndex ind = index (row, 0, QModelIndex ());
+   emit dataChanged (ind, ind);
+   }
+
+
 void Pagemodel::keepAllPages (void)
    {
    for (int i = 0; i < _count; i++)

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -170,6 +170,11 @@ public:
    void reset (const Desktopmodel *model, const QModelIndex &index,
       int start, int count);
 
+   /** mark a single page as changed so its thumbnail is recreated
+
+      \param pagenum  page which has changed */
+   void updatePage (int pagenum);
+
    enum e_role
       {
 /* roles available in this model:

--- a/pagetools.ui
+++ b/pagetools.ui
@@ -213,26 +213,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="vflip">
-       <property name="toolTip">
-        <string>Rotate the page 180 degrees</string>
-       </property>
-       <property name="text">
-        <string>r</string>
-       </property>
-       <property name="icon">
-        <iconset resource="maxview.qrc">
-         <normaloff>:/images/images/vflip.xpm</normaloff>:/images/images/vflip.xpm</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="rright">
        <property name="toolTip">
         <string>Rotate the page right</string>
@@ -243,6 +223,46 @@
        <property name="icon">
         <iconset resource="maxview.qrc">
          <normaloff>:/images/images/rright.xpm</normaloff>:/images/images/rright.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="hflip">
+       <property name="toolTip">
+        <string>Flip the page horizontally</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/hflip.xpm</normaloff>:/images/images/hflip.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="vflip">
+       <property name="toolTip">
+        <string>Flip the page vertically</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/vflip.xpm</normaloff>:/images/images/vflip.xpm</iconset>
        </property>
        <property name="iconSize">
         <size>

--- a/pagetools.ui
+++ b/pagetools.ui
@@ -195,7 +195,7 @@
      <item>
       <widget class="QToolButton" name="rleft">
        <property name="toolTip">
-        <string>Zoom the image to fit within the window</string>
+        <string>Rotate the page left</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -215,7 +215,7 @@
      <item>
       <widget class="QToolButton" name="vflip">
        <property name="toolTip">
-        <string>Zoom the image to fit within the window</string>
+        <string>Rotate the page 180 degrees</string>
        </property>
        <property name="text">
         <string>r</string>
@@ -235,7 +235,7 @@
      <item>
       <widget class="QToolButton" name="rright">
        <property name="toolTip">
-        <string>Zoom the image to fit within the window</string>
+        <string>Rotate the page right</string>
        </property>
        <property name="text">
         <string>...</string>

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -1171,6 +1171,21 @@ void Pagewidget::transformPage (File::e_transform op)
 }
 
 
+void Pagewidget::refreshPage (int pagenum)
+   {
+   _pagemodel->updatePage (pagenum);
+
+   // if this is the page being shown, redisplay it
+   if (pagenum == _pagenum)
+      {
+      QModelIndex ind = _pagemodel->index (pagenum - _start, 0,
+                                           QModelIndex ());
+      if (ind.isValid ())
+         slotPreviewPage (ind);
+      }
+   }
+
+
 void Pagewidget::slotRotateRight (void)
 {
    transformPage (File::Transform_rotate90);

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -114,8 +114,9 @@ Pagewidget::Pagewidget (Desktopmodelconv *modelconv, QString base, QWidget *pare
    connect (_tools->revert, SIGNAL (clicked ()), this, SLOT (slotRevert ()));
 
    connect (_tools->rleft, SIGNAL (clicked ()), this, SLOT (slotRotateLeft ()));
-   connect (_tools->vflip, SIGNAL (clicked ()), this, SLOT (slotRotate180 ()));
    connect (_tools->rright, SIGNAL (clicked ()), this, SLOT (slotRotateRight ()));
+   connect (_tools->hflip, SIGNAL (clicked ()), this, SLOT (slotFlipHorizontal ()));
+   connect (_tools->vflip, SIGNAL (clicked ()), this, SLOT (slotFlipVertical ()));
 
    _modified = false;
 
@@ -1192,15 +1193,21 @@ void Pagewidget::slotRotateRight (void)
 }
 
 
-void Pagewidget::slotRotate180 (void)
-{
-   transformPage (File::Transform_rotate180);
-}
-
-
 void Pagewidget::slotRotateLeft (void)
 {
    transformPage (File::Transform_rotate270);
+}
+
+
+void Pagewidget::slotFlipHorizontal (void)
+{
+   transformPage (File::Transform_hflip);
+}
+
+
+void Pagewidget::slotFlipVertical (void)
+{
+   transformPage (File::Transform_vflip);
 }
 
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -1157,28 +1157,35 @@ void Pagewidget::ocrCopy (void)
    }
 
 
-void Pagewidget::addRotate (int add)
+/* transform the page being shown, with undo. The display refreshes
+   through the model's pageContentChanged() signal */
+void Pagewidget::transformPage (File::e_transform op)
 {
-   _rotate = (_rotate + 360 + add) % 360;
-   updateWindow ();
+   QModelIndex ind;
+
+   if (!getCurrentIndex (ind, true))
+      return;
+
+   Desktopmodel *model = _modelconv->getDesktopmodel (_model);
+   model->transformPage (ind, _pagenum, op);
 }
 
 
 void Pagewidget::slotRotateRight (void)
 {
-   addRotate (90);
+   transformPage (File::Transform_rotate90);
 }
 
 
 void Pagewidget::slotRotate180 (void)
 {
-   addRotate (180);
+   transformPage (File::Transform_rotate180);
 }
 
 
 void Pagewidget::slotRotateLeft (void)
 {
-   addRotate (-90);
+   transformPage (File::Transform_rotate270);
 }
 
 

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -53,6 +53,7 @@ struct file_info;
 
 #include "qgraphicsview.h"
 #include "desk.h"
+#include "file.h"
 
 struct err_info;
 
@@ -203,6 +204,9 @@ public:
       };
 
    struct err_info *operation (Desk::operation_t type, int ival);
+
+   /** transform the page being shown, with undo */
+   void transformPage (File::e_transform op);
 
    /** redisplay the current page - can be used if the smoothing setting
        has been changed, for example */
@@ -355,11 +359,6 @@ protected slots:
 
    /** copy the ocr test to the clipboard */
    void ocrCopy (void);
-
-   /** add an amount to the rotation of the current page
-
-      \param add  amount to add (-90, 90, 180) */
-   void addRotate (int add);
 
    /** rotate the current page image right 90 degrees */
    void slotRotateRight (void);

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -208,6 +208,12 @@ public:
    /** transform the page being shown, with undo */
    void transformPage (File::e_transform op);
 
+   /** refresh a single page whose content has changed: reload its
+       thumbnail and, if it is the page being shown, the main image
+
+      \param pagenum  page which has changed */
+   void refreshPage (int pagenum);
+
    /** redisplay the current page - can be used if the smoothing setting
        has been changed, for example */
    void redisplay (void);

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -370,11 +370,14 @@ protected slots:
    /** rotate the current page image right 90 degrees */
    void slotRotateRight (void);
 
-   /** rotate the current page image 180 degrees */
-   void slotRotate180 (void);
-
    /** rotate the current page image left 90 degrees */
    void slotRotateLeft (void);
+
+   /** flip the current page image horizontally */
+   void slotFlipHorizontal (void);
+
+   /** flip the current page image vertically */
+   void slotFlipVertical (void);
 
 public:
    QAction *_returnToDesktop;

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -132,6 +132,7 @@ private:
 class Pagewidget : public QWidget
    {
    Q_OBJECT
+   friend class TestDesktopUi;
    friend class TestPagewidget;
 
 public:

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -487,6 +487,28 @@ err_info *Pdfio::flush (void)
    }
 
 
+err_info *Pdfio::rotatePage (int pagenum, int degrees)
+   {
+   if (!_doc)
+      CALL (open ());
+   try
+      {
+      PdfPage *page = _doc->GetPage (pagenum);
+
+      if (!page)
+         return err_make (ERRFN, ERR_could_not_find_image_chunk_for_page1,
+               pagenum + 1);
+      page->SetRotation ((page->GetRotation () + degrees) % 360);
+      }
+   catch (const PdfError &eCode)
+      {
+      return make_error (eCode);
+      }
+
+   // write the change and reopen the renderer's view of the file
+   return flush ();
+   }
+
 
 int Pdfio::numPages (void)
    {

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -376,9 +376,12 @@ err_info *Pdfio::getImageSize (int pagenum, bool preview, QSize &size,
          }
       }
 #ifdef EXCEPTIONS
-   catch (const PdfError &eCode)
+   catch (const PdfError &)
       {
-      return make_error (eCode);
+      /* if PoDoFo cannot handle the page, fall back to poppler below.
+         For example PoDoFo 0.9.8 refuses to decode the streams of
+         images with under 8 bits per pixel, since its predictor checks
+         misread the image's BitsPerComponent as predictor parameters */
       }
 #endif
    if (preview)
@@ -464,9 +467,13 @@ err_info *Pdfio::getImage (QString fname, int pagenum, QImage &image, double xsc
          return NULL;
          }
       }
-   catch (const PdfError &eCode)
+   catch (const PdfError &)
       {
-      return make_error (eCode);
+      /* if PoDoFo cannot decode the page image, fall back to rendering
+         with poppler below. For example PoDoFo 0.9.8 refuses to decode
+         the streams of images with under 8 bits per pixel, since its
+         predictor checks misread the image's BitsPerComponent as
+         predictor parameters */
       }
 
 #ifdef CONFIG_use_poppler

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -372,6 +372,13 @@ err_info *Pdfio::getImageSize (int pagenum, bool preview, QSize &size,
 
          get_image_details (dict, width, height, bpp);
          size = QSize (width, height);
+
+         /* a 90 or 270 degree /Rotate swaps the displayed dimensions,
+            to match the rotated image apply_rotation() produces */
+         int rot = ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360)
+               % 360;
+         if (rot == 90 || rot == 270)
+            size.transpose ();
          return NULL;
          }
       }
@@ -403,6 +410,28 @@ err_info *Pdfio::getImageSize (int pagenum, bool preview, QSize &size,
 #endif
       }
    return NULL;
+   }
+
+
+QImage Pdfio::apply_rotation (int pagenum, const QImage &image) const
+   {
+   if (!_doc)
+      return image;
+
+   /* /Rotate is the clockwise rotation a viewer applies to the page,
+      so map it to the matching image transform */
+   int rotation = ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360)
+         % 360;
+   switch (rotation)
+      {
+      case 90 :
+         return File::transformImage (image, File::Transform_rotate90);
+      case 180 :
+         return File::transformImage (image, File::Transform_rotate180);
+      case 270 :
+         return File::transformImage (image, File::Transform_rotate270);
+      }
+   return image;
    }
 
 
@@ -464,6 +493,12 @@ err_info *Pdfio::getImage (QString fname, int pagenum, QImage &image, double xsc
                qPrintable (fname), pagenum + 1, stride * height, len);
          Filepage::getImageFromLines (buff, width, height, bpp, stride,
                image, true, false, bpp == 1);
+
+         /* podofo extracts the raw embedded scan, which does not
+            reflect the page's /Rotate attribute; apply it so the
+            rendered image matches what a PDF viewer (and the poppler
+            fallback) shows */
+         image = apply_rotation (pagenum, image);
          return NULL;
          }
       }

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -24,6 +24,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 
 #include <QDebug>
+#include <QFile>
 
 #include "podofo/podofo.h"
 
@@ -141,22 +142,33 @@ err_info *Pdfio::create (void)
 
 err_info *Pdfio::close (void)
    {
+   /* PdfMemDocument loads objects on demand, so writing over the file
+      it is still reading from fails with an unexpected end of file.
+      Write to a temporary file and rename it into place */
+   QString tmpname = _pathname + ".tmp";
+
    try
       {
-      _doc->Write (_pathname.toLatin1 ().constData());
+      _doc->Write (tmpname.toLatin1 ().constData());
       }
    catch (const PdfError &eCode)
       {
+      QFile::remove (tmpname);
       return make_error (eCode);
       }
+   if (QFile::exists (_pathname))
+      QFile::remove (_pathname);
+   if (!QFile::rename (tmpname, _pathname))
+      return err_make (ERRFN, ERR_could_not_rename_file2,
+            qPrintable (tmpname), qPrintable (_pathname));
+
+   // reopen both libraries' views of the new file
+   delete _doc;
+   _doc = 0;
 #ifdef CONFIG_use_poppler
-   if (_pop)
-      {
-      _pop.reset();
-      CALL (open ());
-      }
+   _pop.reset();
 #endif
-   return NULL;
+   return open ();
    }
 
 
@@ -473,6 +485,7 @@ err_info *Pdfio::flush (void)
    {
    return close ();
    }
+
 
 
 int Pdfio::numPages (void)

--- a/pdfio.h
+++ b/pdfio.h
@@ -35,6 +35,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <memory>
 
+#include <QImage>
 #include <QString>
 
 #include "config.h"
@@ -194,6 +195,17 @@ protected:
       \param bpp     returns bits per pixel (1, 8 or 24) */
    void get_image_details (const PoDoFo::PdfDictionary *dict, int &width, int &height,
          int &bpp) const;
+
+   /** apply a page's /Rotate attribute to an extracted image
+
+      PoDoFo's image extraction returns the raw embedded scan, which
+      does not reflect the page's /Rotate attribute. This rotates the
+      image to match what a PDF viewer would display.
+
+      \param pagenum  page whose rotation to apply
+      \param image    image to rotate
+      \returns the rotated image */
+   QImage apply_rotation (int pagenum, const QImage &image) const;
 
    err_info *make_error (const PoDoFo::PdfError &eCode);
 

--- a/pdfio.h
+++ b/pdfio.h
@@ -93,6 +93,12 @@ public :
 
    err_info *flush (void);
 
+   /** rotate a page by adjusting its /Rotate key (lossless)
+
+      \param pagenum  page to rotate
+      \param degrees  clockwise rotation to add: 90, 180 or 270 */
+   err_info *rotatePage (int pagenum, int degrees);
+
    int numPages (void);
 
    err_info *getImage (QString fname, int pagenum, QImage &image, double xscale,

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -550,6 +550,51 @@ void TestDesktopUi::testDirTreeNavigation()
    here instead, so tests never launch anything */
 static QUrl s_opened_url;
 
+void TestDesktopUi::testRotateActions()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // select the max stack and capture its first page
+   clickItem(view, 0);
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   File *f = model->getFile(src_ind);
+   QVERIFY(f);
+
+   QImage orig, image;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!f->getImage(0, false, orig, size, trueSize, bpp, false));
+
+   // the rotate-right toolbar action turns the page on its side
+   me.actionRright->trigger();
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.width(), orig.height());
+   QCOMPARE(image.height(), orig.width());
+
+   // undo from the Edit menu rotates it back
+   me.actionUndo->trigger();
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), orig.size());
+
+   // rotate-left and the flips are wired up too
+   me.actionRleft->trigger();
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.width(), orig.height());
+   me.actionUndo->trigger();
+
+   me.actionVflip->trigger();
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), orig.size());
+   me.actionUndo->trigger();
+}
+
 void TestDesktopUi::testEmailSingleStack()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1,6 +1,7 @@
 #include <QClipboard>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QToolButton>
 #include <QtTest/QtTest>
 
 #include "test.h"
@@ -15,6 +16,8 @@
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
+#include "pagemodel.h"
+#include "pageview.h"
 #include "pagewidget.h"
 #include "qxmlconfig.h"
 #include "test_desktopui.h"
@@ -606,6 +609,65 @@ void TestDesktopUi::testRotateActions()
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.size(), orig.size());
    me.actionUndo->trigger();
+}
+
+void TestDesktopUi::testRotatePageKeepsSelection()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // select the max stack and wait for the preview pane to show it
+   clickItem(view, 0);
+   Pagewidget *pagew = desktop->_page;
+   QTRY_VERIFY(pagew->_pagemodel->rowCount(QModelIndex()) > 1);
+
+   // click the second page's thumbnail in the preview pane
+   QModelIndex page_ind = pagew->_pagemodel->index(1, 0, QModelIndex());
+   pagew->_pageview->scrollTo(page_ind);
+   QRect rect = pagew->_pageview->visualRect(page_ind);
+   QVERIFY(rect.isValid());
+   QTest::mouseClick(pagew->_pageview->viewport(), Qt::LeftButton,
+                     Qt::NoModifier, rect.center());
+   QCOMPARE(pagew->getCurrentPage(), 1);
+
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   File *f = model->getFile(src_ind);
+   QVERIFY(f);
+
+   QImage orig, other, image;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!f->getImage(1, false, orig, size, trueSize, bpp, false));
+   QVERIFY(!f->getImage(0, false, other, size, trueSize, bpp, false));
+
+   /* rotating the page must not rebuild the whole page model (which
+      reloads every thumbnail) and must keep the same page selected */
+   QSignalSpy resetSpy(pagew->_pagemodel, SIGNAL(modelReset()));
+
+   QToolButton *rright = pagew->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   // only the second page is transformed
+   QVERIFY(!f->getImage(1, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.width(), orig.height());
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), other.size());
+
+   // the selection stays on page two and the view is not rebuilt
+   QCOMPARE(pagew->getCurrentPage(), 1);
+   QCOMPARE(resetSpy.count(), 0);
+
+   me.actionUndo->trigger();
+   QVERIFY(!f->getImage(1, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), orig.size());
+   QCOMPARE(pagew->getCurrentPage(), 1);
 }
 
 void TestDesktopUi::testRotateUnloadedStack()

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -939,3 +939,4 @@ void TestDesktopUi::testDirFilterHidesOtherYears()
    QVERIFY(desktop->findDir(path + "/" + this_year).isValid());
    QVERIFY(desktop->findDir(path + "/" + last_year).isValid());
 }
+

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -11,6 +11,7 @@
 #include "desktopview.h"
 #include "desktopwidget.h"
 #include "dirmodel.h"
+#include "filemax.h"
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
@@ -593,6 +594,61 @@ void TestDesktopUi::testRotateActions()
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.size(), orig.size());
    me.actionUndo->trigger();
+}
+
+void TestDesktopUi::testRotateUnloadedStack()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   QString path;
+
+   /* show the repo once so that the desk caches are written, as in a
+      repository which has been used before */
+   {
+      Mainwindow first;
+      Desktopmodel *m;
+      QModelIndex ind;
+
+      path = setupRepo();
+      Desktopwidget *desktop = first.getDesktop();
+      QVERIFY(!desktop->addDir(path));
+      first.show();
+      QVERIFY(QTest::qWaitForWindowExposed(&first));
+      QTest::qWait(50);
+      desktop->closing();
+      Q_UNUSED(m);
+      Q_UNUSED(ind);
+   }
+
+   /* a fresh session reads the caches, so the stack's File is not
+      loaded and reports no pages: rotating must still work */
+   Mainwindow me;
+   Desktopwidget *desktop = me.getDesktop();
+   QVERIFY(!desktop->addDir(path));
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   model = desktop->getModel();
+   repo_ind = model->index(0, 0, QModelIndex());
+   Desktopview *view = desktop->getView();
+
+   QModelIndex src_ind = model->index(0, 0, repo_ind);
+   qDebug() << "pagecount before:"
+            << model->getFile(src_ind)->pagecount();
+
+   view->setSelectionRange(0, 1);
+   me.actionRright->trigger();
+
+   Filemax fresh(path + "/", "testfile.max", nullptr);
+   QVERIFY(fresh.load() == nullptr);
+
+   QImage image;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!fresh.getImage(0, false, image, size, trueSize, bpp, false));
+   QVERIFY(image.width() > image.height());   // it turned on its side
 }
 
 void TestDesktopUi::testEmailSingleStack()

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -562,34 +562,46 @@ void TestDesktopUi::testRotateActions()
    Desktopwidget *desktop = me.getDesktop();
    Desktopview *view = desktop->getView();
 
-   // select the max stack and capture its first page
+   // select the max stack and capture its first and last pages
    clickItem(view, 0);
    QModelIndex src_ind = model->index(0, 0, repo_ind);
    File *f = model->getFile(src_ind);
    QVERIFY(f);
 
-   QImage orig, image;
+   QImage orig, lastOrig, image;
    QSize size, trueSize;
    int bpp;
    QVERIFY(!f->getImage(0, false, orig, size, trueSize, bpp, false));
+   QVERIFY(!f->getImage(4, false, lastOrig, size, trueSize, bpp, false));
 
-   // the rotate-right toolbar action turns the page on its side
-   me.actionRright->trigger();
+   // the desktop toolbar's rotate-right button turns every page on
+   // its side
+   QPushButton *rright = desktop->findChild<QPushButton *>("rright");
+   QVERIFY(rright);
+   QTest::mouseClick(rright, Qt::LeftButton);
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.width(), orig.height());
    QCOMPARE(image.height(), orig.width());
+   QVERIFY(!f->getImage(4, false, image, size, trueSize, bpp, false));
+   QVERIFY(image.width() >= lastOrig.height());
+   QVERIFY(image.height() <= lastOrig.width());
 
-   // undo from the Edit menu rotates it back
+   // undo from the Edit menu rotates them all back
    me.actionUndo->trigger();
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.size(), orig.size());
+   QVERIFY(!f->getImage(4, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.height(), lastOrig.height());
 
-   // rotate-left and the flips are wired up too
-   me.actionRleft->trigger();
+   // the rotate-left button is wired up too
+   QPushButton *rleft = desktop->findChild<QPushButton *>("rleft");
+   QVERIFY(rleft);
+   QTest::mouseClick(rleft, Qt::LeftButton);
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.width(), orig.height());
    me.actionUndo->trigger();
 
+   // the flip menu action shares the same path
    me.actionVflip->trigger();
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.size(), orig.size());

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -45,6 +45,9 @@ private slots:
    //! Test the rotate and flip actions transform the current page
    void testRotateActions();
 
+   //! Test rotating one page in the preview pane keeps the selection
+   void testRotatePageKeepsSelection();
+
    //! Test rotating a stack which has not been viewed yet
    void testRotateUnloadedStack();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -42,6 +42,9 @@ private slots:
    //! Test stack navigation wraps at either end
    void testStackNavigationWraps();
 
+   //! Test the rotate and flip actions transform the current page
+   void testRotateActions();
+
    //! Test the Edit->Select-all menu action selects every stack
    void testSelectAllAction();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -45,6 +45,9 @@ private slots:
    //! Test the rotate and flip actions transform the current page
    void testRotateActions();
 
+   //! Test rotating a stack which has not been viewed yet
+   void testRotateUnloadedStack();
+
    //! Test the Edit->Select-all menu action selects every stack
    void testSelectAllAction();
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -745,12 +745,12 @@ void TestFile::testTransformPage()
             File::Transform_hflip);
 }
 
-/* Check that rendering a PDF page falls back to poppler when PoDoFo
-   cannot decode the page image. PoDoFo 0.9.8 refuses to decode the
-   streams of images with under 8 bits per pixel, such as the 1-bit
-   pages which paperman's own PDF conversion writes, because its
-   predictor checks misread the image's BitsPerComponent as predictor
-   parameters */
+/* Check that PDF pages render correctly after rotation. A 1-bit page
+   falls back to poppler because PoDoFo 0.9.8 refuses to decode the
+   streams of images with under 8 bits per pixel (its predictor checks
+   misread the image's BitsPerComponent as predictor parameters). A
+   colour page goes through PoDoFo's image extraction, which returns
+   the raw scan, so the render must apply the page's /Rotate itself */
 void TestFile::testPdfMonoRender()
 {
    QTemporaryDir tmp;
@@ -788,6 +788,20 @@ void TestFile::testPdfMonoRender()
    int bpp;
    QVERIFY(!pdf->getImage(3, false, image, size, trueSize, bpp, false));
    QVERIFY(!image.isNull());
+
+   /* the colour page 0 goes through PoDoFo's image extraction, which
+      returns the raw scan; the render must still reflect the page's
+      rotation, so a rotated page renders rotated rather than upright */
+   QImage colour;
+   QVERIFY(!pdf->getImage(0, false, colour, size, trueSize, bpp, false));
+   QVERIFY(colour.width() != colour.height());
+
+   QVERIFY(!pdf->transformPage(0, File::Transform_rotate90));
+   QVERIFY(!pdf->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.width(), colour.height());
+   QCOMPARE(image.height(), colour.width());
+   QImage want = File::transformImage(colour, File::Transform_rotate90);
+   QVERIFY(nearlySame(image, want));
    delete pdf;
 }
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -743,3 +743,71 @@ void TestFile::testTransformPage()
             File::Transform_hflip);
 }
 
+/* Compare a page rendered after transformPage() against the original
+   render transformed in memory. The stored page may be wider than the
+   reference because of format padding, so compare the reference-sized
+   region; lossless pages must match exactly, JPEG pages nearly */
+static void checkTransformedRender(Filemax &max, int pagenum,
+                                   File::e_transform op, bool lossless)
+{
+   QImage a, b;
+   QSize size, trueSize;
+   int bpp;
+
+   QVERIFY(!max.getImage(pagenum, false, a, size, trueSize, bpp, false));
+   QVERIFY(!max.transformPage(pagenum, op));
+   QVERIFY(!max.getImage(pagenum, false, b, size, trueSize, bpp, false));
+
+   QImage expected = File::transformImage(a, op);
+   QVERIFY(b.width() >= expected.width());
+   QVERIFY(b.width() < expected.width() + 32);
+   QVERIFY(b.height() >= expected.height());
+   QVERIFY(b.height() < expected.height() + 32);
+
+   QImage got = b.copy(0, 0, expected.width(), expected.height())
+                   .convertToFormat(QImage::Format_Grayscale8);
+   QImage want = expected.convertToFormat(QImage::Format_Grayscale8);
+
+   qint64 total = 0, worst = 0;
+   for (int y = 0; y < want.height(); y++) {
+      const uchar *pg = got.constScanLine(y);
+      const uchar *pw = want.constScanLine(y);
+      for (int x = 0; x < want.width(); x++) {
+         int d = qAbs(int(pg[x]) - int(pw[x]));
+         total += d;
+         if (d > worst)
+            worst = d;
+      }
+   }
+   qint64 mean = total / (qint64(want.width()) * want.height());
+   if (lossless) {
+      QVERIFY2(worst == 0, qPrintable(QString("worst pixel diff %1")
+                                      .arg(worst)));
+   } else {
+      QVERIFY2(mean < 4, qPrintable(QString("mean pixel diff %1")
+                                    .arg(mean)));
+   }
+
+   // put the page back for the next check
+   QVERIFY(!max.transformPage(pagenum, File::transformInverse(op)));
+}
+
+void TestFile::testTransformMatchesReference()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+   copyFixture("testfile.max", tmp.path());
+
+   Filemax max(dir, "testfile.max", nullptr);
+   QVERIFY(max.load() == nullptr);
+
+   // page 3 is a 1-bit text page, compressed losslessly
+   checkTransformedRender(max, 3, File::Transform_rotate90, true);
+   checkTransformedRender(max, 3, File::Transform_rotate180, true);
+   checkTransformedRender(max, 3, File::Transform_vflip, true);
+
+   // page 0 is a colour page with JPEG tiles, so allow encoding loss
+   checkTransformedRender(max, 0, File::Transform_rotate90, false);
+   checkTransformedRender(max, 0, File::Transform_rotate180, false);
+}

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -757,6 +757,12 @@ static void checkTransformedRender(Filemax &max, int pagenum,
    int bpp;
 
    QVERIFY(!max.getImage(pagenum, false, a, size, trueSize, bpp, false));
+
+   /* crop the decode padding so the reference matches what
+      transformPage() stores */
+   if (a.size() != size)
+      a = a.copy(QRect(QPoint(0, 0), size));
+
    QVERIFY(!max.transformPage(pagenum, op));
    QVERIFY(!max.getImage(pagenum, false, b, size, trueSize, bpp, false));
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -811,3 +811,30 @@ void TestFile::testTransformMatchesReference()
    checkTransformedRender(max, 0, File::Transform_rotate90, false);
    checkTransformedRender(max, 0, File::Transform_rotate180, false);
 }
+
+void TestFile::testTransformEmptyStack()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   /* create an empty stack, as the app does for a new stack which has
+      not been scanned into yet */
+   Filemax max(dir, "empty.max", nullptr);
+   QVERIFY(max.create() == nullptr);
+   QVERIFY(max.flush() == nullptr);
+   QCOMPARE(max.pagecount(), 0);
+
+   qint64 size_before = QFileInfo(dir + "empty.max").size();
+   QVERIFY(size_before > 0);
+
+   // there is nothing to rotate, so this must fail rather than crash
+   err_info *err = max.transformPage(0, File::Transform_rotate90);
+   QVERIFY(err != nullptr);
+
+   // and the file must be untouched and still loadable
+   QCOMPARE(QFileInfo(dir + "empty.max").size(), size_before);
+   Filemax fresh(dir, "empty.max", nullptr);
+   QVERIFY(fresh.load() == nullptr);
+   QCOMPARE(fresh.pagecount(), 0);
+}

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -629,6 +629,64 @@ void TestFile::testTransformPage()
       QCOMPARE(max.pagecount(), 5);
    }
 
+   // --- max: a 1-bit text page survives rotation ---
+   {
+      Filemax max(dir, "testfile.max", nullptr);
+      QVERIFY(max.load() == nullptr);
+
+      QImage orig, image;
+      QSize size, trueSize;
+      int bpp;
+      QVERIFY(!max.getImage(3, false, orig, size, trueSize, bpp, false));
+      qDebug() << "page 3 bpp" << bpp << "format" << orig.format();
+
+      QVERIFY(!max.transformPage(3, File::Transform_rotate90));
+      QVERIFY(!max.getImage(3, false, image, size, trueSize, bpp, false));
+
+      // 1-bit images are stored with the width padded to 32 pixels
+      QVERIFY(image.width() >= orig.height());
+      QVERIFY(image.width() < orig.height() + 32);
+
+      /* the page must not come back blank: it has text, so a fair
+         number of pixels are dark */
+      QImage grey = image.convertToFormat(QImage::Format_Grayscale8);
+      int dark = 0;
+      for (int y = 0; y < grey.height(); y += 4) {
+         const uchar *p = grey.constScanLine(y);
+         for (int x = 0; x < grey.width(); x += 4)
+            if (p[x] < 128)
+               dark++;
+      }
+      qDebug() << "dark pixels" << dark;
+      QVERIFY(dark > 100);
+
+      /* a fresh object reading the file from disk must see the rotated
+         page too, and its preview must not be blank */
+      {
+         Filemax fresh(dir, "testfile.max", nullptr);
+         QVERIFY(fresh.load() == nullptr);
+         QImage fimage;
+         QVERIFY(!fresh.getImage(3, false, fimage, size, trueSize, bpp,
+                                 false));
+         qDebug() << "fresh size" << fimage.size();
+         QVERIFY(nearlySame(fimage, image));
+
+         QPixmap pixmap;
+         QVERIFY(!fresh.getPreviewPixmap(3, pixmap, false));
+         QImage pgrey =
+            pixmap.toImage().convertToFormat(QImage::Format_Grayscale8);
+         int pdark = 0;
+         for (int y = 0; y < pgrey.height(); y++) {
+            const uchar *p = pgrey.constScanLine(y);
+            for (int x = 0; x < pgrey.width(); x++)
+               if (p[x] < 128)
+                  pdark++;
+         }
+         qDebug() << "preview size" << pixmap.size() << "dark" << pdark;
+         QVERIFY(pdark > 20);
+      }
+   }
+
    // --- pdf: rotation works, mirroring is not available ---
    {
       copyFixture("testpdf.pdf", tmp.path());
@@ -684,3 +742,4 @@ void TestFile::testTransformPage()
    QCOMPARE(File::transformInverse(File::Transform_hflip),
             File::Transform_hflip);
 }
+

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -556,3 +556,131 @@ void TestFile::testCacheBoundaryReads()
    // a halfword at the very end of the file can still be read
    QCOMPARE(f.gethw(bytes.size() - 2), hw_at(bytes.size() - 2));
 }
+
+//! Check two images are the same size and nearly identical in content,
+//! allowing for JPEG recompression loss
+static bool nearlySame(const QImage &a, const QImage &b)
+{
+   if (a.size() != b.size())
+      return false;
+
+   QImage ga = a.convertToFormat(QImage::Format_Grayscale8);
+   QImage gb = b.convertToFormat(QImage::Format_Grayscale8);
+   qint64 total = 0;
+   int count = 0;
+
+   for (int y = 0; y < ga.height(); y += 13) {
+      const uchar *pa = ga.constScanLine(y);
+      const uchar *pb = gb.constScanLine(y);
+      for (int x = 0; x < ga.width(); x += 13, count++)
+         total += qAbs(int(pa[x]) - int(pb[x]));
+   }
+   return count && total / count < 8;
+}
+
+void TestFile::testTransformPage()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   // --- max: rotate and mirror are applied and are reversible ---
+   {
+      copyFixture("testfile.max", tmp.path());
+      Filemax max(dir, "testfile.max", nullptr);
+      QVERIFY(max.load() == nullptr);
+
+      QImage orig, image;
+      QSize size, trueSize;
+      int bpp;
+      QVERIFY(!max.getImage(0, false, orig, size, trueSize, bpp, false));
+      QString title_before;
+      QVERIFY(!max.getPageTitle(0, title_before));
+
+      // rotating swaps the dimensions
+      QVERIFY(!max.transformPage(0, File::Transform_rotate90));
+      QVERIFY(!max.getImage(0, false, image, size, trueSize, bpp, false));
+      QCOMPARE(image.width(), orig.height());
+      QCOMPARE(image.height(), orig.width());
+
+      // the page keeps its title
+      QString title;
+      QVERIFY(!max.getPageTitle(0, title));
+      QCOMPARE(title, title_before);
+
+      // rotating back restores the original content
+      QVERIFY(!max.transformPage(0, File::Transform_rotate270));
+      QVERIFY(!max.getImage(0, false, image, size, trueSize, bpp, false));
+
+      /* rotating back restores the original content. The pages are
+         JPEG compressed so allow for recompression loss */
+      QVERIFY(nearlySame(image, orig));
+
+      /* mirroring changes the image (the page has horizontal colour
+         bars, so flip vertically) and mirroring again restores it */
+      QVERIFY(!max.transformPage(0, File::Transform_vflip));
+      QVERIFY(!max.getImage(0, false, image, size, trueSize, bpp, false));
+      QVERIFY(!nearlySame(image, orig));
+      QVERIFY(!max.transformPage(0, File::Transform_vflip));
+      QVERIFY(!max.getImage(0, false, image, size, trueSize, bpp, false));
+      QVERIFY(nearlySame(image, orig));
+
+      // the other pages are untouched
+      QCOMPARE(max.pagecount(), 5);
+   }
+
+   // --- pdf: rotation works, mirroring is not available ---
+   {
+      copyFixture("testpdf.pdf", tmp.path());
+      Filepdf pdf(dir, "testpdf.pdf", nullptr);
+      QVERIFY(pdf.load() == nullptr);
+
+      QImage orig, image;
+      QSize size, trueSize;
+      int bpp;
+      QVERIFY(!pdf.getImage(0, false, orig, size, trueSize, bpp, false));
+
+      QVERIFY(!pdf.transformPage(0, File::Transform_rotate90));
+      QVERIFY(!pdf.getImage(0, false, image, size, trueSize, bpp, false));
+      QCOMPARE(image.width(), orig.height());
+      QCOMPARE(image.height(), orig.width());
+
+      QVERIFY(!pdf.transformPage(0, File::Transform_rotate270));
+      QVERIFY(!pdf.getImage(0, false, image, size, trueSize, bpp, false));
+      QCOMPARE(image.size(), orig.size());
+
+      err_info *err = pdf.transformPage(0, File::Transform_hflip);
+      QVERIFY(err && err->errnum == ERR_no_available_for_this_file_type);
+   }
+
+   // --- jpeg: rotation is applied to the page file ---
+   {
+      copyFixture("colour_plasma.jpg", tmp.path());
+      Filejpeg jpg(dir, "colour_plasma.jpg", nullptr);
+      QVERIFY(jpg.load() == nullptr);
+
+      QImage orig, image;
+      QSize size, trueSize;
+      int bpp;
+      QVERIFY(!jpg.getImage(0, false, orig, size, trueSize, bpp, false));
+
+      QVERIFY(!jpg.transformPage(0, File::Transform_rotate90));
+      QVERIFY(!jpg.getImage(0, false, image, size, trueSize, bpp, false));
+      QCOMPARE(image.width(), orig.height());
+      QCOMPARE(image.height(), orig.width());
+
+      // the change is on disk, not just in memory
+      QImage ondisk(dir + "colour_plasma.jpg");
+      QCOMPARE(ondisk.width(), orig.height());
+   }
+
+   // --- the inverse helper undoes each transform ---
+   QCOMPARE(File::transformInverse(File::Transform_rotate90),
+            File::Transform_rotate270);
+   QCOMPARE(File::transformInverse(File::Transform_rotate270),
+            File::Transform_rotate90);
+   QCOMPARE(File::transformInverse(File::Transform_rotate180),
+            File::Transform_rotate180);
+   QCOMPARE(File::transformInverse(File::Transform_hflip),
+            File::Transform_hflip);
+}

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -745,6 +745,52 @@ void TestFile::testTransformPage()
             File::Transform_hflip);
 }
 
+/* Check that rendering a PDF page falls back to poppler when PoDoFo
+   cannot decode the page image. PoDoFo 0.9.8 refuses to decode the
+   streams of images with under 8 bits per pixel, such as the 1-bit
+   pages which paperman's own PDF conversion writes, because its
+   predictor checks misread the image's BitsPerComponent as predictor
+   parameters */
+void TestFile::testPdfMonoRender()
+{
+   QTemporaryDir tmp;
+   QString dir = tmp.path() + "/";
+
+   copyFixture("testfile.max", tmp.path());
+   Filemax max(dir, "testfile.max", nullptr);
+   QVERIFY(max.load() == nullptr);
+
+   File *pdf = File::createFile(dir, "converted.pdf", nullptr,
+                                File::Type_pdf);
+   QVERIFY(pdf);
+   QVERIFY(pdf->create() == nullptr);
+   Operation op("Convert file", 0, 0);
+   QVERIFY(max.copyTo(pdf, 3, op, false) == nullptr);
+   QCOMPARE(pdf->pagecount(), max.pagecount());
+
+   // every page must render, including the 1-bit one
+   for (int page = 0; page < pdf->pagecount(); page++) {
+      QImage image;
+      QSize size, trueSize;
+      int bpp;
+      err_info *e = pdf->getImage(page, false, image, size, trueSize, bpp,
+                                  false);
+      QVERIFY2(!e, qPrintable(QString("page %1: %2").arg(page)
+                              .arg(e ? e->errstr : "")));
+      QVERIFY(!image.isNull());
+   }
+
+   /* rotating the 1-bit page and re-rendering follows the same path as
+      the page view's refresh after a rotation */
+   QVERIFY(!pdf->transformPage(3, File::Transform_rotate90));
+   QImage image;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!pdf->getImage(3, false, image, size, trueSize, bpp, false));
+   QVERIFY(!image.isNull());
+   delete pdf;
+}
+
 /* Compare a page rendered after transformPage() against the original
    render transformed in memory. The stored page may be wider than the
    reference because of format padding, so compare the reference-sized

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,6 +1,8 @@
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
+#include <cstring>
+
 #include "err.h"
 #include "file.h"
 #include "filejpeg.h"
@@ -767,23 +769,26 @@ static void checkTransformedRender(Filemax &max, int pagenum,
    QImage got = b.copy(0, 0, expected.width(), expected.height())
                    .convertToFormat(QImage::Format_Grayscale8);
    QImage want = expected.convertToFormat(QImage::Format_Grayscale8);
+   QCOMPARE(got.size(), want.size());
 
-   qint64 total = 0, worst = 0;
-   for (int y = 0; y < want.height(); y++) {
-      const uchar *pg = got.constScanLine(y);
-      const uchar *pw = want.constScanLine(y);
-      for (int x = 0; x < want.width(); x++) {
-         int d = qAbs(int(pg[x]) - int(pw[x]));
-         total += d;
-         if (d > worst)
-            worst = d;
-      }
-   }
-   qint64 mean = total / (qint64(want.width()) * want.height());
    if (lossless) {
-      QVERIFY2(worst == 0, qPrintable(QString("worst pixel diff %1")
-                                      .arg(worst)));
+      /* the two routes must produce identical bytes: compare each row
+         directly (the rows are compared individually because the
+         scanline padding bytes are not meaningful) */
+      for (int y = 0; y < want.height(); y++)
+         QVERIFY2(!memcmp(got.constScanLine(y), want.constScanLine(y),
+                          want.width()),
+                  qPrintable(QString("row %1 differs").arg(y)));
    } else {
+      // JPEG tiles are recompressed, so allow a small mean difference
+      qint64 total = 0;
+      for (int y = 0; y < want.height(); y++) {
+         const uchar *pg = got.constScanLine(y);
+         const uchar *pw = want.constScanLine(y);
+         for (int x = 0; x < want.width(); x++)
+            total += qAbs(int(pg[x]) - int(pw[x]));
+      }
+      qint64 mean = total / (qint64(want.width()) * want.height());
       QVERIFY2(mean < 4, qPrintable(QString("mean pixel diff %1")
                                     .arg(mean)));
    }

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -74,6 +74,10 @@ private slots:
    //! transformed in memory
    void testTransformMatchesReference();
 
+   //! transforming an empty stack reports an error and leaves the
+   //! file intact
+   void testTransformEmptyStack();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -70,6 +70,10 @@ private slots:
    //! transformPage rotates and mirrors pages of each file type
    void testTransformPage();
 
+   //! a re-rendered transformed page matches the reference image
+   //! transformed in memory
+   void testTransformMatchesReference();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -70,6 +70,9 @@ private slots:
    //! transformPage rotates and mirrors pages of each file type
    void testTransformPage();
 
+   //! rendering a PDF page PoDoFo cannot decode falls back to poppler
+   void testPdfMonoRender();
+
    //! a re-rendered transformed page matches the reference image
    //! transformed in memory
    void testTransformMatchesReference();

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -70,7 +70,7 @@ private slots:
    //! transformPage rotates and mirrors pages of each file type
    void testTransformPage();
 
-   //! rendering a PDF page PoDoFo cannot decode falls back to poppler
+   //! PDF pages render correctly after rotation, mono and colour
    void testPdfMonoRender();
 
    //! a re-rendered transformed page matches the reference image

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -67,6 +67,9 @@ private slots:
    //! the end of a cache window
    void testCacheBoundaryReads();
 
+   //! transformPage rotates and mirrors pages of each file type
+   void testTransformPage();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -213,6 +213,55 @@ void TestPagewidget::testRotateButtons()
    QCOMPARE(page->_rotate, 0);
 }
 
+//! Count dark pixels in an image, sampling every few pixels
+static int darkPixels(const QImage &img)
+{
+   QImage grey = img.convertToFormat(QImage::Format_Grayscale8);
+   int dark = 0;
+
+   for (int y = 0; y < grey.height(); y += 4) {
+      const uchar *p = grey.constScanLine(y);
+      for (int x = 0; x < grey.width(); x += 4)
+         if (p[x] < 128)
+            dark++;
+   }
+   return dark;
+}
+
+void TestPagewidget::testRotateActionDisplay()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   // the displayed page has content
+   QSize before = page->_image.size();
+   QVERIFY(darkPixels(page->_image) > 50);
+
+   /* rotating in the page view must show the rotated page, not a
+      blank or stale one */
+   me.actionRright->trigger();
+   QCOMPARE(page->_image.size(), QSize(before.height(), before.width()));
+   QVERIFY(darkPixels(page->_image) > 50);
+
+   // rotating a second time works too (back to the original size)
+   me.actionRright->trigger();
+   QCOMPARE(page->_image.size(), before);
+   QVERIFY(darkPixels(page->_image) > 50);
+
+   // a third press reaches 270 degrees
+   me.actionRright->trigger();
+   QCOMPARE(page->_image.size(), QSize(before.height(), before.width()));
+   QVERIFY(darkPixels(page->_image) > 50);
+
+   // undo returns to 180 degrees, shown immediately
+   me.actionUndo->trigger();
+   QCOMPARE(page->_image.size(), before);
+   QVERIFY(darkPixels(page->_image) > 50);
+}
+
 void TestPagewidget::testEditAttributesSave()
 {
    Desktopmodel *model;

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -178,6 +178,22 @@ void TestPagewidget::testZoomLevelEdit()
    QCOMPARE(zoomValue(zoom), 200);
 }
 
+//! Mean per-pixel difference between two same-sized images
+static int meanDiff(const QImage &a, const QImage &b)
+{
+   QImage ga = a.convertToFormat(QImage::Format_Grayscale8);
+   QImage gb = b.convertToFormat(QImage::Format_Grayscale8);
+   qint64 total = 0;
+
+   for (int y = 0; y < ga.height(); y++) {
+      const uchar *pa = ga.constScanLine(y);
+      const uchar *pb = gb.constScanLine(y);
+      for (int x = 0; x < ga.width(); x++)
+         total += qAbs(int(pa[x]) - int(pb[x]));
+   }
+   return total / (qint64(ga.width()) * ga.height());
+}
+
 void TestPagewidget::testRotateButtons()
 {
    Desktopmodel *model;
@@ -188,8 +204,9 @@ void TestPagewidget::testRotateButtons()
 
    QToolButton *rleft = page->findChild<QToolButton *>("rleft");
    QToolButton *rright = page->findChild<QToolButton *>("rright");
-   QToolButton *r180 = page->findChild<QToolButton *>("vflip");
-   QVERIFY(rleft && rright && r180);
+   QToolButton *hflip = page->findChild<QToolButton *>("hflip");
+   QToolButton *vflip = page->findChild<QToolButton *>("vflip");
+   QVERIFY(rleft && rright && hflip && vflip);
 
    QModelIndex ind;
    QVERIFY(page->getCurrentIndex(ind, true));
@@ -217,10 +234,22 @@ void TestPagewidget::testRotateButtons()
    QCOMPARE(image.size(), first.size());
    QCOMPARE(page->_image.size(), first.size());
 
-   // the 180-degree button keeps the size and is undoable
-   QTest::mouseClick(r180, Qt::LeftButton);
+   /* the flips match the reference transform (a small difference is
+      allowed for JPEG recompression) and are undoable */
+   QTest::mouseClick(vflip, Qt::LeftButton);
    QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
    QCOMPARE(image.size(), first.size());
+   QVERIFY(meanDiff(image,
+                    File::transformImage(first, File::Transform_vflip)) < 4);
+   me.actionUndo->trigger();
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QVERIFY(meanDiff(image, first) < 4);
+
+   QTest::mouseClick(hflip, Qt::LeftButton);
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), first.size());
+   QVERIFY(meanDiff(image,
+                    File::transformImage(first, File::Transform_hflip)) < 4);
    me.actionUndo->trigger();
    QCOMPARE(page->_image.size(), first.size());
 }

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -191,26 +191,38 @@ void TestPagewidget::testRotateButtons()
    QToolButton *r180 = page->findChild<QToolButton *>("vflip");
    QVERIFY(rleft && rright && r180);
 
-   QCOMPARE(page->_rotate, 0);
+   QModelIndex ind;
+   QVERIFY(page->getCurrentIndex(ind, true));
+   File *f = model->getFile(ind);
+   QVERIFY(f);
 
-   // Rotate right goes clockwise in 90-degree steps
+   QImage first, last, image;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!f->getImage(0, false, first, size, trueSize, bpp, false));
+   QVERIFY(!f->getImage(4, false, last, size, trueSize, bpp, false));
+
+   /* rotate-right transforms only the page being shown; the other
+      pages are untouched */
    QTest::mouseClick(rright, Qt::LeftButton);
-   QCOMPARE(page->_rotate, 90);
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.width(), first.height());
+   QVERIFY(!f->getImage(4, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), last.size());
+   QCOMPARE(page->_image.height(), first.width());
 
-   QTest::mouseClick(rright, Qt::LeftButton);
-   QCOMPARE(page->_rotate, 180);
-
-   // Rotate left goes back
+   // rotate-left turns it back
    QTest::mouseClick(rleft, Qt::LeftButton);
-   QCOMPARE(page->_rotate, 90);
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), first.size());
+   QCOMPARE(page->_image.size(), first.size());
 
-   // The 180 button turns the page upside down from where it is
+   // the 180-degree button keeps the size and is undoable
    QTest::mouseClick(r180, Qt::LeftButton);
-   QCOMPARE(page->_rotate, 270);
-
-   // A full circle returns to normal
-   QTest::mouseClick(rright, Qt::LeftButton);
-   QCOMPARE(page->_rotate, 0);
+   QVERIFY(!f->getImage(0, false, image, size, trueSize, bpp, false));
+   QCOMPARE(image.size(), first.size());
+   me.actionUndo->trigger();
+   QCOMPARE(page->_image.size(), first.size());
 }
 
 //! Count dark pixels in an image, sampling every few pixels

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -33,7 +33,7 @@ private slots:
    //! Test typing a zoom level into the zoom box
    void testZoomLevelEdit();
 
-   //! Test the rotate buttons transform the displayed page
+   //! Test the rotate and flip buttons transform the displayed page
    void testRotateButtons();
 
    //! Test the rotate action updates the displayed page

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -36,6 +36,9 @@ private slots:
    //! Test the rotate-left/right and 180 display buttons
    void testRotateButtons();
 
+   //! Test the rotate action updates the displayed page
+   void testRotateActionDisplay();
+
    //! Test editing stack attributes and saving them
    void testEditAttributesSave();
 

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -33,7 +33,7 @@ private slots:
    //! Test typing a zoom level into the zoom box
    void testZoomLevelEdit();
 
-   //! Test the rotate-left/right and 180 display buttons
+   //! Test the rotate buttons transform the displayed page
    void testRotateButtons();
 
    //! Test the rotate action updates the displayed page

--- a/toolbar.ui
+++ b/toolbar.ui
@@ -169,6 +169,98 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="rleft">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Rotate each page in the stack left</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/rleft.xpm</normaloff>:/images/images/rleft.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="rright">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Rotate each page in the stack right</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/rright.xpm</normaloff>:/images/images/rright.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hflip">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Flip each page in the stack horizontally</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/hflip.xpm</normaloff>:/images/images/hflip.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="vflip">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Flip each page in the stack vertically</string>
+       </property>
+       <property name="icon">
+        <iconset resource="maxview.qrc">
+         <normaloff>:/images/images/vflip.xpm</normaloff>:/images/images/vflip.xpm</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/utils.cpp
+++ b/utils.cpp
@@ -285,7 +285,16 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
             mem_check ();
             }
          else
-            memcpy (dest, buffer[0], tile_bytes);
+            {
+            int bytes = tile_bytes;
+
+            /* the tile may be padded beyond the image width, so avoid
+               writing past the end of each destination row */
+            if (max_width != -1 &&
+                bytes > max_width * (int)cinfo.output_components)
+               bytes = max_width * cinfo.output_components;
+            memcpy (dest, buffer[0], bytes);
+            }
          dest += line_bytes;
          }
 //       debug1 (("width = %d, tile_bytes = %d, line_bytes = %d, decoded %d lines\n",


### PR DESCRIPTION
The toolbar rotate and flip actions have been dead since the Qt3
port: they end in a stubbed-out operation() and the original Desk
code is disabled. This adds a transformPage() operation to File with
an implementation for each type: max pages are decoded, transformed
and replaced in place (keeping title, timestamp and OCR text), PDF
pages rotate losslessly via the /Rotate key, and JPEG pages are
rewritten. Mirroring a PDF page reports 'not available'.

The operation is undoable from the Edit menu, the page view and
desktop preview refresh, and tests cover the file layer for each
type plus the actions end to end.

Along the way this repairs the never-used max_replace_page() (it
initialised the wrong page struct) and fixes Pdfio writing a loaded
document over its own input file, which podofo cannot do.