### PR TITLE
Add Copy as PDF to the clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Scanning | Fast folder finding | Scanning dialog | Side-by-side preview & OCR
 - double click to view full size page image (also on right pane)
 - print stacks and pages, including page annotations
 - email files as PDF via Gmail (Ctrl+Shift+E, paste with Ctrl+V)
+- copy files as PDF to the clipboard (Ctrl+C, paste anywhere)
 - full undo/redo
 
 

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -826,6 +826,21 @@ public:
    err_info *opEmailFiles (QModelIndex parent, QModelIndexList &slist,
          File::e_type type);
 
+   /** copy files to the clipboard, ready to paste elsewhere
+
+       The selected files are converted to the requested type (if any)
+       and put on the clipboard as a text/uri-list, so they can be
+       pasted into another application, such as a Gmail compose window,
+       as an attachment.  If more than one file is copied they are
+       packed into a zip archive first.
+
+      \param parent  desk containing the files
+      \param slist   list of files to copy
+      \param type    type to convert to (or Type_other to leave as is)
+      \returns error or NULL if ok */
+   err_info *opCopyFiles (QModelIndex parent, QModelIndexList &slist,
+         File::e_type type);
+
    /** when non-null, URLs which would be opened in the browser (e.g.
        the email compose window) are stored here instead. Used by
        tests to check the URL without launching anything */
@@ -1331,10 +1346,38 @@ protected:
       \param fname   filename to use for zip file (if required). The extension 
                      of this is ignored and replaced with .zip
       \param fnameList list of filenames to send (each a full path)
-      \param can_delete returns true if the original files can be deleted, 
+      \param can_delete returns true if the original files can be deleted,
                      false if the email program wants them to stay around
       \returns error or NULL if ok */
    err_info *emailFiles (QString &fname, QStringList &fnamelist, bool &can_delete);
+
+   /** convert the selected files ready for email or copy
+
+       Each file is converted to the requested type into a temporary
+       file, or its own path is used when type is Type_other.
+
+      \param slist      list of files to package
+      \param type       type to convert to (or Type_other to leave as is)
+      \param op         operation to update with progress
+      \param fname      returns a name to use for the zip, if needed
+      \param fname_list returns the list of files to put on the clipboard
+      \param tmp_list   returns the temporary files which may be deleted
+      \returns error or NULL if ok */
+   err_info *packageFiles (QModelIndexList &slist, File::e_type type,
+         Operation &op, QString &fname, QStringList &fname_list,
+         QStringList &tmp_list);
+
+   /** put files on the clipboard as a text/uri-list
+
+       If more than one file is given they are packed into a zip first.
+
+      \param fname     filename to use for the zip file, if needed
+      \param fnamelist list of files to put on the clipboard (full paths)
+      \param can_delete returns true if the original files can be deleted,
+                     false if they must stay around for the paste
+      \returns error or NULL if ok */
+   err_info *copyFilesToClipboard (QString &fname, QStringList &fnamelist,
+         bool &can_delete);
 
 private:
    QList<Desk *> _desks;  //!< the model directories

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -336,6 +336,7 @@ void Desktopwidget::addActions(void)
    addAction (_act_email, "&Files", SLOT (email ()), "Ctrl+E");
    addAction (_act_email_pdf, "as &PDF", SLOT (emailPdf ()), "Ctrl+Shift+E");
    addAction (_act_email_max, "as &Max", SLOT (emailMax ()), "Ctrl+Alt+E");
+   addAction (_act_copy, "&Copy as PDF", SLOT (copy ()), "Ctrl+C");
    addAction (_act_move, "&Move to folder",  SLOT(moveToFolder ()), "Ctrl+M");
 //   addAction (_act_send, "&Send stacks", SLOT (send ()), "Ctrl+S");
 //   addAction (_act_deliver_out, "&Delivery outgoing", SLOT (deliverOut ()), "");
@@ -1221,6 +1222,7 @@ void Desktopwidget::updateActions()
    _act_email->setEnabled (at_least_one);
    _act_email_max->setEnabled (at_least_one);
    _act_email_pdf->setEnabled (at_least_one);
+   _act_copy->setEnabled (at_least_one);
 
 }
 
@@ -1262,6 +1264,8 @@ void Desktopwidget::slotPopupMenu (QModelIndex &index)
    submenu->addAction (_act_email);
    submenu->addAction (_act_email_max);
    submenu->addAction (_act_email_pdf);
+   submenu->addSeparator ();
+   submenu->addAction (_act_copy);
 /* to be implemented
    submenu = context_menu->addMenu (tr ("&Send..."));
    submenu->addAction (_act_send);
@@ -1516,8 +1520,31 @@ void Desktopwidget::emailPdf (void)
 {
    QModelIndex parent = _view->rootIndexSource ();
    QModelIndexList slist = _view->getSelectedListSource ();
-   
+
    _main->complain(_contents->opEmailFiles(parent, slist, File::Type_pdf));
+}
+
+
+void Desktopwidget::copy (void)
+{
+   QModelIndex parent = _view->rootIndexSource ();
+   QModelIndexList slist = _view->getSelectedListSource ();
+
+   if (slist.isEmpty ())
+      return;
+
+   // tell the user what landed on the clipboard and how to use it
+   if (!_main->complain (_contents->opCopyFiles (parent, slist,
+         File::Type_pdf)))
+      {
+      QString msg = slist.size () == 1
+         ? tr ("Copied as a PDF document - press Ctrl+V to paste it into "
+               "an email, a file manager or another app")
+         : tr ("Copied %1 documents as a zip - press Ctrl+V to paste it "
+               "into an email, a file manager or another app")
+                  .arg (slist.size ());
+      emit newContents (msg);
+      }
 }
 
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -420,6 +420,9 @@ private slots:
    // convert files to pdf and email as attachments
    void emailPdf (void);
 
+   // copy files to the clipboard as PDF, ready to paste elsewhere
+   void copy (void);
+
    // send files
    void send (void);
 
@@ -566,6 +569,7 @@ private:
    QAction *_act_duplicate_odd, *_act_duplicate_even;
    QAction *_act_duplicate_jpeg, *_act_move;
    QAction *_act_email, *_act_email_max, *_act_email_pdf;
+   QAction *_act_copy;
 //   QAction *_act_send, *_act_deliver_out;
 
    Toolbar *_toolbar;

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -540,7 +540,8 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
    }
 
 
-err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool &can_delete)
+err_info *Desktopmodel::copyFilesToClipboard (QString &fname,
+      QStringList &fnamelist, bool &can_delete)
 {
    can_delete = true;
 
@@ -548,10 +549,12 @@ err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool
    if (fnamelist.size () == 1)
       {
       fname = fnamelist [0];
-      can_delete = false;   // we need to keep the file for the email program
+      can_delete = false;   // we need to keep the file on the clipboard
       }
    else
       CALL (util_buildZip (fname, fnamelist));
+
+   QUrl url = QUrl::fromLocalFile (fname);
 
    // Put the file on the clipboard as a text/uri-list so Gmail compose
    // (and any other webmail that accepts file paste) treats Ctrl+V as a
@@ -559,8 +562,25 @@ err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool
    // so this is the only path that lands a real attachment in Gmail
    // without a per-user OAuth dance.
    QMimeData *mime = new QMimeData ();
-   mime->setUrls (QList<QUrl> () << QUrl::fromLocalFile (fname));
+   mime->setUrls (QList<QUrl> () << url);
+
+   /* A bare text/uri-list is enough for a browser, but file managers
+      need a copy/cut marker to paste the file.  Provide both the GNOME
+      and KDE flavours so Files, Nautilus, Dolphin and the like treat
+      Ctrl+V as a file copy. */
+   mime->setData ("x-special/gnome-copied-files",
+         QByteArray ("copy\n") + url.toEncoded ());
+   mime->setData ("application/x-kde-cutselection", QByteArray ("0"));
+
    QApplication::clipboard ()->setMimeData (mime);
+
+   return NULL;
+}
+
+
+err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool &can_delete)
+{
+   CALL (copyFilesToClipboard (fname, fnamelist, can_delete));
 
    // Open Gmail's compose URL with a pre-filled subject and body.  The
    // attachment cannot ride on the URL, but the user pastes it with
@@ -576,21 +596,17 @@ err_info *Desktopmodel::emailFiles (QString &fname, QStringList &fnamelist, bool
 }
 
 
-err_info *Desktopmodel::opEmailFiles (QModelIndex parent, QModelIndexList &slist,
-      File::e_type type)
+err_info *Desktopmodel::packageFiles (QModelIndexList &slist,
+      File::e_type type, Operation &op, QString &fname,
+      QStringList &fname_list, QStringList &tmp_list)
 {
    int upto = 0;
-   QStringList fname_list, tmp_list;
-
-   UNUSED (parent);
-   Operation op ("Packaging", slist.size (), 0);
 
    // name of first file will be used for the zip name
-   QString fname = getFile (slist [0])->filename ();
+   fname = getFile (slist [0])->filename ();
    QString dir = QString ("%1/").arg (P_tmpdir);
 
    // put the path on front of each file
-   err_info *e = NULL;
    foreach (QModelIndex ind, slist)
    {
       File *f = getFile (ind);
@@ -607,17 +623,57 @@ err_info *Desktopmodel::opEmailFiles (QModelIndex parent, QModelIndexList &slist
 
          QString ext = File::typeExt (type);
          uniq = util_findNextFilename (f->leaf (), dir, ext);
-         CALLB (f->duplicateToDesk (0, type, uniq, 3, op, fnew));
+         CALL (f->duplicateToDesk (0, type, uniq, 3, op, fnew));
          fname_list << uniq;
          tmp_list << uniq;
       }
       op.setProgress (upto++);
    }
+   return NULL;
+}
+
+
+err_info *Desktopmodel::opEmailFiles (QModelIndex parent, QModelIndexList &slist,
+      File::e_type type)
+{
+   QString fname;
+   QStringList fname_list, tmp_list;
+
+   UNUSED (parent);
+   Operation op ("Packaging", slist.size (), 0);
+
+   err_info *e = packageFiles (slist, type, op, fname, fname_list, tmp_list);
    bool can_delete = true;
    if (!e)
       e = emailFiles (fname, fname_list, can_delete);
 
    // delete the files if we are allowed
+   if (can_delete) {
+      foreach (QString fname, tmp_list)
+         {
+         QFile f (fname);
+         f.remove ();
+         }
+   }
+   return e;
+}
+
+
+err_info *Desktopmodel::opCopyFiles (QModelIndex parent, QModelIndexList &slist,
+      File::e_type type)
+{
+   QString fname;
+   QStringList fname_list, tmp_list;
+
+   UNUSED (parent);
+   Operation op ("Packaging", slist.size (), 0);
+
+   err_info *e = packageFiles (slist, type, op, fname, fname_list, tmp_list);
+   bool can_delete = true;
+   if (!e)
+      e = copyFilesToClipboard (fname, fname_list, can_delete);
+
+   // delete the converted files if they are not the one on the clipboard
    if (can_delete) {
       foreach (QString fname, tmp_list)
          {

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -47,3 +47,13 @@ generally.
 
 If more than one file is selected they are packed into a single zip
 first, since most compose paste handlers only take one file.
+
+Copying files
+-------------
+
+The Copy command (Ctrl+C) converts the selected files to PDF and puts
+the result on the clipboard as a ``text/uri-list``, the same way the
+Email menu does, but without opening a browser.  Paste it wherever a
+file is wanted: a Gmail compose window (Ctrl+V attaches it), a file
+manager, or a chat window.  As with email, more than one file is packed
+into a single zip first.

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -831,6 +831,62 @@ void TestDesktopUi::testEmailAsPdfConverts()
    QFile::remove(pdf);
 }
 
+void TestDesktopUi::testCopyAsPdf()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+   Desktopmodel::url_capture = &s_opened_url;
+   s_opened_url = QUrl();
+
+   // start with an empty clipboard so we can be sure copy fills it
+   QApplication::clipboard()->clear();
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // copy the max stack: a converted PDF lands on the clipboard
+   clickItem(view, 0);
+   QVERIFY(desktop->_act_copy->isEnabled());
+   QSignalSpy statusSpy(desktop, SIGNAL(newContents(QString)));
+   desktop->_act_copy->trigger();
+
+   // the status bar is told what was copied and how to paste it
+   QCOMPARE(statusSpy.count(), 1);
+   QString status = statusSpy.takeFirst().at(0).toString();
+   QVERIFY(status.contains("PDF"));
+   QVERIFY(status.contains("Ctrl+V"));
+
+   const QMimeData *mime = QApplication::clipboard()->mimeData();
+   QVERIFY(mime);
+   QVERIFY(mime->hasUrls());
+   QCOMPARE(mime->urls().size(), 1);
+
+   QString pdf = mime->urls()[0].toLocalFile();
+   QVERIFY(pdf.endsWith(".pdf"));
+   QVERIFY(QFile::exists(pdf));
+
+   // it really is a PDF, ready to paste into a compose window
+   QFile fil(pdf);
+   QVERIFY(fil.open(QIODevice::ReadOnly));
+   QCOMPARE(fil.read(4), QByteArray("%PDF"));
+   fil.close();
+
+   // the GNOME copy marker is present so file managers paste the file
+   // rather than ignoring a bare uri-list
+   QVERIFY(mime->hasFormat("x-special/gnome-copied-files"));
+   QByteArray gnome = mime->data("x-special/gnome-copied-files");
+   QVERIFY(gnome.startsWith("copy\n"));
+   QVERIFY(gnome.contains(QUrl::fromLocalFile(pdf).toEncoded()));
+
+   // copying does not open a browser window, unlike emailing
+   QVERIFY(s_opened_url.isEmpty());
+
+   QFile::remove(pdf);
+}
+
 void TestDesktopUi::testDragDropToFolder()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -81,6 +81,9 @@ private slots:
    //! Test emailing a stack as PDF converts it first
    void testEmailAsPdfConverts();
 
+   //! Test copying a stack puts a PDF on the clipboard without a browser
+   void testCopyAsPdf();
+
    //! Test dragging a stack onto a folder in the tree moves it there
    void testDragDropToFolder();
 


### PR DESCRIPTION
Adds a Copy command (Ctrl+C, also in the desktop context menu) which converts the selected stacks to PDF and puts them on the clipboard as a `text/uri-list`, ready to paste into a Gmail compose window, a file manager or a chat window — without opening a browser.

It reuses the clipboard packaging the Email menu already uses, factored out into `copyFilesToClipboard()` and `packageFiles()` so both paths share one implementation. Multiple files are packed into a zip first, and the converted PDF is kept (not deleted) so the later paste still finds it.

Covered by `testCopyAsPdf()`, which checks a PDF lands on the clipboard and that no browser window opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)