### PR TITLE
Show a rotated page's thumbnail at once, not blanked

### DIFF
--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -112,7 +112,14 @@ void Pagemodel::updatePage (int pagenum)
 
    if (row < 0 || row >= _row_count)
       return;
-   _pages [row].invalidate ();
+
+   /* regenerate the thumbnail straight away so the changed page (e.g.
+      after a rotation) is shown in its new form at once.  Going through
+      invalidate() would null the pixmap and defer the rescale to the
+      background timer, so the page would blank briefly first */
+   _pages [row]._rescale = true;
+   if (!_pages [row].updatePixmap ())
+      _pages [row].invalidate ();   // not set up yet: rebuild lazily
 
    QModelIndex ind = index (row, 0, QModelIndex ());
    emit dataChanged (ind, ind);

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -58,6 +58,8 @@ class Pageinfo
    friend class Pagemodel;   /* needs direct access to _scan_image so two
                                 pages can be drawn in parallel during a
                                 progressive duplex scan */
+   friend class TestPagewidget;
+   friend class TestDesktopUi;
 public:
    Pageinfo ();
    ~Pageinfo ();
@@ -159,6 +161,8 @@ Q_DECLARE_METATYPE(Pageinfo *)
 class Pagemodel : public QAbstractItemModel
    {
    Q_OBJECT
+   friend class TestPagewidget;
+   friend class TestDesktopUi;
 public:
    Pagemodel (QObject *parent);
    ~Pagemodel ();

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -670,6 +670,45 @@ void TestDesktopUi::testRotatePageKeepsSelection()
    QCOMPARE(pagew->getCurrentPage(), 1);
 }
 
+void TestDesktopUi::testRotatePreviewThumbnailReady()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // select the max stack; the preview pane on the right shows its pages
+   clickItem(view, 0);
+   Pagewidget *pagew = desktop->_page;
+   QTRY_VERIFY(pagew->_pagemodel->rowCount(QModelIndex()) > 1);
+   Pagemodel *pm = pagew->_pagemodel;
+
+   /* mimic the displayed state: the shown page's thumbnail has been
+      generated and is ready (the background rescale runs on a timer, so
+      force it here rather than waiting) */
+   pm->ensurePage(0);
+   pm->_pages[0]._rescale = true;
+   pm->_pages[0].updatePixmap();
+   QVERIFY(!pm->_pages[0]._pixmap.isNull());
+
+   // rotate the shown page using the preview pane's rotate button
+   QToolButton *rright = pagew->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   /* the preview pane's thumbnail must show its rotated form straight
+      away, rather than blanking until the next background rescale */
+   QVERIFY(pm->_pages[0]._valid);
+   bool dodgy = true;
+   QPixmap thumb = pm->_pages[0].pixmap(dodgy);
+   QVERIFY(!thumb.isNull());
+   QVERIFY(!dodgy);
+}
+
 void TestDesktopUi::testRotateUnloadedStack()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -48,6 +48,9 @@ private slots:
    //! Test rotating one page in the preview pane keeps the selection
    void testRotatePageKeepsSelection();
 
+   //! Test a rotated page's preview thumbnail is ready at once
+   void testRotatePreviewThumbnailReady();
+
    //! Test rotating a stack which has not been viewed yet
    void testRotateUnloadedStack();
 

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -9,6 +9,7 @@
 #include "desktopwidget.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
+#include "pagemodel.h"
 #include "pageview.h"
 #include "pagewidget.h"
 #include "test_pagewidget.h"
@@ -252,6 +253,40 @@ void TestPagewidget::testRotateButtons()
                     File::transformImage(first, File::Transform_hflip)) < 4);
    me.actionUndo->trigger();
    QCOMPARE(page->_image.size(), first.size());
+}
+
+void TestPagewidget::testRotateThumbnailReady()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QToolButton *rright = page->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+
+   Pagemodel *pm = page->_pagemodel;
+
+   /* mimic the displayed state: the shown page's thumbnail has already
+      been generated and is ready (the background rescale runs on a
+      timer, so force it here rather than waiting) */
+   pm->ensurePage(0);
+   pm->_pages[0]._rescale = true;
+   pm->_pages[0].updatePixmap();
+   QVERIFY(!pm->_pages[0]._pixmap.isNull());
+
+   // rotate the shown page
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   /* the thumbnail must be ready in its rotated form straight away: it
+      must not be invalidated (which would blank it until the next
+      background rescale) and pixmap() must return a ready image */
+   QVERIFY(pm->_pages[0]._valid);
+   bool dodgy = true;
+   QPixmap thumb = pm->_pages[0].pixmap(dodgy);
+   QVERIFY(!thumb.isNull());
+   QVERIFY(!dodgy);
 }
 
 //! Count dark pixels in an image, sampling every few pixels

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -36,6 +36,9 @@ private slots:
    //! Test the rotate and flip buttons transform the displayed page
    void testRotateButtons();
 
+   //! Test a rotated page's thumbnail is ready at once, not blanked
+   void testRotateThumbnailReady();
+
    //! Test the rotate action updates the displayed page
    void testRotateActionDisplay();
 


### PR DESCRIPTION
When a single page is rotated, its thumbnail blanked for a moment before the rotated image appeared. `updatePage()` invalidated the page's `Pageinfo`, so the next repaint rebuilt it with a null pixmap and deferred the rescale to a background timer.

Regenerate the thumbnail synchronously in `updatePage()` instead, so the rotated page shows in its new form straight away. Falls back to the lazy path only when the page has not been set up yet.

Covered by `testRotateThumbnailReady()`, which rotates the shown page and checks the thumbnail stays valid with a ready pixmap (it fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)