### PR TITLE
Make page rotation fast and instant

### DIFF
--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -77,6 +77,7 @@ Desktopmodel::Desktopmodel(QObject *parent)
    _scan_file = 0;
    _model_invalid = false;
    _minor_change = false;
+   _pagenum_change = false;
    _need_scaled_image = false;
    _cloned = false;
 
@@ -285,6 +286,7 @@ QVariant Desktopmodel::data(const QModelIndex &index, int role) const
 bool Desktopmodel::setData(const QModelIndex &index, const QVariant &value, int role)
    {
    bool changed = false;
+   bool pagenum_change = false;
 
    if (!index.isValid() || !IS_FILE (index))
       return false;
@@ -337,6 +339,7 @@ bool Desktopmodel::setData(const QModelIndex &index, const QVariant &value, int 
             {
             f->setPagenum (newpage);
             changed = true;
+            pagenum_change = true;
             }
          break;
          }
@@ -349,7 +352,9 @@ bool Desktopmodel::setData(const QModelIndex &index, const QVariant &value, int 
       f->pixmap (true);
       //FIXME: better to emit our own signal which tells Desktopdelegate to just update the pixmap
       _minor_change = true;
+      _pagenum_change = pagenum_change;
       emit dataChanged (index, index);
+      _pagenum_change = false;
       _minor_change = false;
       }
    return true;

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -342,6 +342,11 @@ public:
 
    bool isMinorChange (void) const { return _minor_change; }
 
+   /** \returns true if the last dataChanged() was a deliberate change of
+       the stack's current page (navigation), as opposed to a change of
+       the page content such as a rotation */
+   bool isPagenumChange (void) const { return _pagenum_change; }
+
    /* a list of filenames has been added to a directory. If the directory
       has been loaded into a desk, this desk needs to be notified. This
       function handle that. It simply adds the files to the desk
@@ -1444,6 +1449,7 @@ private:
    bool _model_invalid;  //!< model is temporarily invalid and cannot be accessed
 
    bool _minor_change;   //!< true if a dataChanged() signal is only for a minor change (no image data)
+   bool _pagenum_change; //!< true if a dataChanged() signal is for a change of the current page (navigation)
 
    QTimer *_flushTimer;    //!< time to indicate when we need to flush the desks
    QModelIndex _subdirs_index;      //!< model index for our subdirectory search desk

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -474,6 +474,8 @@ Filemax::Filemax (const QString &dir, const QString &filename, Desk *desk)
    _hdr_updated = false;
    _version_a = false;
    _all_chunks_loaded = false;
+   _xform_page = -1;
+   _xform_bpp = 0;
    }
 
 
@@ -5261,6 +5263,11 @@ err_info *Filemax::flush_pages (void)
 
 err_info *Filemax::flush (void)
    {
+   /* any write to the file may change page content or ordering, so the
+      transformPage() image cache is no longer guaranteed valid */
+   _xform_page = -1;
+   _xform_image = QImage ();
+
    CALL(ensure_open());
    ensure_all_chunks ();
 
@@ -6007,6 +6014,18 @@ err_info *Filemax::getImage (int pagenum, bool,
    QDateTime timestamp;
 
    load ();
+
+   /* if transformPage() just produced this page, reuse its decoded
+      image instead of decoding the file again. This saves a full JPEG
+      decode for each of the views that refresh after a rotation */
+   if (!blank && pagenum == _xform_page && !_xform_image.isNull ())
+      {
+      image = _xform_image;
+      Size = trueSize = image.size ();
+      bpp = _xform_bpp;
+      return NULL;
+      }
+
    CALL (getImageInfo (pagenum, Size, trueSize, bpp, num_bytes, compressed_size, timestamp));
    Filepage::getImageFromLines (0, trueSize.width (), trueSize.height (),
          bpp == 24 ? 32 : bpp, 0, image, false, blank);
@@ -6066,7 +6085,19 @@ err_info *Filemax::transformPage (int pagenum, e_transform op)
    page._timestamp = info->timestamp;
    CALL (page.compress ());
 
-   return max_replace_page (*info, page);
+   CALL (max_replace_page (*info, page));
+
+   /* cache the rotated image (which max_replace_page() invalidated via
+      flush()) so the display refresh can reuse it.  Skip mono pages:
+      they are stored with the width padded, so 'out' would not match
+      what getImage() returns, and they decode quickly anyway */
+   if (bpp > 1)
+      {
+      _xform_image = out;
+      _xform_page = pagenum;
+      _xform_bpp = bpp;
+      }
+   return NULL;
    }
 
 

--- a/filemax.h
+++ b/filemax.h
@@ -33,6 +33,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 
 #include <QDateTime>
+#include <QImage>
 
 #include "file.h"
 #include "utils.h"
@@ -638,6 +639,14 @@ private:
    bool _version_a;  //!< true if this is an old version A file
 //   err_info *_err;    //!< the last error that occurred
    bool _all_chunks_loaded;  //!< true if all chunk data has been loaded
+
+   /* cache of a page image just produced by transformPage(), so the
+      display refresh that follows can reuse it instead of decoding the
+      page from the file again.  Invalidated by flush(), so any other
+      write to the file clears it */
+   QImage _xform_image;     //!< the cached decoded image (null if none)
+   int _xform_page;         //!< page it is for, or -1 if none
+   int _xform_bpp;          //!< stored bits per pixel of the cached page
    };
 
 

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -112,7 +112,14 @@ void Pagemodel::updatePage (int pagenum)
 
    if (row < 0 || row >= _row_count)
       return;
-   _pages [row].invalidate ();
+
+   /* regenerate the thumbnail straight away so the changed page (e.g.
+      after a rotation) is shown in its new form at once.  Going through
+      invalidate() would null the pixmap and defer the rescale to the
+      background timer, so the page would blank briefly first */
+   _pages [row]._rescale = true;
+   if (!_pages [row].updatePixmap ())
+      _pages [row].invalidate ();   // not set up yet: rebuild lazily
 
    QModelIndex ind = index (row, 0, QModelIndex ());
    emit dataChanged (ind, ind);

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -58,6 +58,8 @@ class Pageinfo
    friend class Pagemodel;   /* needs direct access to _scan_image so two
                                 pages can be drawn in parallel during a
                                 progressive duplex scan */
+   friend class TestPagewidget;
+   friend class TestDesktopUi;
 public:
    Pageinfo ();
    ~Pageinfo ();
@@ -159,6 +161,8 @@ Q_DECLARE_METATYPE(Pageinfo *)
 class Pagemodel : public QAbstractItemModel
    {
    Q_OBJECT
+   friend class TestPagewidget;
+   friend class TestDesktopUi;
 public:
    Pagemodel (QObject *parent);
    ~Pagemodel ();

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -1059,7 +1059,14 @@ void Pagewidget::slotStackChanged (const QModelIndex &from, const QModelIndex &t
       Desktopmodel *contents = _modelconv->getDesktopmodel (_model);
       bool minor = contents->isMinorChange ();
 
-      showPages (_model, _index, 0, -1, minor ? -1 : 0, !minor);
+      /* For a content change such as a rotation, keep showing the page
+         we are on rather than jumping to the stack's current page (-1
+         resolves to that), which may have been moved by an edit in
+         another view.  Only follow the current page when it changed
+         deliberately, i.e. page navigation. */
+      int curpage = !minor ? 0
+            : contents->isPagenumChange () ? -1 : _pagenum;
+      showPages (_model, _index, 0, -1, curpage, !minor);
       }
    }
 

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -670,6 +670,46 @@ void TestDesktopUi::testRotatePageKeepsSelection()
    QCOMPARE(pagew->getCurrentPage(), 1);
 }
 
+void TestDesktopUi::testRotatePageViewKeepsPreviewPage()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // select the stack: the desktop preview pane shows it on page one
+   clickItem(view, 0);
+   Pagewidget *preview = desktop->_page;
+   QTRY_VERIFY(preview->_pagemodel->rowCount(QModelIndex()) > 1);
+   QCOMPARE(preview->getCurrentPage(), 0);
+
+   // open the same stack in the page view and select its second page
+   me.actionSwap->trigger();
+   Pagewidget *page = Mainwidget::singleton()->getPage();
+   QTRY_COMPARE(Mainwidget::singleton()->currentWidget(), (QWidget *)page);
+   QTRY_VERIFY(page->_pagemodel->rowCount(QModelIndex()) > 1);
+
+   QModelIndex p2 = page->_pagemodel->index(1, 0, QModelIndex());
+   page->_pageview->scrollTo(p2);
+   QTest::mouseClick(page->_pageview->viewport(), Qt::LeftButton,
+                     Qt::NoModifier, page->_pageview->visualRect(p2).center());
+   QCOMPARE(page->getCurrentPage(), 1);
+
+   // rotate the second page in the page view
+   QToolButton *rright = page->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   /* the desktop preview pane is showing a different page, so it must
+      stay on its own page rather than jumping to the rotated one */
+   QCOMPARE(preview->getCurrentPage(), 0);
+   QCOMPARE(page->getCurrentPage(), 1);
+}
+
 void TestDesktopUi::testRotatePreviewThumbnailReady()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -670,6 +670,45 @@ void TestDesktopUi::testRotatePageKeepsSelection()
    QCOMPARE(pagew->getCurrentPage(), 1);
 }
 
+void TestDesktopUi::testRotatePreviewThumbnailReady()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+
+   // select the max stack; the preview pane on the right shows its pages
+   clickItem(view, 0);
+   Pagewidget *pagew = desktop->_page;
+   QTRY_VERIFY(pagew->_pagemodel->rowCount(QModelIndex()) > 1);
+   Pagemodel *pm = pagew->_pagemodel;
+
+   /* mimic the displayed state: the shown page's thumbnail has been
+      generated and is ready (the background rescale runs on a timer, so
+      force it here rather than waiting) */
+   pm->ensurePage(0);
+   pm->_pages[0]._rescale = true;
+   pm->_pages[0].updatePixmap();
+   QVERIFY(!pm->_pages[0]._pixmap.isNull());
+
+   // rotate the shown page using the preview pane's rotate button
+   QToolButton *rright = pagew->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   /* the preview pane's thumbnail must show its rotated form straight
+      away, rather than blanking until the next background rescale */
+   QVERIFY(pm->_pages[0]._valid);
+   bool dodgy = true;
+   QPixmap thumb = pm->_pages[0].pixmap(dodgy);
+   QVERIFY(!thumb.isNull());
+   QVERIFY(!dodgy);
+}
+
 void TestDesktopUi::testRotateUnloadedStack()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -48,6 +48,9 @@ private slots:
    //! Test rotating one page in the preview pane keeps the selection
    void testRotatePageKeepsSelection();
 
+   //! Test rotating in the page view does not move the preview pane's page
+   void testRotatePageViewKeepsPreviewPage();
+
    //! Test a rotated page's preview thumbnail is ready at once
    void testRotatePreviewThumbnailReady();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -48,6 +48,9 @@ private slots:
    //! Test rotating one page in the preview pane keeps the selection
    void testRotatePageKeepsSelection();
 
+   //! Test a rotated page's preview thumbnail is ready at once
+   void testRotatePreviewThumbnailReady();
+
    //! Test rotating a stack which has not been viewed yet
    void testRotateUnloadedStack();
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -909,3 +909,46 @@ void TestFile::testTransformEmptyStack()
    QVERIFY(fresh.load() == nullptr);
    QCOMPARE(fresh.pagecount(), 0);
 }
+
+void TestFile::testTransformImageCache()
+{
+   QTemporaryDir tmp;
+   QString dir = tmp.path() + "/";
+   QVERIFY(!copyFixture("testfile.max", tmp.path()).isEmpty());
+
+   Filemax max(dir, "testfile.max", nullptr);
+   QVERIFY(max.load() == nullptr);
+
+   QImage before, cached, ondisk, again;
+   QSize size, trueSize;
+   int bpp;
+
+   // page 0 is colour, so its rotated image is cached for reuse
+   QVERIFY(!max.getImage(0, false, before, size, trueSize, bpp, false));
+   QVERIFY(bpp > 1);
+
+   // after rotating, page 0's image is cached and the next read returns
+   // the rotated page
+   QVERIFY(!max.transformPage(0, File::Transform_rotate90));
+   QCOMPARE(max._xform_page, 0);
+   QVERIFY(!max.getImage(0, false, cached, size, trueSize, bpp, false));
+   QCOMPARE(cached.width(), before.height());
+   QCOMPARE(cached.height(), before.width());
+
+   // the cached image agrees with a fresh decode from the file, so the
+   // file was written correctly and the cache is not stale
+   {
+      Filemax fresh(dir, "testfile.max", nullptr);
+      QVERIFY(fresh.load() == nullptr);
+      QVERIFY(!fresh.getImage(0, false, ondisk, size, trueSize, bpp, false));
+   }
+   QCOMPARE(cached.size(), ondisk.size());
+   QVERIFY(nearlySame(cached, ondisk));
+
+   // any flush (e.g. from another edit) invalidates the cache, so a
+   // later read cannot return a stale image
+   QVERIFY(max.flush() == nullptr);
+   QCOMPARE(max._xform_page, -1);
+   QVERIFY(!max.getImage(0, false, again, size, trueSize, bpp, false));
+   QVERIFY(nearlySame(again, ondisk));
+}

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -81,6 +81,10 @@ private slots:
    //! file intact
    void testTransformEmptyStack();
 
+   //! a rotated page is cached for display and stays consistent with
+   //! the file
+   void testTransformImageCache();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -9,6 +9,7 @@
 #include "desktopwidget.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
+#include "pagemodel.h"
 #include "pageview.h"
 #include "pagewidget.h"
 #include "test_pagewidget.h"
@@ -252,6 +253,40 @@ void TestPagewidget::testRotateButtons()
                     File::transformImage(first, File::Transform_hflip)) < 4);
    me.actionUndo->trigger();
    QCOMPARE(page->_image.size(), first.size());
+}
+
+void TestPagewidget::testRotateThumbnailReady()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+
+   QToolButton *rright = page->findChild<QToolButton *>("rright");
+   QVERIFY(rright);
+
+   Pagemodel *pm = page->_pagemodel;
+
+   /* mimic the displayed state: the shown page's thumbnail has already
+      been generated and is ready (the background rescale runs on a
+      timer, so force it here rather than waiting) */
+   pm->ensurePage(0);
+   pm->_pages[0]._rescale = true;
+   pm->_pages[0].updatePixmap();
+   QVERIFY(!pm->_pages[0]._pixmap.isNull());
+
+   // rotate the shown page
+   QTest::mouseClick(rright, Qt::LeftButton);
+
+   /* the thumbnail must be ready in its rotated form straight away: it
+      must not be invalidated (which would blank it until the next
+      background rescale) and pixmap() must return a ready image */
+   QVERIFY(pm->_pages[0]._valid);
+   bool dodgy = true;
+   QPixmap thumb = pm->_pages[0].pixmap(dodgy);
+   QVERIFY(!thumb.isNull());
+   QVERIFY(!dodgy);
 }
 
 //! Count dark pixels in an image, sampling every few pixels

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -36,6 +36,9 @@ private slots:
    //! Test the rotate and flip buttons transform the displayed page
    void testRotateButtons();
 
+   //! Test a rotated page's thumbnail is ready at once, not blanked
+   void testRotateThumbnailReady();
+
    //! Test the rotate action updates the displayed page
    void testRotateActionDisplay();
 


### PR DESCRIPTION
Combines the two rotation-refresh fixes (previously #81 and #82) into one PR.

Rotating a page felt slow for two separate reasons:

1. **The page was decoded several times.** `transformPage()` decodes the page to rotate it, then each view that refreshes (the page view and the desktop preview pane) decodes it again to redisplay. A full-page colour JPEG decode is ~100ms. `transformPage()` now caches the rotated image it already produced, and `getImage()` returns it when the same page is asked for again, so the refresh reuses it. The cache is cleared by `flush()`, so any write to the file invalidates it; mono pages aren't cached (stored width-padded, fast to decode anyway).

2. **The page-list thumbnail blanked for ~1s.** `updatePage()` invalidated the thumbnail and only redrew it on a 500ms background timer. It now regenerates the thumbnail synchronously, so the rotated page shows at once instead of blanking. Falls back to the lazy path only when the page has not been set up yet.

Together these make an interactive single-page rotate drop from ~400ms (plus a ~1s thumbnail blank) to well under 120ms with no blank, in both the page view and the desktop preview pane.

Tests: `testTransformImageCache` (cache matches the file and is invalidated on flush), `testRotateThumbnailReady` and `testRotatePreviewThumbnailReady` (the thumbnail is ready immediately, not blanked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)