### PR TITLE
Rotate remote stacks via the server

### DIFF
--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1018,6 +1018,22 @@ private:
     *  if the file isn't in any of our desks. */
    QModelIndex indexForFile(File *file) const;
 
+   /** The path of a stack relative to its repository root, with no
+    *  leading slash (e.g. "sub/dir/stack.max"), used as the {path} in
+    *  the server's per-stack URLs. */
+   QString remoteStackPath(Desk *desk, File *file) const;
+
+   /** Re-fetch a single stack's thumbnail from the server after its
+    *  content changed (e.g. a rotation) and refresh the view. */
+   void refreshRemoteThumbnail(Desk *desk, class RemoteBackend *backend,
+                               File *file);
+
+   /** Transform a page of a remote stack by asking the server to do
+    *  it, then refresh the thumbnail.  See opTransformPage(). */
+   err_info *opTransformPageRemote(const QModelIndex &index, File *file,
+                                   Desk *desk, class RemoteBackend *backend,
+                                   int pagenum, File::e_transform op);
+
    bool getNewScaledImage (Paperscan &scan, const PPage *page, const char *data,
          int nbytes, QImage &image, int &scaled_linenum);
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -40,8 +40,10 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QUrl>
 
 #include "desktopmodel.h"
+#include "desk.h"
 #include "file.h"
 #include "op.h"
+#include "remotebackend.h"
 #include "utils.h"
 
 
@@ -498,6 +500,16 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
    File *f = getFile (index);
    err_info *e = NULL;
 
+   /* A remote stack opens as a stub whose pages aren't reachable here,
+      so ask the server that holds it to do the transform instead. */
+   Desk *desk = f ? f->desk () : NULL;
+   if (desk)
+      {
+      RemoteBackend *remote = dynamic_cast<RemoteBackend *> (desk->backend ());
+      if (remote)
+         return opTransformPageRemote (index, f, desk, remote, pagenum, op);
+      }
+
    if (f)
       {
       /* the file may not have been loaded yet, in which case it reports
@@ -537,6 +549,59 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          e = f->not_impl ();
       }
    return e;
+   }
+
+
+QString Desktopmodel::remoteStackPath (Desk *desk, File *file) const
+   {
+   /* desk->dir() and desk->rootDir() are absolute and both end in '/';
+      the stack's path within the repository is the directory below the
+      root plus the filename. */
+   QString dirInRepo = desk->dir ();
+   QString root = desk->rootDir ();
+   if (dirInRepo.startsWith (root))
+      dirInRepo = dirInRepo.mid (root.length ());
+   if (dirInRepo.endsWith ('/'))
+      dirInRepo.chop (1);
+   return dirInRepo.isEmpty () ? file->filename ()
+                               : dirInRepo + "/" + file->filename ();
+   }
+
+
+void Desktopmodel::refreshRemoteThumbnail (Desk *desk, RemoteBackend *backend,
+      File *file)
+   {
+   if (!_connectedBackends.contains (backend))
+      {
+      connect (backend, &RemoteBackend::thumbnailReady,
+               this, &Desktopmodel::onThumbnailReady);
+      _connectedBackends.insert (backend);
+      }
+   quint64 token = backend->fetchThumbnailAsync (desk->repoName (),
+         remoteStackPath (desk, file), /*page=*/1, /*size=*/"small");
+   _pendingThumbnails.insert (token, file);
+   }
+
+
+err_info *Desktopmodel::opTransformPageRemote (const QModelIndex &index,
+      File *file, Desk *desk, RemoteBackend *backend, int pagenum,
+      File::e_transform op)
+   {
+   /* The wire page number is 1-based; a value below 1 means every page,
+      which is how the all-pages case (pagenum == -1) is expressed. */
+   int wirePage = pagenum < 0 ? 0 : pagenum + 1;
+
+   if (!backend->transformPage (desk->repoName (),
+                                remoteStackPath (desk, file), wirePage,
+                                File::transformName (op)))
+      return err_make (ERRFN, ERR_remote_transform_failed1,
+                       qPrintable (backend->lastError ()));
+
+   /* refresh the grid thumbnail from the server, and let any open page
+      view know the content changed */
+   refreshRemoteThumbnail (desk, backend, file);
+   emit pageContentChanged (index, pagenum);
+   return NULL;
    }
 
 

--- a/err.cpp
+++ b/err.cpp
@@ -107,6 +107,7 @@ static const char *err_msg [ERR_count] =
    "SQL error: %s",
    "Search index not open",
    "Could not open file '%s' for reading",
+   "Remote transform failed: %s",
    };
 
 

--- a/err.h
+++ b/err.h
@@ -119,6 +119,7 @@ enum
    ERR_sql_error1,
    ERR_index_not_open,
    ERR_could_not_open_file_for_reading1,
+   ERR_remote_transform_failed1,
 
    ERR_count
    };

--- a/file.cpp
+++ b/file.cpp
@@ -789,6 +789,31 @@ File::e_transform File::transformInverse (e_transform op)
    }
 
 
+QString File::transformName (e_transform op)
+   {
+   switch (op)
+      {
+      case Transform_rotate90 :  return "rotate90";
+      case Transform_rotate180 : return "rotate180";
+      case Transform_rotate270 : return "rotate270";
+      case Transform_hflip :     return "hflip";
+      case Transform_vflip :     return "vflip";
+      }
+   return "";
+   }
+
+
+bool File::transformFromName (const QString &name, e_transform &op)
+   {
+   if (name == "rotate90")  { op = Transform_rotate90;  return true; }
+   if (name == "rotate180") { op = Transform_rotate180; return true; }
+   if (name == "rotate270") { op = Transform_rotate270; return true; }
+   if (name == "hflip")     { op = Transform_hflip;     return true; }
+   if (name == "vflip")     { op = Transform_vflip;     return true; }
+   return false;
+   }
+
+
 QImage File::transformImage (const QImage &image, e_transform op)
    {
    switch (op)

--- a/file.h
+++ b/file.h
@@ -277,6 +277,17 @@ public:
    /** returns the transform which undoes the given one */
    static e_transform transformInverse (e_transform op);
 
+   /** the wire name of a transform, e.g. "rotate90", used by the
+       client/server transform API */
+   static QString transformName (e_transform op);
+
+   /** parse a wire transform name back to an enum
+
+      \param name  one of rotate90/rotate180/rotate270/hflip/vflip
+      \param op    returns the transform on success
+      \returns true if the name is recognised */
+   static bool transformFromName (const QString &name, e_transform &op);
+
    /** apply a transform to an image */
    static QImage transformImage (const QImage &image, e_transform op);
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -309,6 +309,39 @@ QByteArray RemoteBackend::getRequest(const QString &pathAndQuery)
 }
 
 
+bool RemoteBackend::transformPage(const QString &repo, const QString &path,
+                                  int page, const QString &op)
+{
+   _lastError.clear();
+
+   /* Build the (decoded) endpoint path; postRequest() percent-encodes
+      special characters via QUrl::setPath while keeping the slashes as
+      path separators, which the server splits on. */
+   QString endpoint = "/v1/repos/" + repo + "/stacks/" + path + "/transform";
+
+   QJsonObject body;
+   body["page"] = page;
+   body["op"]   = op;
+   QByteArray data = QJsonDocument(body).toJson(QJsonDocument::Compact);
+
+   QByteArray resp = postRequest(endpoint, data);
+   if (resp.isEmpty()) {
+      if (_lastError.isEmpty())
+         _lastError = "empty response from transform";
+      return false;
+   }
+
+   QJsonDocument doc = QJsonDocument::fromJson(resp);
+   if (doc.isObject() && doc.object().value("success").toBool(false))
+      return true;
+
+   _lastError = doc.isObject()
+                    ? doc.object().value("error").toString("transform failed")
+                    : QStringLiteral("invalid transform response");
+   return false;
+}
+
+
 QByteArray RemoteBackend::postRequest(const QString &path,
                                       const QByteArray &body)
 {

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -95,6 +95,15 @@ public:
                                 const QString &size
                                     = QStringLiteral("medium"));
 
+    /** Rotate or flip a page of a stack on the server.  @p page is
+     *  1-based; a value below 1 transforms every page.  @p op is the
+     *  wire name of the transform: one of "rotate90", "rotate180",
+     *  "rotate270", "hflip", "vflip".  Sync: blocks until the server
+     *  responds.  Returns true on success; on failure lastError() is
+     *  set. */
+    bool transformPage(const QString &repo, const QString &path,
+                       int page, const QString &op);
+
 signals:
     void browseDirectoryReady(quint64 token,
                               const DirectoryListing &listing);

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -804,19 +804,6 @@ QByteArray SearchServer::handleAuthLogin(const QHash<QString, QString> &params)
 }
 
 
-/* Map a wire op string to the transform enum.  Returns true if the
-   string is recognised. */
-static bool transformFromString(const QString &s, File::e_transform &op)
-{
-    if (s == "rotate90")  { op = File::Transform_rotate90;  return true; }
-    if (s == "rotate180") { op = File::Transform_rotate180; return true; }
-    if (s == "rotate270") { op = File::Transform_rotate270; return true; }
-    if (s == "hflip")     { op = File::Transform_hflip;     return true; }
-    if (s == "vflip")     { op = File::Transform_vflip;     return true; }
-    return false;
-}
-
-
 QByteArray SearchServer::handleTransform(const QString &path,
                                          const QHash<QString, QString> &params,
                                          const QString &authedUser)
@@ -877,7 +864,7 @@ QByteArray SearchServer::handleTransform(const QString &path,
                                      "Body must be JSON {page, op}"));
     QJsonObject obj = doc.object();
     File::e_transform op;
-    if (!transformFromString(obj.value("op").toString(), op))
+    if (!File::transformFromName(obj.value("op").toString(), op))
         return buildHttpResponse(400, "Bad Request", "application/json",
                                  buildJsonResponse(false, "",
                                      "Unknown transform op"));

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -458,16 +458,14 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                                       const QHash<QString, QString> &params,
                                       QTcpSocket *client)
 {
-    /* POST is only accepted on a small allowlist; everything else is GET. */
-    if (method == "POST") {
-        if (path == "/v1/auth/login")
-            return handleAuthLogin(params);
+    /* Logging in must work without a token, so handle it before the auth
+       check below.  Other POST routes fall through and are dispatched
+       after authentication. */
+    if (method == "POST" && path == "/v1/auth/login")
+        return handleAuthLogin(params);
+    if (method != "GET" && method != "POST") {
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
-                                QString("POST not supported on this path"));
-    }
-    if (method != "GET") {
-        return buildHttpResponse(405, "Method Not Allowed", "text/plain",
-                                QString("Only GET requests are supported"));
+                                QString("Only GET and POST requests are supported"));
     }
 
     /* Identify the caller.  authedUser is non-empty when a bearer token
@@ -512,6 +510,15 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                                          "User not permitted to access repository: "
                                          + repoName));
         }
+    }
+
+    /* POST mutation routes (authenticated above).  These come before the
+       GET routing chain, which assumes a GET. */
+    if (method == "POST") {
+        if (path.startsWith("/v1/repos/") && path.endsWith("/transform"))
+            return handleTransform(path, params, authedUser);
+        return buildHttpResponse(405, "Method Not Allowed", "text/plain",
+                                QString("POST not supported on this path"));
     }
 
     // Route requests
@@ -794,6 +801,147 @@ QByteArray SearchServer::handleAuthLogin(const QHash<QString, QString> &params)
     return buildHttpResponse(200, "OK", "application/json",
                              QString::fromUtf8(outDoc.toJson(
                                  QJsonDocument::Compact)));
+}
+
+
+/* Map a wire op string to the transform enum.  Returns true if the
+   string is recognised. */
+static bool transformFromString(const QString &s, File::e_transform &op)
+{
+    if (s == "rotate90")  { op = File::Transform_rotate90;  return true; }
+    if (s == "rotate180") { op = File::Transform_rotate180; return true; }
+    if (s == "rotate270") { op = File::Transform_rotate270; return true; }
+    if (s == "hflip")     { op = File::Transform_hflip;     return true; }
+    if (s == "vflip")     { op = File::Transform_vflip;     return true; }
+    return false;
+}
+
+
+QByteArray SearchServer::handleTransform(const QString &path,
+                                         const QHash<QString, QString> &params,
+                                         const QString &authedUser)
+{
+    /* Path shape: /v1/repos/{repo}/stacks/{stackPath}/transform, where
+       {stackPath} may itself contain '/' for subdirectories and is
+       percent-encoded. */
+    QString rest = path;
+    rest.remove(0, QStringLiteral("/v1/repos/").size());
+    rest.chop(QStringLiteral("/transform").size());
+    int sep = rest.indexOf("/stacks/");
+    if (sep < 0)
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed transform path"));
+    QString repoName = urlDecode(rest.left(sep));
+    QString filePath = urlDecode(rest.mid(sep
+                                          + QStringLiteral("/stacks/").size()));
+
+    // Security: prevent directory traversal
+    if (filePath.isEmpty() || filePath.contains("..")
+        || filePath.startsWith("/"))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "", "Invalid path"));
+
+    /* Per-user repo gating.  The GET path checks a ?repo= query
+       parameter; here the repo is in the URL so check it directly. */
+    if (!authedUser.isEmpty() && !_users.repoAllowed(authedUser, repoName))
+        return buildHttpResponse(403, "Forbidden", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "User not permitted to access repository: "
+                                     + repoName));
+
+    // Resolve the repository to a path on disk
+    QString repoPath = _rootPath;
+    if (!repoName.isEmpty()) {
+        bool found = false;
+        foreach (const QString &p, _rootPaths) {
+            if (QFileInfo(p).fileName() == repoName) {
+                repoPath = p;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return buildHttpResponse(404, "Not Found", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Repository not found: " + repoName));
+    }
+
+    // Parse the body: { "page": N, "op": "rotate90" }
+    QByteArray body = params.value("__body__").toUtf8();
+    QJsonParseError jerr;
+    QJsonDocument doc = QJsonDocument::fromJson(body, &jerr);
+    if (jerr.error != QJsonParseError::NoError || !doc.isObject())
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {page, op}"));
+    QJsonObject obj = doc.object();
+    File::e_transform op;
+    if (!transformFromString(obj.value("op").toString(), op))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Unknown transform op"));
+    /* 'page' is 1-based; a value below 1 (or absent) means transform
+       every page of the stack. */
+    int page = obj.value("page").toInt(-1);
+
+    QString fullPath = repoPath + "/" + filePath;
+    QFileInfo fi(fullPath);
+    if (!fi.exists())
+        return buildHttpResponse(404, "Not Found", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "File not found: " + filePath));
+
+    File::e_type type = File::typeFromName(fi.fileName());
+    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
+                                  nullptr, type);
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Cannot open file"));
+    err_info *err = file->load();
+    if (err) {
+        QString msg = err->errstr;
+        delete file;
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", msg));
+    }
+
+    int pagecount = file->pagecount();
+    if (pagecount <= 0) {
+        delete file;
+        return buildHttpResponse(409, "Conflict", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Stack has no pages"));
+    }
+    if (page >= 1 && page > pagecount) {
+        delete file;
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Page out of range"));
+    }
+
+    if (page >= 1)
+        err = file->transformPage(page - 1, op);
+    else
+        for (int i = 0; !err && i < pagecount; i++)
+            err = file->transformPage(i, op);
+    if (err) {
+        QString msg = err->errstr;
+        delete file;
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", msg));
+    }
+    delete file;
+
+    /* The file's mtime has changed, so cached thumbnails and pages
+       (whose cache keys include the mtime) will miss and be re-rendered
+       on the next request; no explicit cache invalidation is needed. */
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
 }
 
 QString SearchServer::searchFiles(const QString &repoPath, const QString &searchPath,

--- a/searchserver.h
+++ b/searchserver.h
@@ -203,6 +203,23 @@ private:
     QByteArray handleAuthLogin(const QHash<QString, QString> &params);
 
     /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/transform
+     *
+     * Rotates or flips a page (or every page) of a stack on disk by
+     * calling File::transformPage().  The body is JSON {page, op} where
+     * page is 1-based (a value below 1 means every page) and op is one
+     * of rotate90/rotate180/rotate270/hflip/vflip.
+     *
+     * @param path        The full request path (carries repo and stack)
+     * @param params      Parsed request parameters (incl. __body__)
+     * @param authedUser  The authenticated user, or empty for API-key auth
+     * @return HTTP response, 200 with {success:true} on success
+     */
+    QByteArray handleTransform(const QString &path,
+                               const QHash<QString, QString> &params,
+                               const QString &authedUser);
+
+    /**
      * Search for files matching a pattern
      * @param repoPath    Repository root path
      * @param searchPath  Directory to search in (relative to root)

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1312,6 +1312,38 @@ void TestSearchServer::testTransformEndpoint()
     server.stop();
 }
 
+void TestSearchServer::testRemoteBackendTransform()
+{
+    /* Round-trip: rotate a page through RemoteBackend and confirm the
+       file the server holds on disk really turned. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+    QString dir = tmpDir.path() + "/";
+
+    QSize before = serverTestPageSize(dir, "testfile.max", 0);
+    QVERIFY(!before.isEmpty());
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+
+    RemoteBackend client(QUrl(QString("http://localhost:%1").arg(PORT)));
+    QVERIFY2(client.transformPage(repo, "testfile.max", 1, "rotate90"),
+             client.lastError().toUtf8().constData());
+
+    QSize after = serverTestPageSize(dir, "testfile.max", 0);
+    QCOMPARE(after.width(), before.height());
+    QCOMPARE(after.height(), before.width());
+
+    // an unknown op fails and reports an error rather than asserting
+    QVERIFY(!client.transformPage(repo, "testfile.max", 1, "sideways"));
+    QVERIFY(!client.lastError().isEmpty());
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -14,13 +14,19 @@
 
 #include "../backendstats.h"
 
+#include "../desktopmodel.h"
+#include "../dirmodel.h"
+#include "../desktopundo.h"
 #include "../file.h"
+#include "../measure.h"
 #include "../remotebackend.h"
 #include "../searchserver.h"
 #include "../userstore.h"
 #include "test.h"
 
+#include <QApplication>
 #include <QBuffer>
+#include <QFont>
 #include <QImage>
 
 #include "test_searchserver.h"
@@ -1340,6 +1346,58 @@ void TestSearchServer::testRemoteBackendTransform()
     // an unknown op fails and reports an error rather than asserting
     QVERIFY(!client.transformPage(repo, "testfile.max", 1, "sideways"));
     QVERIFY(!client.lastError().isEmpty());
+
+    server.stop();
+}
+
+void TestSearchServer::testDesktopRemoteTransform()
+{
+    /* Full path: a remote stack shown in the desktop is rotated through
+       Desktopmodel::transformPage, which must detect the remote backend
+       and ask the server to do the work. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    QSize before = serverTestPageSize(dir, "testfile.max", 0);
+    QVERIFY(!before.isEmpty());
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    // point a Dirmodel at the server and a Desktopmodel at the Dirmodel
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err), err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);   // identity converter (no proxy here)
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    // show the remote repo's root directory; its files load as stubs
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+
+    // rotate the first page; the desktop must route this to the server
+    model.transformPage(stack, 0, File::Transform_rotate90);
+
+    QSize after = serverTestPageSize(dir, "testfile.max", 0);
+    QCOMPARE(after.width(), before.height());
+    QCOMPARE(after.height(), before.width());
+
+    // undo rotates it back, again via the server
+    model.getUndoStack()->undo();
+    QSize restored = serverTestPageSize(dir, "testfile.max", 0);
+    QCOMPARE(restored, before);
 
     server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1248,3 +1248,98 @@ void TestSearchServer::testMaxPageJpegCompression()
     QVERIFY(slog.end());
     server.stop();
 }
+
+/* Return the rendered size of one page of a stack on disk. */
+static QSize serverTestPageSize(const QString &dir, const QString &fname,
+                                int pagenum)
+{
+    File *f = File::createFile(dir, fname, nullptr,
+                               File::typeFromName(fname));
+    if (!f || f->load())
+        return QSize();
+    QImage img;
+    QSize sz, tsz;
+    int bpp;
+    err_info *err = f->getImage(pagenum, false, img, sz, tsz, bpp, false);
+    QSize result = err ? QSize() : img.size();
+    delete f;
+    return result;
+}
+
+void TestSearchServer::testTransformEndpoint()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+    QString dir = tmpDir.path() + "/";
+
+    // record the sizes of two pages before the transform
+    QSize before0 = serverTestPageSize(dir, "testfile.max", 0);
+    QSize before4 = serverTestPageSize(dir, "testfile.max", 4);
+    QVERIFY(!before0.isEmpty());
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+
+    // rotate the first page (1-based) 90 degrees
+    auto resp = postJson(
+        QString("/v1/repos/%1/stacks/testfile.max/transform").arg(repo),
+        R"({"page":1,"op":"rotate90"})");
+    QVERIFY2(resp.ok(), resp.header.toUtf8().constData());
+    QVERIFY(QJsonDocument::fromJson(resp.body).object()["success"].toBool());
+
+    // page one on disk is now turned on its side; the other pages are
+    // untouched
+    QSize after0 = serverTestPageSize(dir, "testfile.max", 0);
+    QCOMPARE(after0.width(), before0.height());
+    QCOMPARE(after0.height(), before0.width());
+    QCOMPARE(serverTestPageSize(dir, "testfile.max", 4), before4);
+
+    /* omitting the page rotates every page of the stack, so page five
+       (untouched above) is now turned on its side too.  It is a 1-bit
+       page, whose width is stored padded to a multiple of 32, so check
+       the orientation flipped rather than exact dimensions */
+    QVERIFY(before4.height() > before4.width());   // started portrait
+    auto all = postJson(
+        QString("/v1/repos/%1/stacks/testfile.max/transform").arg(repo),
+        R"({"op":"rotate90"})");
+    QVERIFY2(all.ok(), all.header.toUtf8().constData());
+    QSize again4 = serverTestPageSize(dir, "testfile.max", 4);
+    QVERIFY(again4.width() > again4.height());      // now landscape
+
+    server.stop();
+}
+
+void TestSearchServer::testTransformEndpointErrors()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+
+    // an unknown op is rejected
+    auto badOp = postJson(
+        QString("/v1/repos/%1/stacks/testfile.max/transform").arg(repo),
+        R"({"page":1,"op":"sideways"})");
+    QVERIFY(badOp.header.contains("400"));
+
+    // a missing file is a 404
+    auto missing = postJson(
+        QString("/v1/repos/%1/stacks/nope.max/transform").arg(repo),
+        R"({"page":1,"op":"rotate90"})");
+    QVERIFY(missing.header.contains("404"));
+
+    // a path-traversal attempt (encoded slashes) is rejected
+    QString traversePath = "/v1/repos/" + repo
+        + "/stacks/..%2F..%2Fetc%2Fpasswd/transform";
+    auto traverse = postJson(traversePath, R"({"page":1,"op":"rotate90"})");
+    QVERIFY(traverse.header.contains("400"));
+
+    server.stop();
+}

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -71,6 +71,7 @@ private slots:
    void testMaxPageJpegCompression();
    void testTransformEndpoint();
    void testTransformEndpointErrors();
+   void testRemoteBackendTransform();
 
 private:
    // HTTP GET returning split header and body

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -72,6 +72,7 @@ private slots:
    void testTransformEndpoint();
    void testTransformEndpointErrors();
    void testRemoteBackendTransform();
+   void testDesktopRemoteTransform();
 
 private:
    // HTTP GET returning split header and body

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -69,6 +69,8 @@ private slots:
    void testLargePdfProgressive();
    void testLargeMaxProgressive();
    void testMaxPageJpegCompression();
+   void testTransformEndpoint();
+   void testTransformEndpointErrors();
 
 private:
    // HTTP GET returning split header and body


### PR DESCRIPTION
Remote stacks open on the client as `Fileother` stubs (the client can't reach their pages), so rotating or flipping a remote stack had nowhere to run — `transformPage()` hit `not_impl()`. The server already links the file code, so it's the natural place to do the transform. This makes remote rotation work end to end.

**Server** — `POST /v1/repos/{repo}/stacks/{path}/transform`, body `{page, op}` (page 1-based, below 1 means every page; op is rotate90/rotate180/rotate270/hflip/vflip). It resolves the file, loads it and calls `File::transformPage()` — the same code the GUI uses locally. Auth required, per-user repo allowlist enforced, path checked for traversal. The file's mtime changes so cached thumbnails (keyed by mtime) miss and re-render. `handleRequest()` is restructured so POST routes other than login run after the auth check.

**Client backend** — `RemoteBackend::transformPage(repo, path, page, op)` POSTs to it.

**Desktop wiring** — `opTransformPage()` detects a stack whose desk has a `RemoteBackend` and dispatches there (single page and whole stack), then re-fetches the thumbnail and emits `pageContentChanged()`. Undo/redo go through the same path with the inverse op, so they reach the server for free. `File::transformName()`/`transformFromName()` are the single home for the wire op names, shared by client and server.

**Tests** — endpoint (rotate one/every page, check disk), error cases (unknown op, missing file, traversal), `RemoteBackend` round-trip, and `testDesktopRemoteTransform` which drives the whole path through a `Desktopmodel` against an in-process server and checks the disk file rotates then restores on undo. Full suite green (175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)