### PR TITLE
Fix crash decoding a corrupt page during scanning

### DIFF
--- a/filemax.cpp
+++ b/filemax.cpp
@@ -1632,6 +1632,24 @@ err_info *Filemax::decode_tiledata (chunk_info &chunk,
 
          ptr = get_tile_size (chunk, x, y, &tile_size, &my_tilenum, -1, -1);
 
+         /* A page that is still being written by a scan, or one left
+            corrupt by a scanner double-feed, can present tile geometry
+            that no longer matches the allocated image buffer.  Bound
+            each tile to the rows actually allocated (size holds
+            line_bytes * image height) so the decode can never write
+            past the buffer.  For a valid file every tile already fits,
+            so this is a no-op. */
+         int buffer_rows = chunk.line_bytes ? size / chunk.line_bytes : 0;
+         int starty = chunk.tile_size.y * y;
+         if (starty < 0 || starty >= buffer_rows
+             || tile_size.x <= 0 || tile_size.y <= 0)
+            {
+            pos += chunk.tile [my_tilenum].size - 4;
+            continue;
+            }
+         if (tile_size.y > buffer_rows - starty)
+            tile_size.y = buffer_rows - starty;
+
          if (tilenum != my_tilenum)
             ;
          else if (tilenum >= debug->start_tile


### PR DESCRIPTION
Scanning a stack and viewing it at the same time can crash with a SIGSEGV in `jpeg_decode` (`utils.cpp:284`).

**Cause:** while scanning, the scan pumps the event loop to stay responsive, which lets the background thumbnail timer decode the page that's *still being written*. When a scanner **double-feed** leaves that page corrupt, its chunk header describes tile geometry that no longer matches the allocated image buffer. `get_tile_size()` assumes consistent geometry, so it returns a tile whose position + height run past the end of the buffer, and the JPEG decode walks the destination pointer off the end.

**Fix:** in `decode_tiledata()`, bound every tile to the image buffer — skip a tile that starts outside the buffer or has a non-positive size, and clamp its height to the rows that remain. A corrupt/partial page then produces a garbage thumbnail instead of crashing. For a valid file the tiles always lie within the buffer, so the checks are no-ops (the existing decode tests confirm normal decoding is unchanged).

Reported from a real crash (full backtrace through `Pagemodel::nextUpdate` → `getImage` → `decode_tiledata` → `jpeg_decode`) that happened on a scanner double-feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)