### PR TITLE
Put the page-view tools on a single line

### DIFF
--- a/pagetools.ui
+++ b/pagetools.ui
@@ -24,7 +24,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,1,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QToolButton" name="selectMode">
        <property name="toolTip">
@@ -188,10 +188,6 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QToolButton" name="rleft">
        <property name="toolTip">


### PR DESCRIPTION
The page view's tool strip was on two rows — mode toggles + save/revert on top, rotate/flip + zoom below. This merges them into one horizontal row:

`[select] [move] [scan] [info]` · `[save] [revert] [rotate-left] [rotate-right] [h-flip] [v-flip]` → *(expanding gap)* → `[fit] [1:1] [zoom%] [−] [+]`

Pure `.ui` change (merged the two `QHBoxLayout`s into one, dropped the now-unused stretch); `uic` accepts it and no code referenced the removed second layout. Easy to reorder the groups if a different arrangement reads better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)