### PR TITLE
Follow a scan by completed pages, not blank ones

### DIFF
--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -437,7 +437,7 @@ void Pagemodel::disownScanning (void)
 
 
 
-void Pagemodel::slotNewScannedPage (const QString &coverageStr,
+int Pagemodel::slotNewScannedPage (const QString &coverageStr,
       bool mark_blank)
    {
    Pageinfo *page;
@@ -472,6 +472,8 @@ void Pagemodel::slotNewScannedPage (const QString &coverageStr,
    if (_own_scan)
       emit dataChanged (index (pagenum, 0, QModelIndex ()),
          index (pagenum, 0, QModelIndex ()));
+
+   return _own_scan ? pagenum : -1;
    }
 
 

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -295,8 +295,9 @@ public slots:
    /** handle new pages being scanned into our 'scanning' stack
 
       \param coverageStr   coverage string
-      \param mark_blank    true if page should be marked blank */
-   void slotNewScannedPage (const QString &coverageStr, bool mark_blank);
+      \param mark_blank    true if page should be marked blank
+      \returns the row of the page that was just completed, or -1 */
+   int slotNewScannedPage (const QString &coverageStr, bool mark_blank);
 
 signals:
    /* indicate that part of a page has changed

--- a/pageview.cpp
+++ b/pageview.cpp
@@ -143,6 +143,19 @@ void Pageview::scrollToEnd (bool ifAtEnd)
    }
 
 
+void Pageview::scrollToRow (int row, bool ifAtEnd)
+   {
+   if (row < 0)
+      return;
+   if (!ifAtEnd || _autoscroll)
+      {
+      _ignore_scroll = true;
+      scrollTo (model ()->index (row, 0, QModelIndex ()), PositionAtBottom);
+      _ignore_scroll = false;
+      }
+   }
+
+
 void Pageview::scrollContentsBy (int dx, int dy)
    {
    /* if we caused the scroll, then don't worry. Otherwise the user is trying

--- a/pageview.h
+++ b/pageview.h
@@ -81,6 +81,14 @@ public:
                         end by the user */
    void scrollToEnd (bool ifAtEnd = false);
 
+   /** scroll so a particular row is shown at the bottom of the view,
+       used to follow a scan by its completed pages
+
+      \param row        the row to bring into view
+      \param ifAtEnd    if true, do nothing when the user has scrolled
+                        away from the end */
+   void scrollToRow (int row, bool ifAtEnd = false);
+
 public slots:
    void slotPagePartChanged (const QModelIndex &index, const QImage &image, int scaled_linenum);
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -908,24 +908,26 @@ void Pagewidget::slotNewScannedPage (const QString &coverageStr, bool blank)
          }
       }
 
-   _pagemodel->slotNewScannedPage (coverageStr, blank);
-//    _pageview->scrollToEnd (true);
-//    _pageview->scrollTo (_pagemodel->index (_pagemodel->rowCount (QModelIndex ()) - 1, 0, QModelIndex ()));
+   int pagenum = _pagemodel->slotNewScannedPage (coverageStr, blank);
+
+   /* Follow the scan by the pages that actually have data: scroll to
+      the page that just finished.  This keeps the most recently
+      scanned pages on screen, rather than jumping to the next page the
+      moment it starts (slotBeginningPage) and showing a blank.  It
+      matters now that scanners deliver a whole page in one burst, so
+      the old progressive fill is never seen. */
+   if (_scanning)
+      _pageview->scrollToRow (pagenum, true);
    }
 
 
 void Pagewidget::slotBeginningPage (void)
    {
    if (_scanning)
-      {
-   //    qDebug () << "slotBeginningPage";
-
-      // tell the model that we have a new page
+      // add the new (blank) page to the model, but don't scroll to it;
+      // the view follows the scan by completed pages, in
+      // slotNewScannedPage(), so it keeps showing pages that have data
       _pagemodel->beginningPage ();
-
-      // show it
-      _pageview->scrollToEnd (true);
-      }
    }
 
 


### PR DESCRIPTION
When scanning, the page view inserted a blank row for each new page the moment it *started* and scrolled straight to it, so the page filled in only after the jump. That made sense when scanners streamed the raster slowly and you watched it fill, but modern scanners deliver a whole page in one burst — so all you see is blank pages that flash and vanish as the view jumps ahead to the next not-yet-scanned page.

This follows the scan by the pages that actually have data:
- `slotBeginningPage()` no longer scrolls when a page merely starts.
- `slotNewScannedPage()` scrolls to a page once it has *finished* scanning.
- `Pagemodel::slotNewScannedPage()` returns the completed page's row; `Pageview::scrollToRow()` brings it to the bottom of the view (respecting the user having scrolled away with the existing `_autoscroll` logic).

Net effect: the most recently scanned pages stay on screen instead of blanks.

⚠️ This is a scan-flow/visual change and I couldn't exercise a real scan locally (the sandbox is missing the QtStateMachine dev headers, so no full GUI build here) — it's verified by per-file compiles + the build on CI. Worth a quick scan on your machine to confirm the feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)