### PR TITLE
file: Unfold scanned booklets into sequential pages

### DIFF
--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -94,6 +94,7 @@ class Desktopmodel : public QAbstractItemModel
    friend class UCTrashStacks;
    friend class UCMove;
    friend class UCDuplicate;
+   friend class UCUnfoldBooklet;
    friend class UCUnstackStacks;
    friend class UCUnstackPage;
    friend class UCStackStacks;
@@ -400,6 +401,15 @@ public:
       \param odd_even   which pages to duplicate: 1 = even, 2 = odd, 3 = both */
    void duplicateMax (QModelIndexList &list, QModelIndex parent, int odd_even = 3);
 
+   /** unfold a list of saddle-stitched booklet stacks into sequential pages.
+       Each selected stack is taken as a booklet whose scanned pages each hold
+       two pages side by side; a new stack is created with the pages split and
+       put into reading order. Supports undo
+
+      \param list    list of booklet stacks to unfold
+      \param parent  parent stack */
+   void unfoldBooklet (QModelIndexList &list, QModelIndex parent);
+
    /** delete a list of stacks by moving them to the trash. The list may
        contain null model indexes, which are ignored. Supports undo
 
@@ -621,6 +631,15 @@ protected:
       \returns      error, or NULL if none */
    err_info *opDuplicateStacks (QModelIndexList &list, QModelIndex parent, QStringList &namelist,
          File::e_type type, int odd_even = 3);
+
+   /** unfold a list of booklet stacks into new sequential-page stacks
+
+      \param list       list of booklet stacks to unfold
+      \param parent     parent stack
+      \param namelist   returns the filenames of the new stacks
+      \returns      error, or NULL if none */
+   err_info *opUnfoldBooklets (QModelIndexList &list, QModelIndex parent,
+         QStringList &namelist);
 
    /** delete a single stack without moving it to the trash
 

--- a/desktopundo.cpp
+++ b/desktopundo.cpp
@@ -178,6 +178,37 @@ void UCDuplicate::undo (void)
    }
 
 
+UCUnfoldBooklet::UCUnfoldBooklet (Desktopmodel *model, QModelIndexList &list,
+      QModelIndex &parent)
+      : Desktopundocmd (model)
+   {
+   _dir = model->deskToDirname (parent);
+   _filenames = model->listToFilenames (list);
+   setText (QApplication::translate ("UCUnfoldBooklet",
+      "Unfold booklet (%1)").arg (list.size ()));
+   }
+
+
+void UCUnfoldBooklet::redo (void)
+   {
+   QModelIndex parent = _model->deskFromDirname (_dir);
+   QModelIndexList list = _model->listFromFilenames (_filenames, parent);
+
+   _newnames.clear ();
+   aboutToAdd (parent);
+   complain (_model->opUnfoldBooklets (list, parent, _newnames));
+   }
+
+
+void UCUnfoldBooklet::undo (void)
+   {
+   QModelIndex parent = _model->deskFromDirname (_dir);
+   QModelIndexList list = _model->listFromFilenames (_newnames, parent);
+
+   complain (_model->opDeleteStacks (list, parent));
+   }
+
+
 UCUnstackStacks::UCUnstackStacks (Desktopmodel *model, QModelIndexList &list,
       QModelIndex &parent)
       : Desktopundocmd (model)

--- a/desktopundo.h
+++ b/desktopundo.h
@@ -138,6 +138,25 @@ private:
    };
 
 
+/** unfold a group of saddle-stitched booklet stacks into new stacks with the
+pages split and put into reading order. We record the original filenames and
+the new filenames. To redo we create the unfolded stacks; to undo we remove
+them. This mirrors UCDuplicate */
+
+class UCUnfoldBooklet : public Desktopundocmd
+   {
+public:
+   UCUnfoldBooklet (Desktopmodel *model, QModelIndexList &list,
+      QModelIndex &parent);
+   void redo();
+   void undo();
+private:
+   QString _dir;           //!< desk directory
+   QStringList _filenames; //!< the list of booklet filenames to unfold
+   QStringList _newnames;  //!< the list of unfolded filenames
+   };
+
+
 /** this unstacks a group of stacks completely, so that each stack becomes
 a set of single page stacks.
 

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -332,6 +332,7 @@ void Desktopwidget::addActions(void)
    addAction (_act_duplicate_odd, "&odd pages only", SLOT (duplicateOdd ()), "");
    addAction (_act_duplicate_even, "&even pages only", SLOT (duplicateEven ()), "");
    addAction (_act_duplicate_jpeg, "as &JPEG", SLOT (duplicateJpeg ()), "Ctrl+Shift+J");
+   addAction (_act_unfold_booklet, "Unfold &booklet", SLOT (unfoldBooklet ()), "");
 
    addAction (_act_email, "&Files", SLOT (email ()), "Ctrl+E");
    addAction (_act_email_pdf, "as &PDF", SLOT (emailPdf ()), "Ctrl+Shift+E");
@@ -1219,6 +1220,7 @@ void Desktopwidget::updateActions()
    _act_duplicate_even->setEnabled (at_least_one);
    _act_duplicate_odd->setEnabled (at_least_one);
    _act_duplicate_jpeg->setEnabled (at_least_one);
+   _act_unfold_booklet->setEnabled (at_least_one);
    _act_email->setEnabled (at_least_one);
    _act_email_max->setEnabled (at_least_one);
    _act_email_pdf->setEnabled (at_least_one);
@@ -1257,6 +1259,8 @@ void Desktopwidget::slotPopupMenu (QModelIndex &index)
    submenu->addAction (_act_duplicate_even);
    submenu->addAction (_act_duplicate_odd);
    submenu->addAction (_act_duplicate_jpeg);
+   submenu->addSeparator ();
+   submenu->addAction (_act_unfold_booklet);
 
 //  submenu->insertItem( "as &Tiff", this, SLOT(duplicateTiff()), Qt::CTRL+Qt::Key_T );
    
@@ -1440,6 +1444,16 @@ void Desktopwidget::duplicateOdd (void)
    QModelIndexList slist = _view->getSelectedListSource ();
 
    _contents->duplicateMax (slist, parent, 1);
+   complete (parent, NULL);
+   }
+
+
+void Desktopwidget::unfoldBooklet (void)
+   {
+   QModelIndex parent = _view->rootIndexSource ();
+   QModelIndexList slist = _view->getSelectedListSource ();
+
+   _contents->unfoldBooklet (slist, parent);
    complete (parent, NULL);
    }
 

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -408,6 +408,9 @@ private slots:
 
    void duplicateOdd (void);
 
+   // unfold a saddle-stitched booklet into sequential pages
+   void unfoldBooklet (void);
+
    // email files
    void email (void);
 
@@ -568,6 +571,7 @@ private:
    QAction *_act_duplicate_max, *_act_duplicate_pdf, *_act_duplicate_tiff;
    QAction *_act_duplicate_odd, *_act_duplicate_even;
    QAction *_act_duplicate_jpeg, *_act_move;
+   QAction *_act_unfold_booklet;
    QAction *_act_email, *_act_email_max, *_act_email_pdf;
    QAction *_act_copy;
 //   QAction *_act_send, *_act_deliver_out;

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -220,6 +220,33 @@ err_info *Desktopmodel::opDuplicateStacks (QModelIndexList &list, QModelIndex pa
    }
 
 
+err_info *Desktopmodel::opUnfoldBooklets (QModelIndexList &list,
+      QModelIndex parent, QStringList &namelist)
+   {
+   QList<File *> flist;
+   err_info *err = NULL;
+   QModelIndex ind;
+   File *fnew, *f;
+
+   // each booklet page splits into two, so the work is twice the page count
+   Operation op (tr ("Unfold booklet"), 2 * listPagecount (list), 0);
+   foreach (ind, list)
+      {
+      f = getFile (ind);
+      CALL (f->load ());
+      err = f->unfoldBooklet (op, fnew);
+      if (err)
+         break;
+      flist << fnew;
+      namelist << fnew->filename ();
+      }
+
+   // insert the files
+   insertRows (flist, parent);
+   return err;
+   }
+
+
 err_info *Desktopmodel::opDeleteStack (QModelIndex &index)
    {
    QModelIndexList list;   // list of indexes to delete

--- a/dmuserop.cpp
+++ b/dmuserop.cpp
@@ -90,6 +90,14 @@ void Desktopmodel::duplicateJpeg (QModelIndexList &list, QModelIndex parent)
    }
 
 
+void Desktopmodel::unfoldBooklet (QModelIndexList &list, QModelIndex parent)
+   {
+   _modelconv->assertIsSource (0, &parent, &list);
+   if (checkScanStack (list, parent))
+      _undo->push (new UCUnfoldBooklet (this, list, parent));
+   }
+
+
 void Desktopmodel::trashStacks (QModelIndexList &list, QModelIndex parent)
    {
    _modelconv->assertIsSource (0, &parent, &list);

--- a/file.cpp
+++ b/file.cpp
@@ -1140,7 +1140,6 @@ err_info *File::copyTo (File *fnew, int odd_even, Operation &op, bool verbose,
       QImage image;
       QSize size, trueSize;
       int bpp;
-      Filepage *fp = createPage (fnew->type ());
 
       CALL (getImage (pagenum, false, image, size, trueSize, bpp, false));
 
@@ -1148,57 +1147,166 @@ err_info *File::copyTo (File *fnew, int odd_even, Operation &op, bool verbose,
       if (image.isNull ())
          continue;
 
-      // use JPEG encoding when the target supports it
-      if (fnew->supportsJpeg () && bpp > 1)
-         {
-         bool colour = utilImageDepth (image) > 8;
-         QByteArray jpeg;
-         if (colour)
-            {
-            QBuffer buf (&jpeg);
-            buf.open (QIODevice::WriteOnly);
-            image.save (&buf, "JPEG", 75);
-            }
-         else
-            jpeg = encodeGreyJpeg (image, 75);
-         CALL (fnew->addPageJpeg (jpeg, image.width (), image.height (),
-                                   colour));
-         }
-      else
-         {
-         // auto-detect optimal depth for this page
-         int target_depth = utilImageDepth(image);
-         if (target_depth < bpp) {
-            image = utilReduceDepth(image, target_depth);
-            bpp = image.depth();
-         }
-
-         int image_size;
-#if QT_VERSION >= 0x050a00
-         image_size = image.sizeInBytes();
-#else
-         image_size = image.byteCount();
-#endif
-         QByteArray ba = QByteArray::fromRawData ((const char *)image.bits (),
-                                                  image_size);
-
-//          int stride = (trueSize.width () * bpp + 7) / 8;
-         int stride = image.bytesPerLine ();
-//         mp->stride = (true_size.x * (bpp == 24 ? 32 : bpp) + 7) / 8;
-         // changed from above line, since duplicating a normal colour max file created an error
-
-         QString name = QString (tr ("Page %1")).arg (out_page_count + 1);
-         fp->addData (image.width (), image.height (), image.depth (), stride,
-               name, false, false, out_page_count, ba, ba.size ());
-
-         fp->compress ();
-         CALL (fnew->addPage (fp, false));
-         }
+      CALL (addImageAsPage (fnew, image, bpp, out_page_count));
       out_page_count++;
       op.incProgress (1);
       }
    fnew->flush ();
    fnew->load ();
+   return NULL;
+   }
+
+
+err_info *File::addImageAsPage (File *fnew, QImage &image, int bpp,
+                                int out_page_num)
+   {
+   // use JPEG encoding when the target supports it
+   if (fnew->supportsJpeg () && bpp > 1)
+      {
+      bool colour = utilImageDepth (image) > 8;
+      QByteArray jpeg;
+      if (colour)
+         {
+         QBuffer buf (&jpeg);
+         buf.open (QIODevice::WriteOnly);
+         image.save (&buf, "JPEG", 75);
+         }
+      else
+         jpeg = encodeGreyJpeg (image, 75);
+      CALL (fnew->addPageJpeg (jpeg, image.width (), image.height (), colour));
+      }
+   else
+      {
+      Filepage *fp = createPage (fnew->type ());
+
+      // auto-detect optimal depth for this page
+      int target_depth = utilImageDepth (image);
+      if (target_depth < bpp)
+         {
+         image = utilReduceDepth (image, target_depth);
+         bpp = image.depth ();
+         }
+
+      int image_size;
+#if QT_VERSION >= 0x050a00
+      image_size = image.sizeInBytes ();
+#else
+      image_size = image.byteCount ();
+#endif
+      QByteArray ba = QByteArray::fromRawData ((const char *)image.bits (),
+                                               image_size);
+
+//          int stride = (trueSize.width () * bpp + 7) / 8;
+      int stride = image.bytesPerLine ();
+//         mp->stride = (true_size.x * (bpp == 24 ? 32 : bpp) + 7) / 8;
+      // changed from above line, since duplicating a normal colour max file created an error
+
+      QString name = QString (tr ("Page %1")).arg (out_page_num + 1);
+      fp->addData (image.width (), image.height (), image.depth (), stride,
+            name, false, false, out_page_num, ba, ba.size ());
+
+      fp->compress ();
+      CALL (fnew->addPage (fp, false));
+      }
+   return NULL;
+   }
+
+
+QVector<QPair<int, bool> > File::bookletOrder (int numImages)
+   {
+   int pages = 2 * numImages;
+   QVector<QPair<int, bool> > order (pages);
+
+   /* Each scanned page 's' carries two pages. Counting s from the outer sheet
+      inwards, the outer side (s even) holds the highest remaining page on its
+      left and the lowest on its right; the inner side (s odd) is reversed. The
+      page numbers worked out here are 1-based, matching how a reader numbers a
+      booklet. */
+   for (int s = 0; s < numImages; s++)
+      {
+      int left_page, right_page;
+
+      if (s % 2 == 0)
+         {
+         left_page = pages - s;
+         right_page = s + 1;
+         }
+      else
+         {
+         left_page = s + 1;
+         right_page = pages - s;
+         }
+      order[left_page - 1] = QPair<int, bool> (s, true);
+      order[right_page - 1] = QPair<int, bool> (s, false);
+      }
+   return order;
+   }
+
+
+err_info *File::unfoldBooklet (Operation &op, File *&fnew)
+   {
+   Desk *desk = _desk;
+   e_type type = Type_max;
+   QString ext = typeExt (type);
+   QString uniq = desk->findNextFilename (_leaf + "_unfold", QString (), ext);
+   QString dir = desk->dir ();
+
+   CALL (load ());
+   int numImages = pagecount ();
+
+   fnew = createFile (dir, uniq + ext, desk, type);
+   if (!fnew)
+      return not_impl ();
+   CALL (fnew->create ());
+
+   /* Split each scanned page down the middle and write the halves in reading
+      order. The order alternates which source page is needed, so each page is
+      decoded as its halves come up rather than holding them all in memory. */
+   QVector<QPair<int, bool> > order = bookletOrder (numImages);
+   err_info *err = NULL;
+   int written = 0;
+
+   for (int out = 0; out < order.size (); out++)
+      {
+      int srcpage = order[out].first;
+      bool isLeft = order[out].second;
+
+      QImage image;
+      QSize size, trueSize;
+      int bpp;
+
+      err = getImage (srcpage, false, image, size, trueSize, bpp, false);
+      if (err)
+         break;
+      if (image.isNull ())
+         continue;
+
+      int w = image.width ();
+      int half = w / 2;
+      QImage page = isLeft
+         ? image.copy (0, 0, half, image.height ())
+         : image.copy (half, 0, w - half, image.height ());
+
+      err = addImageAsPage (fnew, page, bpp, written++);
+      if (err)
+         break;
+      op.incProgress (1);
+      }
+
+   // if we got no pages, delete the file
+   if (err || !fnew->valid () || !fnew->pagecount ())
+      {
+      fnew->remove ();
+      delete fnew;
+      fnew = 0;
+      if (!err)
+         return err_make (ERRFN, ERR_cannot_find_any_pages_in_source_document1,
+                          qPrintable (_pathname));
+      return err;
+      }
+   fnew->flush ();
+   fnew->load ();
+   desk->newFile (fnew, this, 1);
    return NULL;
    }
 #endif

--- a/file.h
+++ b/file.h
@@ -46,11 +46,13 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QObject>
 
 #include "imageadjust.h"
+#include <QPair>
 #include <QPoint>
 #include <QPixmap>
 #include <QRect>
 #include <QSize>
 #include <QStringList>
+#include <QVector>
 
 
 #include "err.h"
@@ -156,6 +158,43 @@ public:
 
    err_info *copyTo (File *fnew, int odd_even, Operation &op, bool verbose = false,
                      int first_page = 0, int last_page = -1);
+
+   /** add a single image to a destination file as a new page, using JPEG
+       encoding when the target supports it and a raw page otherwise
+
+      \param fnew          destination file
+      \param image         image to add (may be modified in place to reduce
+                           its depth)
+      \param bpp           bits per pixel of the source image
+      \param out_page_num  zero-based page number, used to name the page
+      \returns error, or NULL if none */
+   err_info *addImageAsPage (File *fnew, QImage &image, int bpp,
+                             int out_page_num);
+
+   /** work out the reading order for unfolding a saddle-stitched booklet
+
+      Each scanned page holds two booklet pages side by side, so a booklet
+      of 'numImages' scanned pages unfolds to 2 * numImages pages. The
+      outermost scanned page carries the last and first pages, the next the
+      second and second-to-last, and so on, alternating which half is the
+      lower page number as the scan moves from the outer to the inner sheets.
+
+      \param numImages  number of scanned pages (sheet sides)
+      \returns a vector of 2 * numImages entries in final reading order; each
+               entry gives the source scanned-page index and whether to take
+               its left half (true) or right half (false) */
+   static QVector<QPair<int, bool> > bookletOrder (int numImages);
+
+   /** unfold a saddle-stitched booklet into sequential pages
+
+      The pages of this file are taken as the sides of a booklet, each holding
+      two pages side by side. They are split down the middle and reordered into
+      normal reading order in a new stack on the desk.
+
+      \param op    operation for progress tracking
+      \param fnew  returns the new file
+      \returns error, or NULL if none */
+   err_info *unfoldBooklet (Operation &op, File *&fnew);
 
 #ifndef QT_NO_WIDGETS
    /** copy pages to a new file, applying an image adjustment to each page

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -10,6 +10,7 @@
 #include "desktopview.h"
 #include "desktopwidget.h"
 #include "dirmodel.h"
+#include "file.h"
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
@@ -269,6 +270,90 @@ void TestOps::testDuplicateEvenOdd()
    Q_ASSERT(max2);
    QCOMPARE(max2->typeName(), "Max");
    QCOMPARE(max2->pagecount(), 2);
+}
+
+void TestOps::testBookletOrder()
+{
+   // A four-sheet booklet unfolds to eight pages. Counting sheets from the
+   // outside in, the reading order is [8|1] [2|7] [6|3] [4|5]
+   QVector<QPair<int, bool> > order = File::bookletOrder(4);
+   QCOMPARE(order.size(), 8);
+
+   // page 1 is the right half of the outer side (scan 0)
+   QCOMPARE(order[0], qMakePair(0, false));
+   // page 2 is the left half of the next side (scan 1)
+   QCOMPARE(order[1], qMakePair(1, true));
+   // page 3 is the right half of scan 2
+   QCOMPARE(order[2], qMakePair(2, false));
+   // page 4 is the left half of scan 3 (innermost)
+   QCOMPARE(order[3], qMakePair(3, true));
+   // page 5 is the right half of scan 3
+   QCOMPARE(order[4], qMakePair(3, false));
+   // page 6 is the left half of scan 2
+   QCOMPARE(order[5], qMakePair(2, true));
+   // page 7 is the right half of scan 1
+   QCOMPARE(order[6], qMakePair(1, false));
+   // page 8 is the left half of the outer side (scan 0)
+   QCOMPARE(order[7], qMakePair(0, true));
+
+   // Every source page is used for exactly one left and one right half
+   QVector<int> lefts(4, 0), rights(4, 0);
+   for (auto &slot : order)
+      (slot.second ? lefts : rights)[slot.first]++;
+   for (int i = 0; i < 4; i++)
+      {
+      QCOMPARE(lefts[i], 1);
+      QCOMPARE(rights[i], 1);
+      }
+}
+
+void TestOps::testUnfoldBooklet()
+{
+   Mainwindow me;
+
+   QModelIndex max_ind;
+   QModelIndex repo_ind;
+   prepareDuplicate(&me, repo_ind, max_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopmodel *model = desktop->getModel();
+
+   // The test booklet has four scanned pages
+   File *booklet = model->getFile(max_ind);
+   Q_ASSERT(booklet);
+   int pages = booklet->pagecount();
+   QCOMPARE(pages, 4);
+
+   // Unfold the booklet (only the max file is selected)
+   Desktopview *view = desktop->getView();
+   view->setSelectionRange(0, 0);
+   desktop->unfoldBooklet();
+
+   int files = model->rowCount(repo_ind);
+   QCOMPARE(files, 3);
+
+   // The new stack is selected, named after the source and holds twice the
+   // number of pages
+   QModelIndex ind;
+   bool has_current = desktop->getCurrentFile(ind);
+   QCOMPARE(has_current, true);
+   Q_ASSERT(ind.isValid());
+   Desktopmodelconv *modelconv = desktop->getModelconv();
+   modelconv->indexToSource(desktop->_contents_proxy, ind);
+
+   QCOMPARE(model->data(ind, Qt::DisplayRole).toString(), "testfile_unfold");
+
+   File *unfolded = model->getFile(ind);
+   Q_ASSERT(unfolded);
+   QCOMPARE(unfolded->typeName(), "Max");
+   QCOMPARE(unfolded->pagecount(), 2 * pages);
+
+   // Undo removes the new stack
+   Desktopundostack *stk = model->getUndoStack();
+   Q_ASSERT(stk->canUndo());
+   stk->undo();
+   files = model->rowCount(repo_ind);
+   QCOMPARE(files, 2);
 }
 
 void TestOps::testDeleteStacks()

--- a/test/test_ops.h
+++ b/test/test_ops.h
@@ -37,6 +37,12 @@ private slots:
    //! Test duplication of odd and even pages
    void testDuplicateEvenOdd();
 
+   //! Test the booklet reading-order calculation
+   void testBookletOrder();
+
+   //! Test unfolding a booklet stack into sequential pages, with undo
+   void testUnfoldBooklet();
+
    //! Test deleting of one or more stacks
    void testDeleteStacks();
 


### PR DESCRIPTION
## Unfold scanned booklets into sequential pages

When a saddle-stitched booklet is taken apart (e.g. by pulling the
staples) and fed through a scanner, each scanned page holds two booklet
pages side by side, and the sheets only come out in reading order on the
outermost sheet. This adds an **Unfold booklet** operation that recovers
normal sequential pages automatically.

### What it does
- Splits each scanned page down the vertical middle into a left and a
  right half (no trimming — the full halves are kept, no page dropped).
- Reorders the halves into reading order using the standard saddle-stitch
  imposition. For an 8-page booklet (4 scanned pages) the scans hold
  `[8|1] [2|7] [6|3] [4|5]` and unfold to `1 2 3 4 5 6 7 8`.
- Creates a new max stack and supports undo, mirroring the existing
  duplicate operation.
- Available from the **Duplicate…** context submenu (and as an action).

### Structure
- `File::bookletOrder()` — pure helper computing the reading order;
  covered by a unit test (`testBookletOrder`).
- `File::addImageAsPage()` — the page-writing logic factored out of
  `copyTo()` so the new path reuses it (no behaviour change to `copyTo`).
- `File::unfoldBooklet()` → `Desktopmodel::opUnfoldBooklets()` /
  `unfoldBooklet()` → `UCUnfoldBooklet` undo → desktop action/slot/menu.

### Tests
- `testBookletOrder` — verifies the imposition for a 4-sheet booklet and
  that every source page contributes exactly one left and one right half.
- `testUnfoldBooklet` — unfolds the test stack, checks the new stack is
  named `testfile_unfold`, is a Max, has twice the page count, and that
  undo removes it.

Note: the full GUI build could not be exercised locally (the sandbox
lacks the QtStateMachine dev headers used by `desktopwidget.cpp`); the
core objects and the test were compiled individually and the full
build/tests rely on CI.
