### PR TITLE
filemax: Fix crash when undoing a page deletion

### DIFF
--- a/filemax.cpp
+++ b/filemax.cpp
@@ -797,6 +797,11 @@ err_info *Filemax::max_read_data (int pos, byte *buf, int size)
    {
    int count;
 
+   // guard against a read while the file is closed, rather than crashing in
+   // fseek() with a NULL stream
+   if (!_fin)
+      return merr_make (ERRFN, ERR_failed_to_read_bytes1, size);
+
    // read the data
    fseek (_fin, pos, SEEK_SET);
    count = fread (buf, 1, size, _fin);
@@ -807,6 +812,10 @@ err_info *Filemax::max_read_data (int pos, byte *buf, int size)
 err_info *Filemax::max_write_data (int pos, byte *data, int size)
    {
    int count;
+
+   // guard against a write while the file is closed (see max_read_data)
+   if (!_fin)
+      return merr_make (ERRFN, ERR_failed_to_write_bytes1, size);
 
    // write the data
    fseek (_fin, pos, SEEK_SET);
@@ -5797,8 +5806,13 @@ err_info *Filemax::restorePages (QBitArray &pages,
          memcpy ((void *)&page, del_info.constData () + upto++ * sizeof (page_info),
             sizeof (page_info));
          assert (page.titlestr.isNull ());
-         CALL (restore_page (page));
-         printf ("page %d: titlestr = %p\n", i, page.titlestr.toLatin1 ().constData());
+
+         // restore_page() reads the page's chunk data back from disc, so the
+         // file must be open, just as removePages() opens it around free_page()
+         CALL (ensure_open ());
+         err_info *err = restore_page (page);
+         ensure_closed ();
+         CALL (err);
          dest_pages << page;
          }
       else

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -952,3 +952,40 @@ void TestFile::testTransformImageCache()
    QVERIFY(!max.getImage(0, false, again, size, trueSize, bpp, false));
    QVERIFY(nearlySame(again, ondisk));
 }
+
+void TestFile::testRemoveRestorePages()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+   QVERIFY(!copyFixture("testfile.max", tmp.path()).isEmpty());
+
+   Filemax max(dir, "testfile.max", nullptr);
+   QVERIFY(max.load() == nullptr);
+   int orig = max.pagecount();
+   QVERIFY(orig > 1);
+
+   // capture the first page so we can check it survives the round-trip
+   QImage before, restored;
+   QSize size, trueSize;
+   int bpp;
+   QVERIFY(!max.getImage(0, false, before, size, trueSize, bpp, false));
+
+   // mark the first page for deletion
+   QBitArray pages(orig);
+   pages.setBit(0);
+   QByteArray del_info;
+   int count = 1;
+
+   QVERIFY(max.removePages(pages, del_info, count) == nullptr);
+   QCOMPARE(max.pagecount(), orig - 1);
+
+   // undo the delete: this reads the deleted page's chunks back from disc,
+   // which used to crash because the file was left closed
+   QVERIFY(max.restorePages(pages, del_info, count) == nullptr);
+   QCOMPARE(max.pagecount(), orig);
+
+   // the restored page still decodes to the same image
+   QVERIFY(!max.getImage(0, false, restored, size, trueSize, bpp, false));
+   QCOMPARE(restored.size(), before.size());
+}

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -85,6 +85,10 @@ private slots:
    //! the file
    void testTransformImageCache();
 
+   //! removePages then restorePages round-trips the page count without
+   //! crashing (restorePages must open the file before reading chunks)
+   void testRemoveRestorePages();
+
 private:
    //! Copy a file from test/files into destDir; returns full path
    QString copyFixture(const QString &name, const QString &destDir);


### PR DESCRIPTION
## Fix segfault when undoing a page deletion

Deleting pages from a stack (untick the green "keep" arrows) and then
pressing **Ctrl-Z** to undo crashes with a segfault:

```
Thread 1 received signal SIGSEGV
#0  __GI_fseek (fp=0x0, ...) at libio/fseek.c:35
#1  Filemax::max_read_data (...) at filemax.cpp:801
#2  Filemax::read_chunk_buf (...) at filemax.cpp:2010
#3  Filemax::restore_chunknum (...)
```

### Root cause
`restorePages()` calls `restore_page()`, which reads each deleted page's
chunk data back from disc via `max_read_data()`. Unlike the matching
`removePages()` — which wraps `free_page()` in `ensure_open()` /
`ensure_closed()` — `restorePages()` never opens the file first. `_fin`
is NULL between operations, so `fseek(NULL, …)` crashes.

### Fix
- Open the file around `restore_page()` and close it afterwards,
  mirroring `removePages()`.
- Defensively make `max_read_data()` / `max_write_data()` return an
  error instead of calling `fseek()` on a NULL stream, so a similar
  omission can't crash again.
- Drop a stray debug `printf()` that fired on every restored page.

### Test
Adds `TestFile::testRemoveRestorePages`: removes a page then restores
it, checking the page count round-trips and the restored page still
decodes (this is the path that used to crash).
