### PR TITLE
pscan: Fix the Alt-L paper-size toggle not reaching the scanner

### DIFF
--- a/pscan.cpp
+++ b/pscan.cpp
@@ -779,22 +779,45 @@ void Pscan::presetShortcut5()
    presetShortcut(5);
 }
 
+void Pscan::selectPreviewSize(int previewId)
+{
+   if (!_preview || previewId == -1)
+      return;
+
+   // Capture the name before setSize(), which may rebuild the preview's
+   // size list and shift the indices out from under us
+   QString name = _preview->getSizeName(previewId);
+   _preview->setSize(previewId);
+
+   // Mirror the choice in our own combo by name, since its index does not
+   // line up with the preview's rebuilt list
+   int row = pageSize->findText(name);
+   if (row != -1)
+      pageSize->setCurrentIndex(row);
+}
+
 void Pscan::selectA4()
 {
-   pageSize->setCurrentIndex(_papersize_a4);
-   _preview->setSize(_papersize_a4);
+   selectPreviewSize(_preview ? _preview->getPreDefA4() : -1);
 }
 
 void Pscan::toggleLetter()
 {
-   int id;
+   if (!_preview)
+      return;
 
-   if (pageSize->currentIndex() ==_papersize_letter)
-      id = _papersize_legal;
-   else
-      id = _papersize_letter;
-   pageSize->setCurrentIndex(id);
-   _preview->setSize(id);
+   // Fetch the current indices rather than the values cached when the
+   // dialog was built: applying a size rebuilds the preview's size list, so
+   // the cached indices go stale after the first toggle and a later toggle
+   // would otherwise send the wrong size to the scanner
+   int letter = _preview->getPreDefLetter();
+   int legal = _preview->getPreDefLegal();
+   if (letter == -1 || legal == -1)
+      return;
+
+   // Decide the target from what the user currently sees, comparing by name
+   bool on_legal = pageSize->currentText() == _preview->getSizeName(legal);
+   selectPreviewSize(on_legal ? letter : legal);
 }
 
 Presetadd::Presetadd(QWidget* parent, Qt::WindowFlags fl)

--- a/pscan.h
+++ b/pscan.h
@@ -187,6 +187,17 @@ private:
     /** Select a preset using a shortcut; item is numbered from 1 */
     void presetShortcut(uint item);
 
+    /** Select a predefined paper size in the preview and mirror it in our
+        own page-size combo.
+
+        The index is looked up fresh from the preview widget each time,
+        since the preview rebuilds its size list (and shifts the indices)
+        whenever the page size changes.
+
+       \param previewId   index into the preview's current size list, or -1
+                          to do nothing */
+    void selectPreviewSize(int previewId);
+
     /** Move the focus to the folder 'find' field */
     void focusFind();
 };

--- a/qi/previewwidget.cpp
+++ b/qi/previewwidget.cpp
@@ -537,10 +537,6 @@ void PreviewWidget::slotRangeChange()
         tlx = tly = 0.0;
         brx = mPreDefs[a].width/(mMaxRangeX -mMinRangeX);
         bry = mPreDefs[a].height/(mMaxRangeY -mMinRangeY);
-        if (sca->getName () == "A4")
-         printf ("%s: %1.15lf, %1.15lf   %1.15lf   %1.15lf\n",
-                 sca->getName ().toLatin1 ().constData(), brx, bry,
-            mMinRangeX, mMaxRangeX);
       }
       sca = mSizeArray [mSizeArray.size() - 1];
       sca->setRange (tlx,tly,brx,bry,mPreDefs[a].width, mPreDefs[a].height);

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -1692,6 +1692,14 @@ void QScanDialog::slotSetPredefinedSize(ScanArea* sca)
 {
   double tlx,tly,brx,bry;
 
+  // Changing the page size below reloads the scanner options and rebuilds the
+  // preview, which can re-enter this slot with a stale size and undo the scan
+  // area we are about to set. Ignore such re-entrant calls
+  static bool in_here = false;
+  if (in_here)
+     return;
+  in_here = true;
+
   // set page size if required
   if (mpWidthOption
      && mpScanner->isOptionActive(mpWidthOption->saneOptionNumber()))
@@ -1715,6 +1723,7 @@ void QScanDialog::slotSetPredefinedSize(ScanArea* sca)
     if (!sca)
     {
       printf ("Warning: size lost\n");
+      in_here = false;
       return;
     }
   }
@@ -1724,8 +1733,6 @@ void QScanDialog::slotSetPredefinedSize(ScanArea* sca)
   tly = sca->tly();
   brx = sca->brx();
   bry = sca->bry();
-   printf ("%1.2lf %1.2lf %1.2lf %1.2lf, valid=%d\n",
-      sca->tlx(),sca->tly(),sca->brx(),sca->bry(), sca->isValid ());
 //change scrollbar options
   mpTlxOption->slotSetPercentValue(tlx);
   mpTlyOption->slotSetPercentValue(tly);
@@ -1734,6 +1741,28 @@ void QScanDialog::slotSetPredefinedSize(ScanArea* sca)
 //set tlx/tly option again (to be sure)
   mpTlxOption->slotSetPercentValue(tlx);
   mpTlyOption->slotSetPercentValue(tly);
+
+  /* The percent-based widget updates above do not always reach the scanner.
+     When the page size shrinks, reloading the options leaves the slider pinned
+     at its (now smaller) maximum, so setting the same percentage produces no
+     valueChanged() and the old, larger scan area stays on the scanner. Push
+     the scan area to the scanner explicitly so it always matches the selected
+     size. */
+  struct { QScrollBarOption *opt; double pct; } area[] = {
+     { mpTlxOption, tlx }, { mpTlyOption, tly },
+     { mpBrxOption, brx }, { mpBryOption, bry }
+  };
+  for (unsigned a = 0; a < sizeof (area) / sizeof (area[0]); a++)
+  {
+     int num = area[a].opt->saneOptionNumber ();
+     if (area[a].pct < 0.0 || !mpScanner->isOptionActive (num)
+        || mpScanner->getOptionType (num) != SANE_TYPE_FIXED)
+        continue;
+     SANE_Fixed val = SANE_FIX (area[a].pct
+        * SANE_UNFIX (mpScanner->getRangeMax (num)));
+     mpScanner->setOption (num, &val);
+  }
+  in_here = false;
 }
 
 /**  */

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -2860,7 +2860,6 @@ int QScanner::xResolutionOption()
 		   	return i;
 			}
 	}
-	printf ("Warning - no xres\n");
 	return 0;
 }
 /**  */
@@ -2879,7 +2878,6 @@ int QScanner::yResolutionOption()
 		  	return i;
 			}
 	}
-    printf ("Warning - no yres\n");
     return 0;
 }
 /**  */
@@ -3932,8 +3930,8 @@ SANE_Status QScanner::do_sane_open (SANE_String_Const name, SANE_Handle *handle)
       _simul_params.pixels_per_line = 2400;
       _simul_params.lines = 3507;
       _simul_params.depth = 1;
-      _max_x = 1200 * 8.5;
-      _max_y = 1200 * 12;
+      _max_x = 1200 * 8.6;   // a little over 8.5in so Letter/Legal (216mm) fit
+      _max_y = 1200 * 14.5;  // over 14in so the ADF can represent Legal paper
       _min_x = 0;
       _min_y = 0;
       _max_x_fb = _max_x;

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -182,28 +182,39 @@ void TestQscanner::testPscanPaperToggle()
    if (pv->getPreDefLetter () == -1 || pv->getPreDefLegal () == -1)
       QSKIP ("scanner does not offer both Letter and Legal sizes");
 
-   // Capture the size actually pushed to the scanner each time a predefined
-   // size is applied
-   QString applied;
-   QObject::connect (pv, &PreviewWidget::signalPredefinedSize, pv,
-      [&applied] (ScanArea *sca) { applied = sca ? sca->getName () : QString (); });
+   QString legalName = pv->getSizeName (pv->getPreDefLegal ());
+   QString letterName = pv->getSizeName (pv->getPreDefLetter ());
 
-   /* Toggling repeatedly must keep the size sent to the scanner in step with
-      the size shown in the combo. This used to drift after the first toggle:
-      applying a size rebuilt the preview's size list, the cached indices went
-      stale, and a later toggle sent the wrong size while the combo showed the
-      right one. */
-   for (int i = 0; i < 4; i++)
+   /* Toggle repeatedly and check the scan area the scanner actually ends up
+      with. This used to get stuck on the first size chosen: the combo changed
+      but the scanner's bottom-right y stayed put, so a Letter scan came out
+      Legal-length (or vice versa). */
+   QMap<QString, double> bryForName;
+   QString prev;
+   for (int i = 0; i < 6; i++)
    {
-      applied.clear ();
       pscan.toggleLetter ();
-      QCOMPARE (applied, pscan.pageSize->currentText ());
+      QString name = pscan.pageSize->currentText ();
+      double bry = SANE_UNFIX (scanner.saneWordValue (scanner.getBryOption ()));
+
+      // each toggle must actually switch the shown size
+      QVERIFY (name != prev);
+      prev = name;
+
+      // the same paper size must always give the same scan height
+      if (bryForName.contains (name))
+         QVERIFY2 (qAbs (bryForName[name] - bry) < 1.0,
+            "scan height changed for an unchanged paper size");
+      else
+         bryForName[name] = bry;
    }
 
-   // And the toggle really does alternate between two sizes
-   QString before = pscan.pageSize->currentText ();
-   pscan.toggleLetter ();
-   QVERIFY (pscan.pageSize->currentText () != before);
+   // We should have seen exactly the two sizes, and Legal (356mm) must scan
+   // clearly taller than Letter (279mm) - before the fix both stayed equal
+   QCOMPARE (bryForName.size (), 2);
+   QVERIFY (bryForName.contains (legalName));
+   QVERIFY (bryForName.contains (letterName));
+   QVERIFY (bryForName[legalName] > bryForName[letterName] + 50.0);
 }
 
 

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -6,6 +6,9 @@
 #include "qxmlconfig.h"
 #include "test_qscanner.h"
 
+#include "qi/previewwidget.h"
+#include "qi/scanarea.h"
+
 #define SIMUL_NAME "simulscan"
 
 
@@ -158,6 +161,49 @@ void TestQscanner::testPscanControls()
    QCOMPARE (scanner.duplex (), !was_duplex);
    QTest::mouseClick (pscan.duplex, Qt::LeftButton);
    QCOMPARE (scanner.duplex (), was_duplex);
+}
+
+
+void TestQscanner::testPscanPaperToggle()
+{
+   ensureXmlConfig ();
+   QScanner scanner;
+   scanner.setDeviceName (SIMUL_NAME);
+   QVERIFY (scanner.openDevice ());
+
+   QScanDialog dialog (&scanner, 0);
+
+   Pscan pscan;
+   pscan.setScanDialog (&dialog);
+   pscan.scannerChanged (&scanner);
+   pscan.setPreviewWidget (dialog.getPreview ());
+
+   PreviewWidget *pv = dialog.getPreview ();
+   if (pv->getPreDefLetter () == -1 || pv->getPreDefLegal () == -1)
+      QSKIP ("scanner does not offer both Letter and Legal sizes");
+
+   // Capture the size actually pushed to the scanner each time a predefined
+   // size is applied
+   QString applied;
+   QObject::connect (pv, &PreviewWidget::signalPredefinedSize, pv,
+      [&applied] (ScanArea *sca) { applied = sca ? sca->getName () : QString (); });
+
+   /* Toggling repeatedly must keep the size sent to the scanner in step with
+      the size shown in the combo. This used to drift after the first toggle:
+      applying a size rebuilt the preview's size list, the cached indices went
+      stale, and a later toggle sent the wrong size while the combo showed the
+      right one. */
+   for (int i = 0; i < 4; i++)
+   {
+      applied.clear ();
+      pscan.toggleLetter ();
+      QCOMPARE (applied, pscan.pageSize->currentText ());
+   }
+
+   // And the toggle really does alternate between two sizes
+   QString before = pscan.pageSize->currentText ();
+   pscan.toggleLetter ();
+   QVERIFY (pscan.pageSize->currentText () != before);
 }
 
 

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -42,6 +42,10 @@ private slots:
    //! The pscan dialog controls (resolution, ADF, duplex, reset) drive
    //! the scanner settings.
    void testPscanControls();
+
+   //! The Alt-L paper-size toggle keeps the size sent to the scanner in
+   //! step with the size shown in the combo, across repeated toggles.
+   void testPscanPaperToggle();
 };
 
 #endif // TEST_QSCANNER_H


### PR DESCRIPTION
## Fix the Alt-L paper-size toggle not reaching the scanner

Toggling paper size (Alt-L for Letter/Legal, or picking a size in the
combo) updated the on-screen combo but left the **scanner** on the
previous size. In the report, the page-height option showed 279 mm
(Letter) while the scan area's bottom-right y stayed at 356 mm (Legal),
so a "Letter" scan still came out Legal-length. The console also spammed
`0.00 0.00 1.00 1.00, valid=0` and `Warning - no yres`.

### Root causes (found by reproducing on the simulated scanner)
1. **Re-entrancy storm.** `slotSetPredefinedSize()` sets the page size,
   which reloads options and rebuilds the preview; that re-enters the
   slot with a stale size and undoes the scan area just applied. Guarded
   against re-entrancy, like `slotReloadOptions()` already is.
2. **Scan area never pushed.** The scan area is only nudged via the
   scroll-bar widgets as a percentage. When the page shrinks, reloading
   pins the slider at its new maximum, so re-applying 100% yields no
   `valueChanged()` and nothing reaches the scanner. Now the four
   scan-area options are pushed to the scanner explicitly.
3. **Stale combo indices.** `Pscan` cached the Letter/Legal/A4 indices
   once; applying a size rebuilds the preview list and shifts them.
   `toggleLetter()`/`selectA4()` now look the indices up fresh and match
   by name.

### Tests
`TestQscanner::testPscanPaperToggle` toggles the paper size against the
simulated scanner and asserts the scanner's bottom-right y follows the
selection (Legal scans clearly taller than Letter). The simulated scanner
now advertises an 8.6×14.5 in bed so it can represent Letter and Legal.
Verified the test **fails without the fix** and passes with it.

Also removes stray debug `printf()`s (size dump, A4 dump, missing
x/yres warnings) that spammed the console during scanning.

### Note on local testing
This was reproduced and fixed against a real local build: installing the
Qt5 dev packages lets the whole app + test suite build and run here
(`QT_QPA_PLATFORM=offscreen ./paperman -t TestQscanner`), which the Qt6
sandbox could not do (missing QtStateMachine headers).
