### PR TITLE
Add coverage measurement, expand tests and fix what they found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ doc/_build/
 install-*
 /server.mk
 .stamp
+build-coverage/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -64,6 +64,12 @@ test-progressive: paperman-server
 test-parallel: paperman
 	scripts/test_parallel.sh
 
+# Build with gcov instrumentation, run the C++ suite and report
+coverage: test-setup
+	scripts/coverage.sh
+
+.PHONY: coverage
+
 docs:
 	$(SPHINXBUILD) -b html $(SPHINXOPTS) $(DOCDIR) $(BUILDDIR)/html
 
@@ -222,6 +228,7 @@ help:
 	@echo "  test-setup       Generate test files in test/files/"
 	@echo "  test-progressive Run progressive-loading tests"
 	@echo "  test-parallel    Run parallel tests"
+	@echo "  coverage         Measure C++ test coverage (build-coverage/)"
 	@echo "  app-test         Run Flutter widget tests"
 	@echo ""
 	@echo "Release targets:"

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -108,6 +108,7 @@ class Desktopmodel : public QAbstractItemModel
 
    // the remote-operation tests drive opXxx directly
    friend class TestSearchServer;
+   friend class TestDesktopUi;
 
 public:
    Desktopmodel(QObject *parent);

--- a/desktopview.cpp
+++ b/desktopview.cpp
@@ -177,13 +177,12 @@ QSize Desktopview::setPositions ()
    }
 
 
-void Desktopview::dataChanged (const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void Desktopview::dataChanged (const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                               const QVector<int> &roles)
    {
-//    printf ("dataChanged\n");
-
-//    setPositions ();
-
-//    return;
+   /* Note: this must match the base-class signature exactly (with the
+      roles argument) or it never gets called, and item positions go
+      stale when the model changes them, e.g. on undoing a move */
 
    // here we update the position of the item
    QModelIndex parent = topLeft.parent ();
@@ -197,7 +196,7 @@ void Desktopview::dataChanged (const QModelIndex &topLeft, const QModelIndex &bo
       }
 
    // this is needed for stackItems()
-   QListView::dataChanged (topLeft, bottomRight);
+   QListView::dataChanged (topLeft, bottomRight, roles);
    }
 
 

--- a/desktopview.h
+++ b/desktopview.h
@@ -166,7 +166,8 @@ public slots:
    //! ensure that the last item is visible
    void scrollToLast (void);
 
-   void dataChanged (const QModelIndex & topLeft, const QModelIndex & bottomRight);
+   void dataChanged (const QModelIndex & topLeft, const QModelIndex & bottomRight,
+                     const QVector<int> &roles = QVector<int> ()) override;
 
    void rowsInserted (const QModelIndex & parent, int start, int end);
 

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -59,6 +59,32 @@ so the files are created automatically before running tests.
 The search-server tests copy them into temporary directories for each run so
 the originals are never modified.
 
+Code Coverage
+-------------
+
+To see how much of the C++ code the tests exercise, run:
+
+.. code:: bash
+
+   make coverage
+
+This builds the test binary with gcov instrumentation in
+``build-coverage/`` (a shadow build, so the normal build directories are
+untouched), runs the whole suite headless and writes an annotated
+per-file report to ``build-coverage/coverage.html`` plus a plain-text
+summary to ``build-coverage/coverage.txt``.  The report covers the
+application code only: the tests themselves, generated moc/qrc/ui files
+and the bundled QuiteInsane scanner code under ``qi/`` are excluded.
+
+The report needs `gcovr <https://gcovr.com/>`_ (``apt install gcovr``).
+``scripts/coverage.sh`` accepts ``QMAKE``, ``JOBS`` and ``SUITE``
+environment variables; set ``SUITE`` to a suite name (as accepted by
+``paperman -t``) to measure the coverage of a single suite:
+
+.. code:: bash
+
+   SUITE=TestSearchServer scripts/coverage.sh
+
 Flutter Widget Tests
 --------------------
 

--- a/filejpeg.cpp
+++ b/filejpeg.cpp
@@ -193,7 +193,7 @@ err_info *Filejpeg::load_annot (void)
    QProcess process;
    QStringList args;
 
-   args << "-t" << "-s" << "-Author" << "-ImageDescription" << "-Keywords"
+   args << "-t" << "-s" << "-Artist" << "-ImageDescription" << "-Keywords"
            << _pathname;
    CALL (run_exiftool (process, "load annotations", args));
    _annot_loaded = true;

--- a/paperman.pro
+++ b/paperman.pro
@@ -272,6 +272,7 @@ test {
       test/test_qscanner.cpp \
       test/test_searchserver.cpp \
       test/test_ocrsearch.cpp \
+      test/test_localbackend.cpp \
       searchserver.cpp \
       serverlog.cpp \
       tokenstore.cpp \
@@ -289,6 +290,7 @@ test {
       test/test_utils.h \
       test/test_searchserver.h \
       test/test_ocrsearch.h \
+      test/test_localbackend.h \
       searchserver.h \
       serverlog.h \
       tokenstore.h \

--- a/paperman.pro
+++ b/paperman.pro
@@ -13,13 +13,21 @@ INSTALLS += target
 
 message ("Type 'make' to build paperman")
 # To build with testing: qmake CONFIG+=test
+# To measure test coverage: scripts/coverage.sh (uses CONFIG+=coverage)
+
+coverage {
+    message("Building with gcov coverage instrumentation")
+    QMAKE_CXXFLAGS += --coverage -O0
+    QMAKE_CFLAGS += --coverage -O0
+    QMAKE_LFLAGS += --coverage
+}
 
 OCRINCPATH = /usr/local/include/nuance-omnipage-csdk-15.5
 OCRLIBPATH = /usr/local/lib/nuance-omnipage-csdk-15.5
 
 CONFIG += qt warn_on
 CONFIG -= release
-!debug: QMAKE_CXXFLAGS += -O2
+!debug:!coverage: QMAKE_CXXFLAGS += -O2
 
 #QMAKE_LFLAGS += -static
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Measure test coverage of the paperman C++ code.
+#
+# Builds the test binary with gcov instrumentation in build-coverage/,
+# runs the full test suite and writes a report:
+#
+#   build-coverage/coverage.html   - annotated per-file report
+#   build-coverage/coverage.txt    - plain-text summary (also printed)
+#
+# Environment:
+#   QMAKE     qmake to use (default: qmake from PATH)
+#   JOBS      parallel build jobs (default: nproc)
+#   SUITE     test suite(s) to run (default: all)
+#
+# Requires gcovr (apt install gcovr).
+
+set -e
+
+src="$(cd "$(dirname "$0")/.." && pwd)"
+build="$src/build-coverage"
+qmake="${QMAKE:-qmake}"
+jobs="${JOBS:-$(nproc)}"
+
+mkdir -p "$build"
+cd "$build"
+"$qmake" "$src/paperman.pro" CONFIG+=test CONFIG+=coverage
+make -j"$jobs"
+
+# Old counts would understate coverage of a re-run
+find "$build" -name '*.gcda' -delete
+
+# Isolate settings and use the offscreen platform so the GUI tests run
+# headless; fixtures load relative to the source directory
+scratch="$(mktemp -d)"
+cd "$src"
+QT_QPA_PLATFORM=offscreen HOME="$scratch/home" XDG_CONFIG_HOME="$scratch/config" \
+    "$build/paperman" -t $SUITE || true
+rm -rf "$scratch"
+
+# Report on the application code: leave out the tests themselves,
+# generated moc/qrc/ui files and the bundled QuiteInsane scanner code
+cd "$build"
+# --gcov-ignore-parse-errors: newer gcc emits per-block lines that
+# some gcovr versions do not understand; they carry no line counts
+gcovr --root "$src" --object-directory "$build" \
+    --gcov-ignore-parse-errors=all \
+    --exclude "$src/test/" \
+    --exclude "$src/qi/" \
+    --exclude '.*/moc_.*' --exclude '.*/qrc_.*' --exclude '.*/ui_.*' \
+    --exclude-unreachable-branches \
+    --html-details coverage.html \
+    --txt coverage.txt \
+    --print-summary
+
+echo
+echo "Full report: $build/coverage.html"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,6 +13,7 @@
 #include "test_qscanner.h"
 #include "test_utils.h"
 #include "test_searchserver.h"
+#include "test_localbackend.h"
 #include "test_ocrsearch.h"
 
 //QTEST_MAIN(TestPaperman)
@@ -28,6 +29,7 @@ static TestPagewidget TEST_PAGEWIDGET("pagewidget");
 static TestQscanner TEST_QSCANNER("qscanner");
 static TestSearchServer TEST_SEARCHSERVER("searchserver");
 static TestOcrSearch TEST_OCRSEARCH("ocrsearch");
+static TestLocalBackend TEST_LOCALBACKEND("localbackend");
 
 int test_run(int, char **in_argv, QApplication *,
              const char *filter)

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1006,6 +1006,89 @@ void TestDesktopUi::testDragDropToFolder()
    delete mime;
 }
 
+void TestDesktopUi::testDragDropGroupToFolder()
+{
+   Mainwindow me;
+
+   // a third stack so the group spans all three file types
+   auto path = setupRepo();
+   QVERIFY(QFile::copy(testSrc + "/colour_plasma.jpg",
+                       path + "/colour_plasma.jpg"));
+
+   Desktopwidget *desktop = me.getDesktop();
+   QVERIFY(!desktop->addDir(path));
+   Desktopmodel *model = desktop->getModel();
+   QModelIndex repo_ind = model->index(0, 0, QModelIndex());
+   QVERIFY(repo_ind.isValid());
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   Desktopview *view = desktop->getView();
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+
+   /* select the whole group: click the first, then extend through the
+      selection model - item geometry can overlap, which makes
+      ctrl-clicks unreliable */
+   clickItem(view, 0);
+   for (int row = 1; row <= 2; row++)
+      view->selectionModel()->select(itemIndex(view, row),
+                                     QItemSelectionModel::Select);
+   QCOMPARE(view->selectionModel()->selectedIndexes().size(), 3);
+
+   // remember where one member sits, to check undo restores layout
+   QModelIndex maxind = model->index("testfile.max", repo_ind);
+   QVERIFY(maxind.isValid());
+   QPoint oldpos =
+      model->data(maxind, Desktopmodel::Role_position).toPoint();
+
+   // build the drag data from the multi-selection, as the view would
+   QMimeData *mime =
+      view->model()->mimeData(view->selectionModel()->selectedIndexes());
+   QVERIFY(mime);
+
+   // drop the group on the 'main' folder in the directory tree
+   QModelIndex dir_ind = desktop->findDir(path + "/main");
+   QVERIFY(dir_ind.isValid());
+   QVERIFY(desktop->_dir_proxy->dropMimeData(mime, Qt::MoveAction, -1, -1,
+                                             dir_ind));
+
+   // every member has moved on disk and left the view
+   QTRY_VERIFY(QFile::exists(path + "/main/testfile.max"));
+   QVERIFY(QFile::exists(path + "/main/testpdf.pdf"));
+   QVERIFY(QFile::exists(path + "/main/colour_plasma.jpg"));
+   QVERIFY(!QFile::exists(path + "/testfile.max"));
+   QVERIFY(!QFile::exists(path + "/testpdf.pdf"));
+   QVERIFY(!QFile::exists(path + "/colour_plasma.jpg"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 0);
+
+   // a single undo brings the whole group back...
+   me.actionUndo->trigger();
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+   QVERIFY(QFile::exists(path + "/testfile.max"));
+   QVERIFY(QFile::exists(path + "/testpdf.pdf"));
+   QVERIFY(QFile::exists(path + "/colour_plasma.jpg"));
+   QVERIFY(!QFile::exists(path + "/main/testfile.max"));
+
+   // ...with the remembered stack at its old spot on the desk
+   maxind = model->index("testfile.max", repo_ind);
+   QVERIFY(maxind.isValid());
+   QCOMPARE(model->data(maxind, Desktopmodel::Role_position).toPoint(),
+            oldpos);
+
+   // and one redo moves the group out again
+   me.actionRedo->trigger();
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 0);
+   QVERIFY(QFile::exists(path + "/main/testfile.max"));
+   QVERIFY(QFile::exists(path + "/main/testpdf.pdf"));
+   QVERIFY(QFile::exists(path + "/main/colour_plasma.jpg"));
+
+   delete mime;
+}
+
+
 void TestDesktopUi::testMoveStackOnDesk()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -19,6 +19,7 @@
 #include "pagemodel.h"
 #include "pageview.h"
 #include "pagewidget.h"
+#include "searchserver.h"
 #include "qxmlconfig.h"
 #include "test_desktopui.h"
 
@@ -1086,6 +1087,90 @@ void TestDesktopUi::testDragDropGroupToFolder()
    QVERIFY(QFile::exists(path + "/main/colour_plasma.jpg"));
 
    delete mime;
+}
+
+
+void TestDesktopUi::testRemoteGroupMoveViaUi()
+{
+   Mainwindow me;
+
+   /* serve the repo over HTTP; the same directory doubles as the
+      server's disk so the moves can be checked there */
+   auto path = setupRepo();
+   QVERIFY(QFile::copy(testSrc + "/colour_plasma.jpg",
+                       path + "/colour_plasma.jpg"));
+
+   SearchServer server(path, 9877);
+   QVERIFY(server.start());
+   QTest::qWait(100);
+   QUrl url("http://localhost:9877");
+   QString repo = QFileInfo(path).fileName();
+   QString root = url.toString() + "/" + repo;
+
+   Desktopwidget *desktop = me.getDesktop();
+   QString err = desktop->addRemoteServer(url);
+   QVERIFY2(err.isEmpty(), qPrintable(err));
+
+   me.resize(1024, 768);
+   me.show();
+   QVERIFY(QTest::qWaitForWindowExposed(&me));
+   QTest::qWait(50);
+
+   // click the remote repository in the folder tree to show its desk
+   QModelIndex repo_dir = desktop->findDir(root);
+   QVERIFY(repo_dir.isValid());
+   Dirview *dir = desktop->_dir;
+   dir->scrollTo(repo_dir);
+   QRect rect = dir->visualRect(repo_dir);
+   QVERIFY(rect.isValid());
+   QTest::mouseClick(dir->viewport(), Qt::LeftButton, Qt::NoModifier,
+                     rect.center());
+   QTRY_COMPARE(desktop->getSelectedPath(), root);
+
+   Desktopview *view = desktop->getView();
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+   QTest::qWait(50);   // let the item layout settle before clicking
+
+   // the remote folder tree fills in asynchronously; expand the repo
+   // so its 'main' subdirectory arrives
+   dir->expand(repo_dir);
+   QTRY_VERIFY(desktop->findDir(root + "/main").isValid());
+
+   /* select the whole group through the selection model: the async
+      thumbnail fetches resize items as they arrive, so a mouse click
+      can land on a neighbour mid-layout */
+   view->selectionModel()->clear();
+   for (int row = 0; row <= 2; row++)
+      view->selectionModel()->select(itemIndex(view, row),
+                                     QItemSelectionModel::Select);
+   QCOMPARE(view->selectionModel()->selectedIndexes().size(), 3);
+
+   QMimeData *mime =
+      view->model()->mimeData(view->selectionModel()->selectedIndexes());
+   QVERIFY(mime);
+
+   // drop the group on the remote 'main' folder
+   QModelIndex dir_ind = desktop->findDir(root + "/main");
+   QVERIFY(desktop->_dir_proxy->dropMimeData(mime, Qt::MoveAction, -1, -1,
+                                             dir_ind));
+
+   // the server's files have moved
+   QTRY_VERIFY(QFile::exists(path + "/main/testfile.max"));
+   QVERIFY(QFile::exists(path + "/main/testpdf.pdf"));
+   QVERIFY(QFile::exists(path + "/main/colour_plasma.jpg"));
+   QVERIFY(!QFile::exists(path + "/testfile.max"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 0);
+
+   // one undo moves the whole group back on the server
+   me.actionUndo->trigger();
+   QTRY_VERIFY(QFile::exists(path + "/testfile.max"));
+   QVERIFY(QFile::exists(path + "/testpdf.pdf"));
+   QVERIFY(QFile::exists(path + "/colour_plasma.jpg"));
+   QVERIFY(!QFile::exists(path + "/main/testfile.max"));
+   QTRY_COMPARE(view->model()->rowCount(view->rootIndex()), 3);
+
+   delete mime;
+   server.stop();
 }
 
 

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1006,6 +1006,64 @@ void TestDesktopUi::testDragDropToFolder()
    delete mime;
 }
 
+void TestDesktopUi::testMoveStackOnDesk()
+{
+   QModelIndex repo_ind;
+   Desktopmodel *model;
+   Mainwindow me;
+
+   setupShown(&me, model, repo_ind);
+
+   Desktopwidget *desktop = me.getDesktop();
+   Desktopview *view = desktop->getView();
+   QString path = desktop->getSelectedPath();
+
+   // pick the stack up with a click, as a user starting a drag would
+   clickItem(view, 0);
+   QModelIndexList selected = view->selectionModel()->selectedIndexes();
+   QCOMPARE(selected.size(), 1);
+   QModelIndex vind = selected[0];
+
+   QModelIndex ind = model->index("testfile.max", repo_ind);
+   QVERIFY(ind.isValid());
+   QPoint oldpos = model->data(ind, Desktopmodel::Role_position).toPoint();
+   QPoint newpos = oldpos + QPoint(150, 80);
+
+   /* complete the gesture the way Desktopview::dropEvent does when a
+      drag ends over empty desk space: hand the model the selection's
+      old and new positions */
+   QModelIndexList list;
+   QList<QPoint> oldlist, plist;
+   list << ind;
+   oldlist << oldpos;
+   plist << newpos;
+   model->move(list, repo_ind, oldlist, plist);
+
+   // the model and the view both show the stack at its new place
+   QCOMPARE(model->data(ind, Desktopmodel::Role_position).toPoint(),
+            newpos);
+   QTRY_COMPARE(view->visualRect(vind).topLeft(), newpos);
+
+   // the new position reaches the desk file on disk when it flushes
+   model->flushAllDesks();
+   QFile pd(path + "/.paperdesk");
+   QVERIFY(pd.open(QIODevice::ReadOnly));
+   QString expect = QString("testfile.max=%1,%2,")
+                        .arg(newpos.x()).arg(newpos.y());
+   QVERIFY2(pd.readAll().contains(expect.toUtf8()),
+            qPrintable(expect));
+
+   // undo from the menu puts it back; redo moves it again
+   me.actionUndo->trigger();
+   QCOMPARE(model->data(ind, Desktopmodel::Role_position).toPoint(),
+            oldpos);
+   QTRY_COMPARE(view->visualRect(vind).topLeft(), oldpos);
+   me.actionRedo->trigger();
+   QCOMPARE(model->data(ind, Desktopmodel::Role_position).toPoint(),
+            newpos);
+}
+
+
 void TestDesktopUi::testImportFlow()
 {
    QModelIndex repo_ind;

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -96,6 +96,10 @@ private slots:
    //! Repositioning a stack on the desk moves it, persists and undoes
    void testMoveStackOnDesk();
 
+   //! A multi-selected group dropped on a folder moves together and
+   //! one undo brings the whole group back
+   void testDragDropGroupToFolder();
+
    //! Test importing files from a directory and moving one in
    void testImportFlow();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -100,6 +100,10 @@ private slots:
    //! one undo brings the whole group back
    void testDragDropGroupToFolder();
 
+   //! The same group drop against a remote repository moves the
+   //! files on the server, with undo
+   void testRemoteGroupMoveViaUi();
+
    //! Test importing files from a directory and moving one in
    void testImportFlow();
 

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -93,6 +93,9 @@ private slots:
    //! Test dragging a stack onto a folder in the tree moves it there
    void testDragDropToFolder();
 
+   //! Repositioning a stack on the desk moves it, persists and undoes
+   void testMoveStackOnDesk();
+
    //! Test importing files from a directory and moving one in
    void testImportFlow();
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,3 +1,4 @@
+#include <QPainter>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -988,4 +989,91 @@ void TestFile::testRemoveRestorePages()
    // the restored page still decodes to the same image
    QVERIFY(!max.getImage(0, false, restored, size, trueSize, bpp, false));
    QCOMPARE(restored.size(), before.size());
+}
+
+
+void TestFile::testJpegAnnotations()
+{
+   if (!QFile::exists("/usr/bin/exiftool"))
+      QSKIP("exiftool is not installed");
+
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   QImage img(80, 60, QImage::Format_RGB32);
+   img.fill(Qt::white);
+   QVERIFY(img.save(dir + "photo.jpg", "JPG"));
+
+   {
+      Filejpeg jf(dir, "photo.jpg", nullptr);
+      QVERIFY(jf.load() == nullptr);
+
+      QHash<int, QString> updates;
+      updates[File::Annot_author] = "An Author";
+      updates[File::Annot_title] = "A Title";
+      updates[File::Annot_ocr] = "line one\nline two";
+      QVERIFY(jf.putAnnot(updates) == nullptr);
+   }
+
+   // a fresh object reads the values back from the file itself
+   Filejpeg again(dir, "photo.jpg", nullptr);
+   QVERIFY(again.load() == nullptr);
+
+   QString text;
+   QVERIFY(again.getAnnot(File::Annot_author, text) == nullptr);
+   QCOMPARE(text, QString("An Author"));
+   QVERIFY(again.getAnnot(File::Annot_title, text) == nullptr);
+   QCOMPARE(text, QString("A Title"));
+
+   /* the ocr text spans lines; it used to be dropped entirely
+      because it had no exif tag to go to */
+   QVERIFY(again.getAnnot(File::Annot_ocr, text) == nullptr);
+   QVERIFY2(text.contains("line one"), qPrintable(text));
+   QVERIFY2(text.contains("line two"), qPrintable(text));
+}
+
+
+void TestFile::testJpegTransform()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   const QString dir = tmp.path() + "/";
+
+   /* left half black, right half white so a flip is visible */
+   QImage img(60, 40, QImage::Format_RGB32);
+   img.fill(Qt::white);
+   {
+      QPainter paint(&img);
+      paint.fillRect(0, 0, 30, 40, Qt::black);
+   }
+   QVERIFY(img.save(dir + "photo.jpg", "JPG"));
+
+   {
+      Filejpeg jf(dir, "photo.jpg", nullptr);
+      QVERIFY(jf.load() == nullptr);
+      QVERIFY(jf.transformPage(0, File::Transform_rotate90) == nullptr);
+   }
+
+   // the rotation lands on disk with swapped dimensions
+   QImage turned(dir + "photo.jpg");
+   QCOMPARE(turned.size(), QSize(40, 60));
+
+   {
+      Filejpeg jf(dir, "photo.jpg", nullptr);
+      QVERIFY(jf.load() == nullptr);
+      QVERIFY(jf.transformPage(0, File::Transform_rotate270) == nullptr);
+   }
+   QImage back(dir + "photo.jpg");
+   QCOMPARE(back.size(), QSize(60, 40));
+
+   // a horizontal flip swaps the dark and light halves
+   {
+      Filejpeg jf(dir, "photo.jpg", nullptr);
+      QVERIFY(jf.load() == nullptr);
+      QVERIFY(jf.transformPage(0, File::Transform_hflip) == nullptr);
+   }
+   QImage flipped(dir + "photo.jpg");
+   QVERIFY(qGray(flipped.pixel(5, 20)) > 128);    // now light on the left
+   QVERIFY(qGray(flipped.pixel(55, 20)) < 128);   // and dark on the right
 }

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -85,6 +85,13 @@ private slots:
    //! the file
    void testTransformImageCache();
 
+   //! jpeg annotations round-trip through exiftool, including the
+   //! multi-line ocr text
+   void testJpegAnnotations();
+
+   //! transformPage() on a jpeg rewrites the image on disk
+   void testJpegTransform();
+
    //! removePages then restorePages round-trips the page count without
    //! crashing (restorePages must open the file before reading chunks)
    void testRemoveRestorePages();

--- a/test/test_localbackend.cpp
+++ b/test/test_localbackend.cpp
@@ -1,0 +1,147 @@
+#include <QtTest/QtTest>
+#include <QTemporaryDir>
+
+#include "../localbackend.h"
+
+#include "test_localbackend.h"
+
+
+/* create a small file with known content */
+static void makeFile(const QString &path, const QByteArray &content)
+{
+   QFile f(path);
+   QVERIFY(f.open(QIODevice::WriteOnly));
+   f.write(content);
+}
+
+
+/* build a little repository:
+      a.max, b.pdf, .paperdesk (hidden), sub/c.jpg */
+static void makeRepo(const QString &root)
+{
+   makeFile(root + "/a.max", "max content");
+   makeFile(root + "/b.pdf", "pdf content");
+   makeFile(root + "/.paperdesk", "[Files]\n");
+   QVERIFY(QDir().mkpath(root + "/sub"));
+   makeFile(root + "/sub/c.jpg", "jpg content");
+}
+
+
+void TestLocalBackend::testRepositories()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   makeRepo(tmp.path());
+
+   LocalBackend be(QStringList() << tmp.path()
+                                 << tmp.path() + "/nosuch");
+   QList<RepositoryInfo> repos = be.listRepositories();
+   QCOMPARE(repos.size(), 2);
+   QCOMPARE(repos[0].name, QFileInfo(tmp.path()).fileName());
+   QCOMPARE(repos[0].path, tmp.path());
+   QVERIFY(repos[0].exists);
+   QVERIFY(!repos[1].exists);
+
+   QCOMPARE(be.rootPathForName(repos[0].name), tmp.path());
+   QCOMPARE(be.rootPathForName("nonexistent"), QString());
+}
+
+
+void TestLocalBackend::testBrowse()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   makeRepo(tmp.path());
+   QString repo = QFileInfo(tmp.path()).fileName();
+
+   LocalBackend be(QStringList() << tmp.path());
+
+   /* the recursive per-directory counts come from the file cache,
+      which the server builds at startup */
+   be.loadCacheForRepo(tmp.path());
+
+   // the root: the subdirectory first, then the files, dotfiles hidden
+   DirectoryListing root = be.browseDirectory(repo, "");
+   QVERIFY2(root.ok, qPrintable(root.error));
+   QCOMPARE(root.entries.size(), 3);
+   QCOMPARE(root.entries[0].name, QString("sub"));
+   QVERIFY(root.entries[0].isDir);
+   QCOMPARE(root.entries[0].count, 1);
+   QCOMPARE(root.entries[1].name, QString("a.max"));
+   QCOMPARE(root.entries[1].size, (qint64)11);
+   QVERIFY(!root.entries[1].isDir);
+   QCOMPARE(root.entries[2].name, QString("b.pdf"));
+
+   // a subdirectory
+   DirectoryListing sub = be.browseDirectory(repo, "sub");
+   QVERIFY(sub.ok);
+   QCOMPARE(sub.entries.size(), 1);
+   QCOMPARE(sub.entries[0].name, QString("c.jpg"));
+   QCOMPARE(sub.entries[0].path, QString("sub/c.jpg"));
+
+   // a missing directory and a missing repository report not-found
+   DirectoryListing bad = be.browseDirectory(repo, "nosuchdir");
+   QVERIFY(!bad.ok);
+   QVERIFY(bad.notFound);
+   DirectoryListing norepo = be.browseDirectory("nosuchrepo", "");
+   QVERIFY(!norepo.ok);
+}
+
+
+void TestLocalBackend::testReadFile()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   makeRepo(tmp.path());
+   QString repo = QFileInfo(tmp.path()).fileName();
+
+   LocalBackend be(QStringList() << tmp.path());
+
+   FileFetch got = be.readFile(repo, "a.max");
+   QVERIFY2(got.ok, qPrintable(got.error));
+   QCOMPARE(got.bytes, QByteArray("max content"));
+
+   FileFetch subFile = be.readFile(repo, "sub/c.jpg");
+   QVERIFY(subFile.ok);
+   QCOMPARE(subFile.bytes, QByteArray("jpg content"));
+
+   FileFetch missing = be.readFile(repo, "nosuch.max");
+   QVERIFY(!missing.ok);
+   QVERIFY(missing.notFound);
+}
+
+
+void TestLocalBackend::testContentType()
+{
+   QCOMPARE(Backend::contentTypeForPath("a.pdf"),
+            QString("application/pdf"));
+   QCOMPARE(Backend::contentTypeForPath("a.jpg"), QString("image/jpeg"));
+   QCOMPARE(Backend::contentTypeForPath("a.jpeg"), QString("image/jpeg"));
+   QCOMPARE(Backend::contentTypeForPath("a.max"),
+            QString("application/octet-stream"));
+   QCOMPARE(Backend::contentTypeForPath("noext"),
+            QString("application/octet-stream"));
+}
+
+
+void TestLocalBackend::testFileCache()
+{
+   QTemporaryDir tmp;
+   QVERIFY(tmp.isValid());
+   makeRepo(tmp.path());
+
+   LocalBackend be(QStringList() << tmp.path());
+   int count = be.loadCacheForRepo(tmp.path());
+   QCOMPARE(count, 3);
+   QCOMPARE(be.cacheCount(tmp.path()), 3);
+   QVERIFY(be.cacheBytes(tmp.path()) > 0);
+
+   const QList<CachedFile> &files = be.fileCacheFor(tmp.path());
+   QCOMPARE(files.size(), 3);
+   QStringList paths;
+   for (const CachedFile &f : files)
+      paths << f.path;
+   QVERIFY(paths.contains("a.max"));
+   QVERIFY(paths.contains("b.pdf"));
+   QVERIFY(paths.contains("sub/c.jpg"));
+}

--- a/test/test_localbackend.h
+++ b/test/test_localbackend.h
@@ -1,0 +1,35 @@
+#ifndef TEST_LOCALBACKEND_H
+#define TEST_LOCALBACKEND_H
+
+#include <QObject>
+
+#include "suite.h"
+
+/** Tests for LocalBackend, the in-process data source the server (and
+    local repositories) read from */
+class TestLocalBackend : public Suite
+{
+   Q_OBJECT
+public:
+   using Suite::Suite;
+
+private slots:
+   //! Repository listing reports existing and missing roots
+   void testRepositories();
+
+   //! Directory browsing lists dirs first, hides dotfiles and
+   //! reports unknown paths
+   void testBrowse();
+
+   //! Whole-file reads return the bytes, with 404-style errors for
+   //! missing files
+   void testReadFile();
+
+   //! Content types derive from the filename extension
+   void testContentType();
+
+   //! The file cache builds from a directory scan
+   void testFileCache();
+};
+
+#endif // TEST_LOCALBACKEND_H

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -1,10 +1,20 @@
 #include <QtTest/QtTest>
+#include <QBuffer>
+#include <QPainter>
+
+#include "../config.h"
 
 #include <pwd.h>
 #include <unistd.h>
 
 #include "../filemax.h"
+#include "../imageadjust.h"
 #include "../utils.h"
+
+extern "C" {
+   #define HAVE_STDINT_H 1
+   #include "../md5.h"
+   };
 #include "test.h"
 
 #include "test_utils.h"
@@ -455,4 +465,93 @@ void TestUtils::testUserName()
    struct passwd *pw = getpwuid(getuid());
    QVERIFY(pw != nullptr);
    QCOMPARE(utilUserName(), QString(pw->pw_name));
+}
+
+
+void TestUtils::testMd5()
+{
+   unsigned char digest[16];
+
+   // RFC 1321 appendix test vectors
+   md5_buffer("", 0, digest);
+   QCOMPARE(QByteArray((const char *)digest, 16).toHex(),
+            QByteArray("d41d8cd98f00b204e9800998ecf8427e"));
+
+   md5_buffer("abc", 3, digest);
+   QCOMPARE(QByteArray((const char *)digest, 16).toHex(),
+            QByteArray("900150983cd24fb0d6963f7d28e17f72"));
+
+   // long enough to exercise the block loop (> 64 bytes)
+   QByteArray many(1000, 'a');
+   md5_buffer(many.constData(), many.size(), digest);
+   QCOMPARE(QByteArray((const char *)digest, 16).toHex(),
+            QByteArray("cabe45dcc9ae5b66ba86600cca6b8ba8"));
+}
+
+
+void TestUtils::testJpegThumbnail()
+{
+   /* a picture large enough that /CONFIG_preview_scale is still a
+      few pixels across */
+   QImage img(480, 240, QImage::Format_RGB32);
+   img.fill(Qt::white);
+   QPainter paint(&img);
+   paint.fillRect(0, 0, 240, 240, Qt::black);
+   paint.end();
+
+   QByteArray jpeg;
+   QBuffer buf(&jpeg);
+   QVERIFY(buf.open(QIODevice::WriteOnly));
+   QVERIFY(img.save(&buf, "JPG"));
+
+   byte *dest = nullptr;
+   int destSize = 0;
+   cpoint size;
+   int valid = jpeg_thumbnail((byte *)jpeg.data(), jpeg.size(), &dest,
+                              &destSize, &size);
+   QVERIFY(valid != 0);
+   QVERIFY(dest != nullptr);
+   QCOMPARE(size.x, 480 / CONFIG_preview_scale);
+   QCOMPARE(size.y, 240 / CONFIG_preview_scale);
+   QVERIFY(destSize > 0);
+   free(dest);
+
+   // garbage input is rejected rather than crashing
+   QByteArray junk(200, 'x');
+   dest = nullptr;
+   QCOMPARE(jpeg_thumbnail((byte *)junk.data(), junk.size(), &dest,
+                           &destSize, &size), 0);
+}
+
+
+void TestUtils::testImageAdjustWhiten()
+{
+   /* a "scan" with a dingy grey background and dark text strokes */
+   QImage img(200, 100, QImage::Format_RGB32);
+   img.fill(QColor(200, 198, 190));
+   QPainter paint(&img);
+   paint.setPen(QPen(QColor(25, 25, 25), 2));
+   for (int i = 0; i < 8; i++)
+      paint.drawLine(10, 12 + i * 10, 190, 12 + i * 10);
+   paint.end();
+
+   ImageAdjust::apply(img, ImageAdjust::Adjust_whiten);
+
+   // the background is stretched to (near) white...
+   QVERIFY(qGray(img.pixel(5, 5)) > 240);
+   QVERIFY(qGray(img.pixel(195, 95)) > 240);
+   // ...while the text stays dark
+   QVERIFY(qGray(img.pixel(100, 12)) < 100);
+
+   QCOMPARE(ImageAdjust::name(ImageAdjust::Adjust_whiten),
+            QString("Whiten background"));
+   QCOMPARE(ImageAdjust::suffix(ImageAdjust::Adjust_whiten),
+            QString("_white"));
+
+   // formats with nothing to do are left alone
+   QImage mono(50, 50, QImage::Format_Mono);
+   mono.fill(1);
+   QImage before = mono;
+   ImageAdjust::apply(mono, ImageAdjust::Adjust_whiten);
+   QCOMPARE(mono, before);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -32,6 +32,15 @@ private slots:
 
    //! Test preview encode/decode against the greyscale test image
    void testPreviewFromJpeg();
+
+   //! md5_buffer() produces the RFC 1321 test-vector digests
+   void testMd5();
+
+   //! jpeg_thumbnail() scales a JPEG down through the epeg decoder
+   void testJpegThumbnail();
+
+   //! whitenBackground() cleans a dingy scan without losing the text
+   void testImageAdjustWhiten();
 private:
    // Create files in a temporary directory structure used for testing
    void createDirStructure(QTemporaryDir& tmp);


### PR DESCRIPTION
This adds code-coverage measurement and uses its report to direct a round
of new tests, which in turn surfaced three real bugs, fixed here.

Note this branch is based on the remote-repository series (remote-ops),
so those commits appear here too until that series merges; the seven
commits from 'test: Add code-coverage measurement' onwards are the new
material.

'make coverage' shadow-builds the test binary with gcov instrumentation
in build-coverage/, runs the whole suite headless and writes an annotated
per-file HTML report plus a text summary via gcovr (the workflow is
described in doc/testing.rst). The first report showed 60.8% of lines
covered and pointed at the gaps the new tests fill: md5, the epeg
thumbnail decoder, image adjustment, jpeg annotations and transforms,
LocalBackend, moving a stack around the desk, and group moves to a
folder both locally and against a server, driven through the UI.

The bugs the new tests caught:

- filejpeg's annotation tag table had four entries for five annotation
  types, so the ocr text indexed past the end and was silently dropped;
  it now maps to the exif UserComment tag
- load_annot() asked exiftool for Author but annotations are written to
  Artist, so a jpeg's author never survived a reload
- Desktopview::dataChanged() did not match the QListView virtual's
  signature (missing the roles argument) so it never ran, leaving stack
  positions stale on screen after undoing or redoing a move

Line coverage ends at 62.8% with 202 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuJ6u4Q43PFHDsNmhRQcA