### PR TITLE
Make remote repositories fully functional

### DIFF
--- a/desk.cpp
+++ b/desk.cpp
@@ -124,7 +124,10 @@ Desk::Desk(const QString &dirPath, const QString &trashPath, bool do_readDesk)
 
 Desk::~Desk ()
    {
-   if (_dir != QString() && _do_writeDesk && !writeDesk ())
+   /* a remote desk uploads on write, so only bother when something
+      actually changed (flushes cover the normal case anyway) */
+   if (_dir != QString() && _do_writeDesk && (!_isRemote || _dirty)
+       && !writeDesk ())
       printf ("couldn't write maxdesk.ini\n");
    while (!_files.isEmpty ())
       delete _files.takeFirst ();
@@ -213,6 +216,19 @@ void Desk::addFiles(const QString &dirPath, Measure *meas)
          qInfo() << "Desk::addFiles: backend error:" << listing.error;
          return;
       }
+
+      if (_isRemote) {
+         /* the server's desk file carries the shared layout; read it
+          * first (validated against the listing) so files take their
+          * shared positions, then add anything it doesn't mention */
+         fetchRemoteDeskFile();
+         QSet<QString> names;
+         for (const DirectoryEntry &e : listing.entries)
+            if (!e.isDir)
+               names.insert(e.name);
+         readDesk(true, &names);
+      }
+
       for (const DirectoryEntry &e : listing.entries) {
          if (e.isDir)
             continue;
@@ -360,6 +376,31 @@ File *Desk::createFile (const QString &dir, const QString fname)
    }
 
 
+void Desk::setBackend (Backend *backend, const QString &repoName,
+                       bool isRemote)
+   {
+   _backend = backend;
+   _repoName = repoName;
+   _isRemote = isRemote;
+   _remote = dynamic_cast<RemoteBackend *> (backend);
+   }
+
+
+QString Desk::remoteRelDir (void) const
+   {
+   /* _dir is the synthetic desk path and _rootDir the repo root, both
+    * with a trailing slash; the part below the root locates this desk
+    * inside the repository */
+   QString rel = _dir;
+
+   if (rel.startsWith (_rootDir))
+      rel = rel.mid (_rootDir.length ());
+   if (rel.endsWith ('/'))
+      rel.chop (1);
+   return rel;
+   }
+
+
 QString Desk::remoteCacheDir (void)
    {
    RemoteBackend *remote = dynamic_cast<RemoteBackend *> (_backend);
@@ -367,15 +408,57 @@ QString Desk::remoteCacheDir (void)
    if (!remote)
       return QString ();
 
-   /* _dir is the synthetic desk path and _rootDir the repo root, both
-    * with a trailing slash; the part below the root locates this desk
-    * inside the repository */
-   QString rel = _dir;
-   if (rel.startsWith (_rootDir))
-      rel = rel.mid (_rootDir.length ());
-   if (rel.endsWith ('/'))
-      rel.chop (1);
-   return remote->cacheDirFor (_repoName, rel);
+   return remote->cacheDirFor (_repoName, remoteRelDir ());
+   }
+
+
+void Desk::fetchRemoteDeskFile (void)
+   {
+   if (!_remote)
+      return;
+
+   QString rel = remoteRelDir ();
+   QString path = rel.isEmpty () ? QString (DESK_FNAME)
+                                 : rel + "/" + DESK_FNAME;
+
+   /* a failure just means the server has no desk file yet (or is
+      unreachable, in which case any cached copy is used) */
+   _remote->ensureCachedFile (_repoName, path);
+   }
+
+
+bool Desk::uploadDeskFile (void)
+   {
+   if (!_remote)
+      return false;
+
+   QFile in (remoteCacheDir () + "/" + DESK_FNAME);
+   if (!in.open (QIODevice::ReadOnly))
+      return false;
+   QByteArray bytes = in.readAll ();
+   in.close ();
+
+   QString rel = remoteRelDir ();
+   QString path = rel.isEmpty () ? QString (DESK_FNAME)
+                                 : rel + "/" + DESK_FNAME;
+   QString etag;
+   if (!_remote->uploadFile (_repoName, path, bytes, nullptr, &etag,
+                             /*overwrite=*/true))
+      {
+      qInfo () << "Desk: could not upload desk file:"
+               << _remote->lastError ();
+      return false;
+      }
+
+   /* record the validator so the next fetch costs a 304 */
+   if (!etag.isEmpty ())
+      {
+      QFile ef (in.fileName () + ".etag");
+
+      if (ef.open (QIODevice::WriteOnly))
+         ef.write (etag.toUtf8 ());
+      }
+   return true;
    }
 
 
@@ -398,27 +481,42 @@ bool Desk::addToExistingFile (QString &fname)
    return false;
 }
 
-void Desk::readDesk (bool read_sizes)
+void Desk::readDesk (bool read_sizes, const QSet<QString> *allowed)
    {
    QFile oldfile;
-   QFile file (_dir + DESK_FNAME);
    QString fname;
 
-   // if there is a maxdesk.ini file, rename it to the official name
-   fname = _dir + "/maxdesk.ini";
-   oldfile.setFileName (fname);
-   if (!oldfile.exists ())
+   /* a remote desk's file lives in the backend's cache (fetched from
+      the server); the legacy maxdesk.ini renaming only applies to a
+      real local directory */
+   QString deskDir = _dir;
+   if (_isRemote)
       {
-      fname = _dir + "/MaxDesk.ini";
-      oldfile.setFileName (fname);
+      deskDir = remoteCacheDir ();
+      if (deskDir.isEmpty ())
+         return;
+      deskDir += "/";
       }
-   if (oldfile.exists ())
+   QFile file (deskDir + DESK_FNAME);
+
+   if (!_isRemote)
       {
-      // if we have the official file, just remove this one
-      if (file.exists ())
-         oldfile.remove ();
-      else
-         oldfile.rename (_dir + DESK_FNAME);
+      // if there is a maxdesk.ini file, rename it to the official name
+      fname = _dir + "/maxdesk.ini";
+      oldfile.setFileName (fname);
+      if (!oldfile.exists ())
+         {
+         fname = _dir + "/MaxDesk.ini";
+         oldfile.setFileName (fname);
+         }
+      if (oldfile.exists ())
+         {
+         // if we have the official file, just remove this one
+         if (file.exists ())
+            oldfile.remove ();
+         else
+            oldfile.rename (_dir + DESK_FNAME);
+         }
       }
 
    QTextStream stream (&file);
@@ -444,8 +542,21 @@ void Desk::readDesk (bool read_sizes)
          {
          QString fname = line.left (pos);
 
-         QFile test (_dir + fname);
-         if (!test.exists ())
+         /* only accept entries which really exist: on disk for a
+            local desk, in the caller's listing for a remote one */
+         if (allowed)
+            {
+            if (!allowed->contains (fname))
+               continue;
+            }
+         else
+            {
+            QFile test (_dir + fname);
+            if (!test.exists ())
+               continue;
+            }
+
+         if (findFile (fname))
             continue;
 
          if (!addToExistingFile (fname))
@@ -468,16 +579,31 @@ bool Desk::writeDesk (void)
    QFile file;
    QString fname;
 
-   // remove any old file
-   fname = _dir + "/maxdesk.ini";
-   file.setFileName (fname);
-   if (file.exists ())
-      file.remove ();
-   fname = _dir + "/MaxDesk.ini";
-   file.setFileName (fname);
-   if (file.exists ())
-      file.remove ();
-   file.setFileName (_dir + DESK_FNAME);
+   /* a remote desk's file is written to the cache and pushed to the
+      server below */
+   QString deskDir = _dir;
+   if (_isRemote)
+      {
+      deskDir = remoteCacheDir ();
+      if (deskDir.isEmpty ())
+         return false;
+      deskDir += "/";
+      QDir ().mkpath (deskDir);
+      }
+
+   if (!_isRemote)
+      {
+      // remove any old file
+      fname = _dir + "/maxdesk.ini";
+      file.setFileName (fname);
+      if (file.exists ())
+         file.remove ();
+      fname = _dir + "/MaxDesk.ini";
+      file.setFileName (fname);
+      if (file.exists ())
+         file.remove ();
+      }
+   file.setFileName (deskDir + DESK_FNAME);
    if (file.exists ())
       file.remove ();
 
@@ -504,6 +630,13 @@ bool Desk::writeDesk (void)
    utilSetGroup(file.fileName());
 
    _dirty = false; // we are clean again
+
+   /* push the layout to the server so every client shares it */
+   if (_isRemote)
+      {
+      file.close ();
+      return uploadDeskFile ();
+      }
    return true;
    }
 

--- a/desk.cpp
+++ b/desk.cpp
@@ -48,6 +48,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "backend.h"
 #include "desk.h"
 #include "file.h"
+#include "remotebackend.h"
 #include "filemax.h"
 #include "fileother.h"
 #include "filepdf.h"
@@ -340,14 +341,41 @@ File *Desk::createFile (const QString &dir, const QString fname)
 
    /* Remote-backed desk: the dir/fname combination is a synthetic
     * URL path that the Filemax/Filepdf/Filejpeg loaders can't open
-    * via QFile.  Use the Fileother stub instead; the Backend's
-    * thumbnail fetch populates the pixmap later via setThumbnail.
-    * Page viewing for remote files needs its own Backend-driven
-    * loader and isn't wired up yet. */
+    * via QFile.  Point the file at this desk's slot in the backend's
+    * disk cache instead, so the real file classes can parse the
+    * bytes once Desktopmodel::ensureContent() has fetched them.  The
+    * Backend's thumbnail fetch still populates the grid pixmap via
+    * setThumbnail without any download.  If the cache location is
+    * unknown (no server id), fall back to the Fileother stub. */
    if (_isRemote)
-      type = File::Type_other;
+      {
+      QString cacheDir = remoteCacheDir ();
+      if (cacheDir.isEmpty ())
+         return File::createFile (dir, fname, this, File::Type_other);
+      QDir ().mkpath (cacheDir);
+      return File::createFile (cacheDir + "/", fname, this, type);
+      }
 
    return File::createFile (dir, fname, this, type);
+   }
+
+
+QString Desk::remoteCacheDir (void)
+   {
+   RemoteBackend *remote = dynamic_cast<RemoteBackend *> (_backend);
+
+   if (!remote)
+      return QString ();
+
+   /* _dir is the synthetic desk path and _rootDir the repo root, both
+    * with a trailing slash; the part below the root locates this desk
+    * inside the repository */
+   QString rel = _dir;
+   if (rel.startsWith (_rootDir))
+      rel = rel.mid (_rootDir.length ());
+   if (rel.endsWith ('/'))
+      rel.chop (1);
+   return remote->cacheDirFor (_repoName, rel);
    }
 
 

--- a/desk.h
+++ b/desk.h
@@ -33,6 +33,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "qsize.h"
 #include "qstring.h"
 #include <QPixmap>
+#include <QPointer>
+#include <QSet>
 
 #include "err.h"
 
@@ -105,13 +107,11 @@ public:
     *  on the Diritem in Dirmodel.  @p repoName is the basename the
     *  backend uses to identify this repository.  @p isRemote tells
     *  us whether file paths handed to addFile are real on the local
-    *  filesystem; when false we force every File entry into the
-    *  Fileother stub (no local open is attempted) and skip the
-    *  .maxdesk write at destruction. */
+    *  filesystem; when false, files live in the backend's disk cache
+    *  and the desk file is fetched from and written back to the
+    *  server. */
    void setBackend(Backend *backend, const QString &repoName,
-                   bool isRemote = false)
-       { _backend = backend; _repoName = repoName; _isRemote = isRemote;
-         if (isRemote) _do_writeDesk = false; }
+                   bool isRemote = false);
 
    /** Backend currently attached to this desk (nullptr for local). */
    Backend *backend() const { return _backend; }
@@ -144,14 +144,22 @@ public:
    void addMatches(const QString &dirPath, const QStringList& matche,
                    Measure *meas);
 
-   /** read the maxdesk.ini file which contains positional and size
+   /** read the .paperdesk file which contains positional and size
       information for each stack in the directory
 
       \param read_sizes    read the size information (otherwise it is
-                           ignored and will be recalculated */
-   void readDesk (bool read_sizes = true);
+                           ignored and will be recalculated
+      \param allowed       if non-null, only create entries whose
+                           filename is in this set (used for remote
+                           desks, where the server listing is the
+                           truth and a local existence check is
+                           meaningless) */
+   void readDesk (bool read_sizes = true,
+                  const QSet<QString> *allowed = nullptr);
 
-   /** write the maxdesk.ini file */
+   /** write the .paperdesk file; for a remote desk this writes the
+       cached copy and uploads it to the server so every client sees
+       the same layout */
    bool writeDesk (void);
 
    // allocate and zero a new file structure
@@ -176,6 +184,18 @@ public:
    /** Local cache directory for this desk's files when the backend is
     *  remote (no trailing slash), or empty when there is none */
    QString remoteCacheDir (void);
+
+   /** The desk's directory relative to the repository root, with no
+    *  surrounding slashes ("" for the root itself) */
+   QString remoteRelDir (void) const;
+
+   /** Fetch the server's copy of the desk file into the cache; a
+    *  missing file just means a fresh directory */
+   void fetchRemoteDeskFile (void);
+
+   /** Upload the cached desk file to the server so other clients see
+    *  this layout */
+   bool uploadDeskFile (void);
 
    /** given a filename, try to make it unique by adding numbers, etc.
 
@@ -633,6 +653,10 @@ private:
    Backend *_backend = nullptr;  //!< Optional data source; nullptr = local QDir
    QString _repoName;  //!< Repository name when _backend is set
    bool _isRemote = false;  //!< Backend is remote: skip local file ops
+
+   /** The backend as a RemoteBackend, guarded so a desk destroyed
+    *  after the backend does not touch a dangling pointer */
+   QPointer<class RemoteBackend> _remote;
    QPoint _pos;        //!< next position for a file to appear
    int _rightMargin;   //!< right margin for items
    int _debug_level;     //!< the debug level to use for max debugging

--- a/desk.h
+++ b/desk.h
@@ -117,6 +117,10 @@ public:
    Backend *backend() const { return _backend; }
    QString repoName() const { return _repoName; }
 
+   /** True when the attached backend is remote, so files here are
+    *  cached copies (or not yet fetched) rather than originals. */
+   bool isRemote() const { return _isRemote; }
+
    /** Non-owning view of this desk's files; used by Desktopmodel to
     *  iterate when scheduling async thumbnail fetches. */
    const QList<File *> &files() const { return _files; }
@@ -168,6 +172,10 @@ public:
       \param dir     directory
       \param fname   file name (the file extension determines the type) */
    File *createFile (const QString &dir, const QString fname);
+
+   /** Local cache directory for this desk's files when the backend is
+    *  remote (no trailing slash), or empty when there is none */
+   QString remoteCacheDir (void);
 
    /** given a filename, try to make it unique by adding numbers, etc.
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -855,6 +855,17 @@ err_info *Desktopmodel::cancelScan (void)
    _scan_desk = 0;
    _scan_file = 0;
 
+   /* a cancelled scan into a remote desk was never uploaded, so
+      remove only the cached copy and the row - the server has
+      nothing to delete */
+   if (ind.isValid () && getFile (ind) && remoteForFile (getFile (ind)))
+      {
+      err_info *e = getFile (ind)->remove ();
+
+      removeRow (ind.row (), ind.parent ());
+      return e;
+      }
+
    // remove the stack in the maxdesk if it is there
    return opDeleteStack (ind);
    }
@@ -865,12 +876,18 @@ err_info *Desktopmodel::confirmScan (QString *fname)
 //    qDebug () << "Desktopmodel::confirmScan";
    Q_ASSERT (_scan_desk && _scan_file);
 
+   // flush the item
+   CALL (_scan_file->flush ());
+
+   /* a stack scanned into a remote desk exists only in the local
+      cache so far; push the finished file to the server (which may
+      rename it on a clash, updating the file object) */
+   if (remoteForFile (_scan_file))
+      CALL (uploadScanStack (_scan_file));
+
    if (fname)
       *fname = _scan_file->filename ();
    QModelIndex ind = index (_scan_file->filename (), _scan_parent);
-
-   // flush the item
-   CALL (_scan_file->flush ());
 
 // this comment might not be relevant since Desktopmodel was enhanced to have multiple maxdesks:
    /* at this point, although we have just flushed the item, it is possible

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -35,6 +35,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QDateTime>
 #include <QDebug>
+#include <QFile>
 #include <QFileInfo>
 #include <QIcon>
 #include <QKeyEvent>
@@ -730,6 +731,19 @@ void Desktopmodel::buildItem (QModelIndex index)
    {
 //    qDebug () << "buildItem" << index;
    File *f = getFile (index);
+
+   /* A remote stack that hasn't been fetched yet has nothing local to
+      load.  Mark it valid so the pixmap-update queue doesn't retry it
+      endlessly; its page count stays zero, which is how
+      ensureContent() knows a download is still needed.  The
+      server-rendered thumbnail stands in for the preview. */
+   Desk *fdesk = f->desk ();
+   if (fdesk && fdesk->isRemote () && !QFile::exists (f->pathname ()))
+      {
+      f->setValid (true);
+      emit dataChanged (index, index);
+      return;
+      }
 
    // if we can't load it, still mark it as valid otherwise we will keep loading it
    if (f->load ())
@@ -1785,6 +1799,9 @@ err_info *Desktopmodel::getImage (const QModelIndex &ind, int pnum, bool do_scal
    _modelconv->assertIsSource (0, &ind, 0);
    File *f = getFile (ind);
 
+   // a remote stack may not have been fetched yet
+   CALL (const_cast<Desktopmodel *> (this)->ensureContent (ind));
+
    if (!f->valid())
       return err_make(ERRFN, ERR_file_not_loaded_yet1,
                       qPrintable(f->filename()));
@@ -1879,6 +1896,9 @@ err_info *Desktopmodel::getImagePreviewSizes (const QModelIndex &ind, int pagenu
    int bpp, csize, num_bytes;
    QDateTime dt;
 
+   // a remote stack may not have been fetched yet
+   CALL (const_cast<Desktopmodel *> (this)->ensureContent (ind));
+
    if (!f->valid())
       return err_make(ERRFN, ERR_file_not_loaded_yet1,
                       qPrintable(f->filename()));
@@ -1944,8 +1964,12 @@ err_info *Desktopmodel::getImagePreview (const QModelIndex &ind, int pagenum,
    File *f = getFile (ind);
    err_info *err;
 
-   err = f->getPreviewPixmap (pagenum == -1 ? f->pagenum () : pagenum,
-      pixmap, blank);
+   // a remote stack may not have been fetched yet
+   err = const_cast<Desktopmodel *> (this)->ensureContent (ind);
+
+   if (!err)
+      err = f->getPreviewPixmap (pagenum == -1 ? f->pagenum () : pagenum,
+         pixmap, blank);
    if (err)
       pixmap = err->errnum == ERR_cannot_open_file1 ? _no_access : _unknown;
    return err;
@@ -1956,6 +1980,9 @@ err_info *Desktopmodel::getPageText (const QModelIndex &ind, int pagenum, QStrin
    {
    File *f = getFile (ind);
    err_info *err;
+
+   // a remote stack may not have been fetched yet
+   CALL (ensureContent (ind));
 
    if (!f->valid())
       return err_make(ERRFN, ERR_file_not_loaded_yet1,

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -1512,8 +1512,17 @@ void Desktopmodel::scheduleRemoteThumbnails(Desk *desk,
    if (!_connectedBackends.contains(backend)) {
       connect(backend, &RemoteBackend::thumbnailReady,
               this, &Desktopmodel::onThumbnailReady);
+      /* queued so a change arriving inside a nested event loop (e.g.
+         while a sync request waits) is handled on a clean turn */
+      connect(backend, &RemoteBackend::stackEvent,
+              this, &Desktopmodel::onRemoteStackEvent,
+              Qt::QueuedConnection);
       _connectedBackends.insert(backend);
    }
+
+   /* follow other clients' changes to this repository */
+   backend->subscribeEvents(repoName);
+
    for (File *f : desk->files()) {
       QString path = dirInRepo.isEmpty()
                          ? f->filename()
@@ -1530,6 +1539,42 @@ void Desktopmodel::scheduleRemoteThumbnails(Desk *desk,
                                                /*page=*/1,
                                                /*size=*/"small");
       _pendingThumbnails.insert(t, f);
+   }
+}
+
+
+void Desktopmodel::onRemoteStackEvent(const QString &repo,
+                                      const QString &op,
+                                      const QString &path,
+                                      const QString &name)
+{
+   UNUSED (op);
+   UNUSED (name);
+   RemoteBackend *remote = qobject_cast<RemoteBackend *>(sender());
+   if (!remote)
+      return;
+
+   /* whatever happened, the cached copy of the stack is suspect */
+   remote->invalidateCachedFile(repo, path);
+
+   /* refresh any shown desk for the affected directory so adds,
+      removes and renames appear; content-only changes come back via
+      the re-fetched thumbnails and revalidation on next open */
+   int slash = path.lastIndexOf('/');
+   QString dirInRepo = slash > 0 ? path.left(slash) : "";
+   for (Desk *desk : _desks) {
+      if (desk->backend() != remote || desk->repoName() != repo)
+         continue;
+      if (remoteRelDir(desk, desk->dir()) != dirInRepo)
+         continue;
+      if (desk == _scan_desk)
+         continue;         // never yank a desk we are scanning into
+
+      QString dir = desk->dir();
+      if (dir.endsWith('/'))
+         dir.chop(1);
+      refresh(dir);
+      scheduleRemoteThumbnails(desk, remote, repo, dirInRepo);
    }
 }
 

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -106,6 +106,9 @@ class Desktopmodel : public QAbstractItemModel
    friend class UCAddRepository;
    friend class UCRemoveRepository;
 
+   // the remote-operation tests drive opXxx directly
+   friend class TestSearchServer;
+
 public:
    Desktopmodel(QObject *parent);
    ~Desktopmodel();
@@ -1022,6 +1025,16 @@ private:
     *  leading slash (e.g. "sub/dir/stack.max"), used as the {path} in
     *  the server's per-stack URLs. */
    QString remoteStackPath(Desk *desk, File *file) const;
+
+   /** The RemoteBackend behind a file's desk, or nullptr when the
+    *  file is local (or detached).  Ops use this to decide whether to
+    *  route a mutation to the server. */
+   class RemoteBackend *remoteForFile(File *file) const;
+
+   /** A directory path relative to a remote desk's repository root:
+    *  desk->rootDir() and any surrounding slashes are stripped, so
+    *  the repo root itself comes back as "". */
+   QString remoteRelDir(Desk *desk, QString dir) const;
 
    /** Re-fetch a single stack's thumbnail from the server after its
     *  content changed (e.g. a rotation) and refresh the view. */

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1106,6 +1106,17 @@ public:
    err_info *getImage (const QModelIndex &ind, int pnum, bool do_scale,
                   QImage &imagep, QSize &Size, QSize &trueSize, int &bpp, bool blank = false) const;
 
+   /** Make sure a stack's page content is available locally.  For a
+       local desk this is a no-op (buildItem() already loads files as
+       they are shown).  For a remote desk it downloads the stack's
+       file into the backend's disk cache (revalidating a cached copy
+       cheaply) and parses it, so pagecount(), getImage() and friends
+       work just as they do locally.  Call before reading pages.
+
+      \param ind    model index of stack
+      \returns error, or NULL if the content is ready */
+   err_info *ensureContent (const QModelIndex &ind);
+
    /** gets an image of a page scaled to the exact requested size, using
        either the preview or full image. Returns a pixmap which is first freed
        if non-null.

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1131,6 +1131,16 @@ public:
    err_info *getImage (const QModelIndex &ind, int pnum, bool do_scale,
                   QImage &imagep, QSize &Size, QSize &trueSize, int &bpp, bool blank = false) const;
 
+   /** OCR one page of a stack and return the text.  A remote stack
+       is OCRed by the server (which stores the text in the stack's
+       ocr annotation); a local one uses the local OCR engine.
+
+      \param ind      model index of stack
+      \param pagenum  0-based page number
+      \param text     returns the recognised text
+      \returns error, or NULL if ok */
+   err_info *ocrPage (const QModelIndex &ind, int pagenum, QString &text);
+
    /** Make sure a stack's page content is available locally.  For a
        local desk this is a no-op (buildItem() already loads files as
        they are shown).  For a remote desk it downloads the stack's

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1036,6 +1036,12 @@ private:
     *  the repo root itself comes back as "". */
    QString remoteRelDir(Desk *desk, QString dir) const;
 
+   /** Push a freshly-scanned stack's cached file to the server.  On a
+    *  name clash the server picks a new name and the file object is
+    *  renamed to match.  The server's validator is recorded so the
+    *  next open revalidates instead of downloading. */
+   err_info *uploadScanStack(File *f);
+
    /** Re-fetch a single stack's thumbnail from the server after its
     *  content changed (e.g. a rotation) and refresh the view. */
    void refreshRemoteThumbnail(Desk *desk, class RemoteBackend *backend,

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1008,6 +1008,12 @@ private slots:
     *  repaints. */
    void onThumbnailReady(quint64 token, const QByteArray &jpegBytes);
 
+   /** Another client changed a stack in a remote repository: drop
+    *  the suspect cached copy and refresh any desk showing the
+    *  affected directory. */
+   void onRemoteStackEvent(const QString &repo, const QString &op,
+                           const QString &path, const QString &name);
+
 private:
    /** Issue async thumbnail fetches for every file in @p desk via
     *  the provided RemoteBackend.  No-op if @p backend is null.

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -36,6 +36,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
+#include <QJsonObject>
 #include <QMimeData>
 #include <QProcess>
 #include <QUrl>
@@ -535,6 +536,32 @@ err_info *Desktopmodel::opUpdateAnnot (QModelIndex &ind, QHash<int, QString> &up
 
    if (f)
       {
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *desk = f->desk ();
+         QJsonObject wire;
+
+         for (auto it = updates.constBegin (); it != updates.constEnd ();
+              ++it)
+            wire [File::annotWireName ((File::e_annot)it.key ())]
+                  = it.value ();
+         if (!remote->updateAnnotations (desk->repoName (),
+                                         remoteStackPath (desk, f), wire))
+            return err_make (ERRFN, ERR_remote_op_failed2, "annotation",
+                             qPrintable (remote->lastError ()));
+
+         /* mirror onto the parsed cached copy so the annotations pane
+            shows the new values without a refetch */
+         if (f->remoteChecked ())
+            {
+            f->putAnnot (updates);
+            f->flush ();
+            }
+         return NULL;
+         }
+
       f->putAnnot (updates);
       f->flush ();
       }

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -45,6 +45,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "desktopmodel.h"
 #include "desk.h"
 #include "file.h"
+#include "ocr.h"
 #include "op.h"
 #include "remotebackend.h"
 #include "utils.h"
@@ -1023,6 +1024,53 @@ void Desktopmodel::refreshRemoteThumbnail (Desk *desk, RemoteBackend *backend,
    quint64 token = backend->fetchThumbnailAsync (desk->repoName (),
          remoteStackPath (desk, file), /*page=*/1, /*size=*/"small");
    _pendingThumbnails.insert (token, file);
+   }
+
+
+err_info *Desktopmodel::ocrPage (const QModelIndex &ind, int pagenum,
+      QString &text)
+   {
+   File *f = getFile (ind);
+
+   if (!f)
+      return NULL;
+
+   RemoteBackend *remote = remoteForFile (f);
+   if (remote)
+      {
+      Desk *desk = f->desk ();
+
+      if (!remote->ocrPage (desk->repoName (), remoteStackPath (desk, f),
+                            pagenum + 1, &text))
+         return err_make (ERRFN, ERR_remote_op_failed2, "ocr",
+                          qPrintable (remote->lastError ()));
+
+      /* the server stored the text in the stack's ocr annotation;
+         mirror it onto the parsed cached copy */
+      if (f->remoteChecked ())
+         {
+         QHash<int, QString> updates;
+
+         updates [File::Annot_ocr] = text;
+         f->putAnnot (updates);
+         f->flush ();
+         }
+      return NULL;
+      }
+
+   CALL (ensureContent (ind));
+
+   QImage image;
+   QSize size, trueSize;
+   int bpp;
+   CALL (getImage (ind, pagenum, false, image, size, trueSize, bpp));
+
+   err_info *err;
+   Ocr *ocr = Ocr::getOcr (err);
+
+   if (!ocr)
+      return err;
+   return ocr->imageToText (image, text);
    }
 
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -243,7 +243,24 @@ err_info *Desktopmodel::opDeleteStacks (QModelIndexList &list, QModelIndex paren
 //    _model_invalid = true;
    foreach (ind, list) if (getFile (ind))
       {
-      CALLB (getFile (ind)->remove ());
+      File *f = getFile (ind);
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *fdesk = f->desk ();
+         QString stackPath = remoteStackPath (fdesk, f);
+
+         if (!remote->deleteStack (fdesk->repoName (), stackPath))
+            {
+            e = err_make (ERRFN, ERR_remote_op_failed2, "delete",
+                          qPrintable (remote->lastError ()));
+            break;
+            }
+         remote->invalidateCachedFile (fdesk->repoName (), stackPath);
+         }
+      else
+         CALLB (f->remove ());
       del_list << ind;
       }
 
@@ -268,6 +285,51 @@ err_info *Desktopmodel::opTrashStacks (QModelIndexList &list, QModelIndex parent
 
 //    savePersistentIndexes ();
 //    emit layoutAboutToBeChanged();
+
+   RemoteBackend *remote = desk
+         ? dynamic_cast<RemoteBackend *> (desk->backend ()) : nullptr;
+
+   if (remote)
+      {
+      /* Trash and move-to-dir both become a server-side move; the
+         shared trash is a directory at the repository root.  The undo
+         record keeps the synthetic absolute path so the round-trip
+         through opUntrashStacks() can find it again. */
+      if (dest.isEmpty ())
+         dest = desk->rootDir () + RemoteBackend::trashDirName ();
+      if (!dest.startsWith (desk->rootDir ()))
+         return err_make (ERRFN, ERR_cannot_move_between_repositories);
+      QString destRel = remoteRelDir (desk, dest);
+
+      foreach (ind, list)
+         {
+         if (!ind.isValid ())
+            continue;
+         File *f = getFile (ind);
+         QString stackPath = remoteStackPath (desk, f);
+         QString finalName;
+
+         if (!remote->moveStack (desk->repoName (), stackPath, destRel,
+                                 copy, &finalName))
+            {
+            e = err_make (ERRFN, ERR_remote_op_failed2, "move",
+                          qPrintable (remote->lastError ()));
+            break;
+            }
+         if (!copy)
+            remote->invalidateCachedFile (desk->repoName (), stackPath);
+         del_list << ind;
+         trashlist << finalName;
+         }
+      if (!copy)
+         {
+         sortForDelete (del_list);
+         foreach (ind, del_list)
+            removeRows (ind.row (), 1, parent);
+         }
+      addFilesToDesk (dest, trashlist);
+      return e;
+      }
 
    if (dest.isEmpty ())
       dest = desk->trashdir ();
@@ -326,6 +388,65 @@ err_info *Desktopmodel::opUntrashStacks (QStringList &trashlist, QModelIndex par
    err_info *e = NULL;
    QList<File *> flist;
    int i;
+
+   RemoteBackend *remote = desk
+         ? dynamic_cast<RemoteBackend *> (desk->backend ()) : nullptr;
+
+   if (remote)
+      {
+      /* Reverse of the remote branch in opTrashStacks(): move each
+         file back from the source directory (the trash, unless this
+         was a move-to-dir) into this desk, or for a copy just delete
+         the copy again. */
+      QString srcRel = src.isEmpty ()
+            ? QString (RemoteBackend::trashDirName ())
+            : remoteRelDir (desk, src);
+      QString destRel = remoteRelDir (desk, desk->dir ());
+
+      for (i = 0; i < trashlist.size (); i++)
+         {
+         QString srcPath = srcRel.isEmpty ()
+               ? trashlist [i] : srcRel + "/" + trashlist [i];
+
+         if (copy)
+            {
+            if (!remote->deleteStack (desk->repoName (), srcPath))
+               {
+               e = err_make (ERRFN, ERR_remote_op_failed2, "delete",
+                             qPrintable (remote->lastError ()));
+               break;
+               }
+            remote->invalidateCachedFile (desk->repoName (), srcPath);
+            continue;
+            }
+
+         QString finalName;
+         if (!remote->moveStack (desk->repoName (), srcPath, destRel,
+                                 false, &finalName))
+            {
+            e = err_make (ERRFN, ERR_remote_op_failed2, "move",
+                          qPrintable (remote->lastError ()));
+            break;
+            }
+         remote->invalidateCachedFile (desk->repoName (), srcPath);
+
+         fnew = desk->createFile (desk->dir (), finalName);
+         desk->newFile (fnew);
+         if (pagepos)
+            {
+            fnew->setPos ((*pagepos) [i].pos);
+            fnew->setPagenum ((*pagepos) [i].pagenum);
+            }
+         filenames [i] = finalName;
+         flist << fnew;
+         refreshRemoteThumbnail (desk, remote, fnew);
+         }
+
+      if (!copy)
+         insertRows (flist, parent);
+      removeFilesFromDesk (src, trashlist);
+      return e;
+      }
 
    /* first, move all the trashed files back into the current directory,
       creating a list of the new File * records thus created. If
@@ -467,6 +588,27 @@ err_info *Desktopmodel::opRenameStack (const QModelIndex &index, QString &newnam
 
    if (f)
       {
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *desk = f->desk ();
+         QString oldCache = f->pathname ();
+
+         if (!remote->renameStack (desk->repoName (),
+                                   remoteStackPath (desk, f), newname))
+            return err_make (ERRFN, ERR_remote_op_failed2, "rename",
+                             qPrintable (remote->lastError ()));
+
+         /* carry the cached copy (and its validator) over to the new
+            name, then update the file object to match the server */
+         f->updateFilename (newname);
+         QFile::rename (oldCache, f->pathname ());
+         QFile::rename (oldCache + ".etag", f->pathname () + ".etag");
+         buildItem (index);
+         return NULL;
+         }
+
       e = f->rename (newname, true);
       buildItem (index);
       getDesk (index.parent ())->dirty ();
@@ -483,6 +625,29 @@ err_info *Desktopmodel::opRenamePage (const QModelIndex &index, int pagenum, QSt
 
    if (f)
       {
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *desk = f->desk ();
+
+         if (!remote->renamePage (desk->repoName (),
+                                  remoteStackPath (desk, f), pagenum + 1,
+                                  newname))
+            return err_make (ERRFN, ERR_remote_op_failed2, "page rename",
+                             qPrintable (remote->lastError ()));
+
+         /* mirror the change onto the cached copy so the page view
+            stays in step without a refetch */
+         if (pagenum >= 0 && pagenum < f->pagecount ())
+            {
+            f->renamePage (pagenum, newname);
+            f->setPagenum (pagenum);
+            }
+         buildItem (index);
+         return NULL;
+         }
+
       if (pagenum >= 0 && pagenum < f->pagecount ()) // which it should be!
          {
          e = f->renamePage (pagenum, newname);
@@ -550,6 +715,28 @@ err_info *Desktopmodel::opTransformPage (const QModelIndex &index,
          e = f->not_impl ();
       }
    return e;
+   }
+
+
+RemoteBackend *Desktopmodel::remoteForFile (File *file) const
+   {
+   Desk *desk = file ? file->desk () : NULL;
+
+   return desk ? dynamic_cast<RemoteBackend *> (desk->backend ()) : nullptr;
+   }
+
+
+QString Desktopmodel::remoteRelDir (Desk *desk, QString dir) const
+   {
+   QString root = desk->rootDir ();
+
+   if (dir.startsWith (root))
+      dir = dir.mid (root.length ());
+   while (dir.endsWith ('/'))
+      dir.chop (1);
+   if (dir.startsWith ('/'))
+      dir = dir.mid (1);
+   return dir;
    }
 
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -638,6 +638,11 @@ void Desktopmodel::opMoveStacks (QModelIndexList &list, QModelIndex parent,
       emit dataChanged (ind, ind);
       }
    desk->dirty ();
+
+   /* positions on a remote desk are shared through the server's desk
+      file; push them at once so other clients see the new layout */
+   if (desk->isRemote ())
+      desk->flush ();
    }
 
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -33,6 +33,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QApplication>
 #include <QClipboard>
+#include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
 #include <QMimeData>
@@ -583,6 +584,52 @@ void Desktopmodel::refreshRemoteThumbnail (Desk *desk, RemoteBackend *backend,
    }
 
 
+err_info *Desktopmodel::ensureContent (const QModelIndex &ind)
+   {
+   File *f = getFile (ind);
+
+   if (!f)
+      return NULL;
+   Desk *desk = f->desk ();
+   RemoteBackend *remote = desk
+         ? dynamic_cast<RemoteBackend *> (desk->backend ()) : nullptr;
+   if (!remote)
+      return NULL;   // local desk: buildItem() has already loaded it
+
+   // checked once already this session; the parsed state is current
+   if (f->remoteChecked ())
+      return NULL;
+
+   bool refreshed = false;
+
+   if (remote->ensureCachedFile (desk->repoName (),
+                                 remoteStackPath (desk, f),
+                                 &refreshed).isEmpty ())
+      return err_make (ERRFN, ERR_remote_fetch_failed1,
+                       qPrintable (remote->lastError ()));
+
+   /* Parse the cached bytes.  A stack shown before ever being fetched
+      is a valid-but-empty shell (see buildItem()), and one cached by
+      an earlier session may have been parsed before this revalidation
+      replaced the bytes: reload() covers both, discarding any stale
+      state.  If the copy was already current and parsed, it's a
+      no-op-ish re-read of an unchanged local file. */
+   if (refreshed || !f->pagecount ())
+      {
+      CALL (f->reload ());
+      f->setValid (true);
+
+      /* the grid item now knows its page count and can render its
+         own preview; refresh it without disturbing any selection */
+      _minor_change = true;
+      buildItem (ind);
+      _minor_change = false;
+      }
+   f->setRemoteChecked (true);
+   return NULL;
+   }
+
+
 err_info *Desktopmodel::opTransformPageRemote (const QModelIndex &index,
       File *file, Desk *desk, RemoteBackend *backend, int pagenum,
       File::e_transform op)
@@ -591,11 +638,41 @@ err_info *Desktopmodel::opTransformPageRemote (const QModelIndex &index,
       which is how the all-pages case (pagenum == -1) is expressed. */
    int wirePage = pagenum < 0 ? 0 : pagenum + 1;
 
-   if (!backend->transformPage (desk->repoName (),
-                                remoteStackPath (desk, file), wirePage,
+   QString stackPath = remoteStackPath (desk, file);
+
+   if (!backend->transformPage (desk->repoName (), stackPath, wirePage,
                                 File::transformName (op)))
       return err_make (ERRFN, ERR_remote_transform_failed1,
                        qPrintable (backend->lastError ()));
+
+   /* Keep the cached copy in step with the server so an open page
+      view shows the turn at once: apply the same transform to the
+      already-parsed local bytes.  If the stack hasn't been fetched
+      (or the local apply fails), drop any cached copy instead; the
+      next ensureContent() downloads the transformed file. */
+   if (file->valid () && file->pagecount ())
+      {
+      err_info *e = NULL;
+
+      if (pagenum == -1)
+         {
+         for (int page = 0; !e && page < file->pagecount (); page++)
+            e = file->transformPage (page, op);
+         }
+      else
+         e = file->transformPage (pagenum, op);
+      if (e)
+         {
+         qInfo () << "local cache transform failed:" << e->errstr;
+         backend->invalidateCachedFile (desk->repoName (), stackPath);
+         file->setRemoteChecked (false);
+         }
+      }
+   else
+      {
+      backend->invalidateCachedFile (desk->repoName (), stackPath);
+      file->setRemoteChecked (false);
+      }
 
    /* refresh the grid thumbnail from the server, and let any open page
       view know the content changed */

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -1021,6 +1021,45 @@ void Desktopmodel::refreshRemoteThumbnail (Desk *desk, RemoteBackend *backend,
    }
 
 
+err_info *Desktopmodel::uploadScanStack (File *f)
+   {
+   Desk *desk = f->desk ();
+   RemoteBackend *remote = dynamic_cast<RemoteBackend *> (desk->backend ());
+
+   QFile in (f->pathname ());
+   if (!in.open (QIODevice::ReadOnly))
+      return err_make (ERRFN, ERR_cannot_open_file1,
+                       qPrintable (f->pathname ()));
+   QByteArray bytes = in.readAll ();
+   in.close ();
+
+   QString finalName, etag;
+   if (!remote->uploadFile (desk->repoName (), remoteStackPath (desk, f),
+                            bytes, &finalName, &etag))
+      return err_make (ERRFN, ERR_remote_op_failed2, "upload",
+                       qPrintable (remote->lastError ()));
+
+   if (!finalName.isEmpty () && finalName != f->filename ())
+      {
+      QString oldCache = f->pathname ();
+
+      f->updateFilename (finalName);
+      QFile::rename (oldCache, f->pathname ());
+      }
+
+   /* record the server's validator so the next open costs a 304 */
+   if (!etag.isEmpty ())
+      {
+      QFile ef (f->pathname () + ".etag");
+
+      if (ef.open (QIODevice::WriteOnly))
+         ef.write (etag.toUtf8 ());
+      }
+   f->setRemoteChecked (true);
+   return NULL;
+   }
+
+
 err_info *Desktopmodel::ensureContent (const QModelIndex &ind)
    {
    File *f = getFile (ind);

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -33,6 +33,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QApplication>
 #include <QClipboard>
+#include <QDataStream>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
@@ -97,6 +98,47 @@ err_info *Desktopmodel::opUnstackStacks (QModelIndexList &list, QModelIndex pare
       QList<File *> flist;
       QStringList stack_names;
 
+      RemoteBackend *remote = remoteForFile (f);
+      if (remote)
+         {
+         /* Unstack on the server page by page, mirroring each step
+            onto the cached copy under the server's chosen name.  Both
+            sides always remove the current first page, so the page
+            numbering stays aligned. */
+         Desk *desk = f->desk ();
+
+         CALL (ensureContent (ind));
+         while (!err && f->pagecount () > 1)
+            {
+            QString serverName;
+            if (!remote->unstackStack (desk->repoName (),
+                                       remoteStackPath (desk, f), 1, 1,
+                                       true, "", &serverName))
+               {
+               err = err_make (ERRFN, ERR_remote_op_failed2, "unstack",
+                               qPrintable (remote->lastError ()));
+               break;
+               }
+            fnew = desk->createFile (desk->dir (), serverName);
+            desk->newFile (fnew, f, pagenum++);
+            err = fnew->create ();
+            if (!err)
+               err = f->unstackPages (0, 1, true, fnew);
+            fnew->setRemoteChecked (true);
+            stack_names << serverName;
+            flist << fnew;
+            }
+         if (flist.size ())
+            {
+            buildItem (ind);
+            insertRows (flist, parent);
+            }
+         _newnames << stack_names;
+         if (err)
+            break;
+         continue;
+         }
+
       CALL(f->load());
       // remove every page from the stack except the first
       while (f->pagecount () > 1)
@@ -144,6 +186,65 @@ err_info *Desktopmodel::opRestackStacks (QModelIndexList &list, QModelIndex pare
    int upto = 0;
    QModelIndex pind;
    int out_destpage = in_destpage; // destination page for first stack
+
+   Desk *rdesk = getDesk (parent);
+   RemoteBackend *remote = rdesk
+         ? dynamic_cast<RemoteBackend *> (rdesk->backend ()) : nullptr;
+
+   if (remote)
+      {
+      /* Stack on the server; it deletes the source files itself.  The
+         destination is refetched afterwards rather than mirrored,
+         since the sources may not all be in the local cache. */
+      foreach (ind, list)
+         {
+         File *f = getFile (ind);
+         int destpage = in_destpage == -1 ? f->pagenum () : in_destpage;
+
+         if (out_destpage == -1)
+            out_destpage = destpage;
+
+         QStringList sources;
+         foreach (pind, pages_list [upto])
+            if (pind != QModelIndex ())
+               {
+               File *pdel = getFile (pind);
+
+               sources << remoteStackPath (rdesk, pdel);
+               delete_list << pind;
+               }
+         upto++;
+         if (sources.isEmpty ())
+            continue;
+
+         QString destPath = remoteStackPath (rdesk, f);
+         if (!remote->stackStacks (rdesk->repoName (), destPath, sources,
+                                   destpage + 1))
+            {
+            e = err_make (ERRFN, ERR_remote_op_failed2, "stack",
+                          qPrintable (remote->lastError ()));
+            break;
+            }
+
+         remote->invalidateCachedFile (rdesk->repoName (), destPath);
+         f->setRemoteChecked (false);
+         err_info *e2 = ensureContent (ind);
+         if (!e)
+            e = e2;
+         }
+      in_destpage = out_destpage;
+
+      /* the server has already deleted the source files; drop their
+         cached copies and rows */
+      foreach (pind, delete_list)
+         remote->invalidateCachedFile (rdesk->repoName (),
+                                       remoteStackPath (rdesk,
+                                                        getFile (pind)));
+      sortForDelete (delete_list);
+      foreach (pind, delete_list)
+         removeRow (pind.row (), pind.parent ());
+      return e;
+      }
 
    // work through each stack in the list
    foreach (ind, list)
@@ -201,6 +302,40 @@ err_info *Desktopmodel::opDuplicateStacks (QModelIndexList &list, QModelIndex pa
    err_info *err = NULL;
    File *fnew, *f;
    int count;
+
+   Desk *rdesk = getDesk (parent);
+   RemoteBackend *remote = rdesk
+         ? dynamic_cast<RemoteBackend *> (rdesk->backend ()) : nullptr;
+
+   if (remote)
+      {
+      /* only a plain copy is available remotely; conversions need
+         the pages, which live on the server */
+      if (type != File::Type_other)
+         return err_make (ERRFN, ERR_remote_op_failed2, "convert",
+                          "not supported for a remote stack");
+
+      foreach (ind, list)
+         {
+         f = getFile (ind);
+         QString name;
+
+         if (!remote->duplicateStack (rdesk->repoName (),
+                                      remoteStackPath (rdesk, f), &name))
+            {
+            err = err_make (ERRFN, ERR_remote_op_failed2, "duplicate",
+                            qPrintable (remote->lastError ()));
+            break;
+            }
+         fnew = rdesk->createFile (rdesk->dir (), name);
+         rdesk->newFile (fnew, f);
+         refreshRemoteThumbnail (rdesk, remote, fnew);
+         flist << fnew;
+         namelist << name;
+         }
+      insertRows (flist, parent);
+      return err;
+      }
 
    // duplicate each stack, creating a list of new files
    QString opname = type == File::Type_other ? tr ("Copy files") :
@@ -515,6 +650,40 @@ err_info *Desktopmodel::opUnstackPage (QModelIndex &ind, int &pagenum,
 
    if (pagenum == -1)
       pagenum = f->pagenum ();
+
+   RemoteBackend *remote = remoteForFile (f);
+   if (remote)
+      {
+      Desk *desk = f->desk ();
+
+      CALL (ensureContent (ind));
+      if (remove && f->pagecount () <= 1)
+         return NULL;
+
+      /* the server picks the new stack's name; mirror the unstack
+         onto the cached copy under that name so both stay in step */
+      QString serverName;
+      if (!remote->unstackStack (desk->repoName (),
+                                 remoteStackPath (desk, f), pagenum + 1, 1,
+                                 remove, "", &serverName))
+         return err_make (ERRFN, ERR_remote_op_failed2, "unstack",
+                          qPrintable (remote->lastError ()));
+
+      fnew = desk->createFile (desk->dir (), serverName);
+      row = desk->newFile (fnew, f, 1);
+      e = fnew->create ();
+      if (!e)
+         e = f->unstackPages (pagenum, 1, remove, fnew);
+      fnew->setRemoteChecked (true);
+
+      newname = serverName;
+      if (remove)
+         buildItem (ind);
+      QModelIndexList list;
+      newItem (row, ind.parent (), list);
+      return e;
+      }
+
    if ((!remove || f->pagecount () > 1)
       && (e = f->unstackItems (pagenum, 1, remove, "", fnew, row, 1), !e))
       {
@@ -578,6 +747,39 @@ err_info *Desktopmodel::opDeletePages (QModelIndex &ind, QBitArray &pages,
 
    if (f)
       {
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *desk = f->desk ();
+
+         CALL (ensureContent (ind));
+
+         QList<int> pageList;
+         for (int i = 0; i < pages.size (); i++)
+            if (pages.testBit (i))
+               pageList << i + 1;
+
+         QString undoId;
+         if (!remote->deletePages (desk->repoName (),
+                                   remoteStackPath (desk, f), pageList,
+                                   &undoId))
+            return err_make (ERRFN, ERR_remote_op_failed2, "page delete",
+                             qPrintable (remote->lastError ()));
+
+         /* Mirror the removal onto the cached copy so the view stays
+            in step without a refetch.  The undo record's blob carries
+            the server's token alongside the local recovery data, so
+            opUndeletePages() can restore both sides. */
+         QByteArray localInfo;
+         e = f->removePages (pages, localInfo, count);
+         del_info.clear ();
+         QDataStream ds (&del_info, QIODevice::WriteOnly);
+         ds << undoId << localInfo;
+         buildItem (ind);
+         return e;
+         }
+
       e = f->removePages (pages, del_info, count);
       buildItem (ind);
       getDesk (ind.parent ())->dirty ();
@@ -594,6 +796,27 @@ err_info *Desktopmodel::opUndeletePages (QModelIndex &ind, QBitArray &pages,
 
    if (f)
       {
+      RemoteBackend *remote = remoteForFile (f);
+
+      if (remote)
+         {
+         Desk *desk = f->desk ();
+         QString undoId;
+         QByteArray localInfo;
+         QDataStream ds (&del_info, QIODevice::ReadOnly);
+
+         ds >> undoId >> localInfo;
+         if (!remote->undeletePages (desk->repoName (),
+                                     remoteStackPath (desk, f), undoId))
+            return err_make (ERRFN, ERR_remote_op_failed2,
+                             "page undelete",
+                             qPrintable (remote->lastError ()));
+
+         e = f->restorePages (pages, localInfo, count);
+         buildItem (ind);
+         return e;
+         }
+
       e = f->restorePages (pages, del_info, count);
       buildItem (ind);
       }

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -710,6 +710,102 @@ cURL
 
 --------------
 
+6. Mutation API (v1)
+~~~~~~~~~~~~~~~~~~~~
+
+The ``/v1/`` namespace adds write operations, used by the desktop
+client when a repository is remote.  All are ``POST`` requests with a
+JSON body (unless noted) to paths of the form::
+
+   /v1/repos/{repo}/stacks/{path}{verb}
+
+where ``{path}`` is the stack's percent-encoded repo-relative path.
+Authentication follows the same rules as the read API; the per-user
+repository allowlist is enforced.  Every response carries
+``{"success": true|false}`` plus the fields shown.
+
+``/rename``
+   Body ``{"newName": ..., "autoRename": true}``.  Renames the stack
+   within its directory; with ``autoRename`` a colliding name gets
+   ``_1``, ``_2``... appended.  Returns ``{"name"}`` with the final
+   name.
+
+``/pages/{n}/rename``
+   Body ``{"newName": ...}``.  Renames 1-based page ``n``.
+
+``/move``
+   Body ``{"destDir": ..., "copy": false}``.  Moves (or copies) the
+   stack to another directory in the same repository; ``destDir`` is
+   repo-relative and ``""`` means the root.  The shared trash
+   directory ``.maxview-trash`` is created on demand; any other
+   destination must exist.  Returns ``{"name"}``.
+
+``/delete``
+   Removes the file outright (no trash).
+
+``/annotations``
+   Body with any subset of ``author``/``title``/``keywords``/
+   ``notes``/``ocr``.  Writes the fields into the stack's annotation
+   block.
+
+``/pages/delete``
+   Body ``{"pages": [n, ...]}`` (1-based).  Removes the pages and
+   keeps the recovery data server-side.  Returns ``{"undoId"}``, an
+   opaque token for ``/pages/undelete``.  Tokens do not survive a
+   server restart, so treat the undo as best-effort.
+
+``/pages/undelete``
+   Body ``{"undoId": ...}``.  Restores the pages removed by the
+   matching ``/pages/delete``.  An unknown or already-redeemed token
+   is ``410 Gone``.
+
+``/unstack``
+   Body ``{"pagenum": n, "pagecount": k, "remove": true,
+   "newName": ...}``.  Splits ``k`` pages starting at 1-based ``n``
+   into a new stack in the same directory, removing them from the
+   source when ``remove`` is set.  Returns ``{"name"}``.
+
+``/stack``
+   Body ``{"sources": [path, ...], "insertPage": n}``.  Appends the
+   pages of each source stack into the target at 1-based
+   ``insertPage`` (absent means the end) and deletes the source
+   files.  All stacks must be the same type.
+
+``/duplicate``
+   Copies the stack's file within its directory under a fresh name.
+   Returns ``{"name"}``.
+
+``/upload``
+   The raw request body is the whole file's bytes (e.g. a stack
+   scanned on a client).  Never overwrites: a name clash gets a fresh
+   name.  Returns ``{"name", "etag"}``.
+
+Whole-file downloads via ``/file`` carry an ``ETag`` header (size and
+mtime).  A request with ``If-None-Match`` returns ``304 Not Modified``
+when the tag still matches, so clients can revalidate cached copies
+cheaply.
+
+7. Change Events (v1)
+~~~~~~~~~~~~~~~~~~~~~
+
+**Endpoint**: ``GET /v1/repos/{repo}/events``
+
+A long-lived ``text/event-stream`` response.  Every successful
+mutation in the repository sends a frame::
+
+   event: stackChanged
+   data: {"repo": ..., "op": ..., "path": ..., "name": ..., "origin": ...}
+
+``op`` is the operation (``rename``, ``move``, ``delete``,
+``transform``, ``annotations``, ``pagesDeleted``, ``pagesRestored``,
+``unstack``, ``stack``, ``duplicate``, ``upload``), ``name`` the
+resulting name where one exists, and ``origin`` echoes the
+``X-Client-Id`` header of the originating request so a client can
+ignore its own changes.  Behind nginx the events path needs
+``proxy_buffering off`` and a long ``proxy_read_timeout``.
+
+--------------
+
 Security Considerations
 -----------------------
 
@@ -733,7 +829,8 @@ File Access
 
 -  Server runs with limited user permissions
 -  Only configured repository paths are accessible
--  No write operations are supported (read-only API)
+-  Write operations exist only under ``/v1/`` and require
+   authentication when it is enabled
 
 --------------
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -777,8 +777,15 @@ repository allowlist is enforced.  Every response carries
 
 ``/upload``
    The raw request body is the whole file's bytes (e.g. a stack
-   scanned on a client).  Never overwrites: a name clash gets a fresh
-   name.  Returns ``{"name", "etag"}``.
+   scanned on a client).  Never overwrites unless ``?overwrite=true``
+   is given (used for the shared ``.paperdesk`` desk file): a name
+   clash gets a fresh name.  Returns ``{"name", "etag"}``.
+
+``/pages/{n}/ocr``
+   Renders 1-based page ``n``, runs the server's OCR engine
+   (tesseract) over it, stores the text in the stack's ``ocr``
+   annotation and returns ``{"text"}``.  ``501`` when no engine is
+   installed on the server.
 
 Whole-file downloads via ``/file`` carry an ``ETag`` header (size and
 mtime).  A request with ``If-None-Match`` returns ``304 Not Modified``

--- a/err.cpp
+++ b/err.cpp
@@ -108,6 +108,7 @@ static const char *err_msg [ERR_count] =
    "Search index not open",
    "Could not open file '%s' for reading",
    "Remote transform failed: %s",
+   "Could not fetch remote file: %s",
    };
 
 

--- a/err.cpp
+++ b/err.cpp
@@ -109,6 +109,8 @@ static const char *err_msg [ERR_count] =
    "Could not open file '%s' for reading",
    "Remote transform failed: %s",
    "Could not fetch remote file: %s",
+   "Remote %s failed: %s",
+   "Cannot move stacks between repositories",
    };
 
 

--- a/err.h
+++ b/err.h
@@ -121,6 +121,8 @@ enum
    ERR_could_not_open_file_for_reading1,
    ERR_remote_transform_failed1,
    ERR_remote_fetch_failed1,
+   ERR_remote_op_failed2,
+   ERR_cannot_move_between_repositories,
 
    ERR_count
    };

--- a/err.h
+++ b/err.h
@@ -120,6 +120,7 @@ enum
    ERR_index_not_open,
    ERR_could_not_open_file_for_reading1,
    ERR_remote_transform_failed1,
+   ERR_remote_fetch_failed1,
 
    ERR_count
    };

--- a/file.cpp
+++ b/file.cpp
@@ -814,6 +814,32 @@ bool File::transformFromName (const QString &name, e_transform &op)
    }
 
 
+QString File::annotWireName (e_annot type)
+   {
+   switch (type)
+      {
+      case Annot_author :   return "author";
+      case Annot_title :    return "title";
+      case Annot_keywords : return "keywords";
+      case Annot_notes :    return "notes";
+      case Annot_ocr :      return "ocr";
+      default :             break;
+      }
+   return "";
+   }
+
+
+bool File::annotFromWireName (const QString &name, e_annot &type)
+   {
+   if (name == "author")   { type = Annot_author;   return true; }
+   if (name == "title")    { type = Annot_title;    return true; }
+   if (name == "keywords") { type = Annot_keywords; return true; }
+   if (name == "notes")    { type = Annot_notes;    return true; }
+   if (name == "ocr")      { type = Annot_ocr;      return true; }
+   return false;
+   }
+
+
 QImage File::transformImage (const QImage &image, e_transform op)
    {
    switch (op)

--- a/file.h
+++ b/file.h
@@ -295,6 +295,17 @@ public:
       \returns true if the name is recognised */
    static bool transformFromName (const QString &name, e_transform &op);
 
+   /** the wire name of an annotation type, used in the server's
+       annotations API: author/title/keywords/notes/ocr */
+   static QString annotWireName (e_annot type);
+
+   /** parse a wire annotation name back to an enum
+
+      \param name  one of author/title/keywords/notes/ocr
+      \param type  returns the type on success
+      \returns true if the name is recognised */
+   static bool annotFromWireName (const QString &name, e_annot &type);
+
    /** apply a transform to an image */
    static QImage transformImage (const QImage &image, e_transform op);
 

--- a/file.h
+++ b/file.h
@@ -219,6 +219,13 @@ public:
    // load / save / create
    virtual err_info *load (void) = 0;  // was desk->ensureMax
 
+   /** Discard any parsed state and read the file from disk again.
+       Used when the underlying bytes have changed under us, e.g. a
+       remote file's cached copy was refreshed from the server.  The
+       default is a plain load(), for types which keep no parsed
+       state. */
+   virtual err_info *reload (void) { return load (); }
+
    /** create the file (on the filesystem). It doesn't need to be written to
        as we will call flush() later for that */
    virtual err_info *create (void) = 0;
@@ -316,6 +323,12 @@ eturns error, or NULL if ok */
     *  via /thumbnail) so that subclasses which don't compute their
     *  own pixmap (Fileother) can display the supplied one. */
    void setThumbnail(const QPixmap &pix) { _pixmap = pix; }
+
+   /** True once this session has fetched or revalidated the remote
+    *  content behind this file and parsed it.  Meaningless for a
+    *  local desk.  See Desktopmodel::ensureContent(). */
+   bool remoteChecked () const { return _remoteChecked; }
+   void setRemoteChecked (bool checked) { _remoteChecked = checked; }
 
    /** returns the preview image for a particular page.
 
@@ -563,6 +576,7 @@ protected:
    err_info _serr;  //!< place to put error
    err_info *_err;  //!< last error which occured with this item
    bool _valid;      //!< true if we have scanned this file and know what it contains
+   bool _remoteChecked = false;  //!< remote content fetched/revalidated this session
 
    // annotation data
    bool _annot_loaded;               // true if data has been loaded

--- a/filejpeg.cpp
+++ b/filejpeg.cpp
@@ -147,7 +147,8 @@ static const char *tags [File::Annot_count] =
    "Artist",
    "ImageDescription",
    "Keywords",
-   "Notes"
+   "Notes",
+   "UserComment"   // OCR text; can be multi-line so read with -b
    };
 
 
@@ -226,6 +227,12 @@ err_info *Filejpeg::load_annot (void)
    CALL (run_exiftool (process, "load notes", args));
    _annot_loaded = true;
    _annot_data [Annot_notes] = utilRemoveQuotes (process.readAllStandardOutput ());
+
+   // The OCR text can be multi-line, so read it in binary form too
+   args.clear ();
+   args << "-b" << "-UserComment" << _pathname;
+   CALL (run_exiftool (process, "load ocr text", args));
+   _annot_data [Annot_ocr] = utilRemoveQuotes (process.readAllStandardOutput ());
 
    return NULL;
    }

--- a/filejpeg.cpp
+++ b/filejpeg.cpp
@@ -64,6 +64,25 @@ err_info *Filejpeg::load (void)
    }
 
 
+err_info *Filejpeg::reload (void)
+   {
+   /* never parsed (or a valid-but-empty remote shell): a plain load
+      builds the page list */
+   if (_pages.isEmpty ())
+      {
+      _valid = false;
+      return load ();
+      }
+
+   /* re-read each page image from disk; the page list itself is
+      unchanged since it mirrors the filenames */
+   foreach (Filejpegpage *page, _pages)
+      if (page)
+         CALL (page->load (_dir));
+   return NULL;
+   }
+
+
   // was desk->ensureMax
 
 /** create the file (on the filesystem). It doesn't need to be written to

--- a/filejpeg.h
+++ b/filejpeg.h
@@ -53,6 +53,8 @@ public:
 
    virtual err_info *load (void);  // was desk->ensureMax
 
+   virtual err_info *reload (void);
+
    virtual err_info *create (void);
 
    virtual err_info *flush (void);

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -5554,6 +5554,20 @@ err_info *Filemax::load ()  // was desk->ensureMax
    }
 
 
+err_info *Filemax::reload (void)
+   {
+   /* free the parsed chunk and page state; chunk_resize() and
+      page_resize() insist on starting from empty lists */
+   max_free ();
+   _fin = NULL;
+   _chunks.clear ();
+   _pages.clear ();
+   _annot_loaded = false;
+   _valid = false;
+   return load ();
+   }
+
+
 err_info *Filemax::getAnnot (e_annot type, QString &text)
    {
    if (!_valid)

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -2707,6 +2707,12 @@ err_info *Filemax::putAnnot (QHash<int, QString> &updates)
    {
    int type;
 
+   /* The file may not be open and its chunk list may be partial when
+      this is the first operation after load() (as on the server).
+      load_annot() reads from the file and create_annot() needs the
+      full chunk list to update the annot chunk in place. */
+   CALL (ensure_open ());
+   CALL (ensure_all_chunks ());
    if (!_annot_loaded)
       CALL (load_annot ());
 
@@ -2714,6 +2720,7 @@ err_info *Filemax::putAnnot (QHash<int, QString> &updates)
       if (updates.contains (type))
          _annot_data [type] = updates [type];
    create_annot ();
+   ensure_closed ();
    return NULL;
    }
 

--- a/filemax.h
+++ b/filemax.h
@@ -160,6 +160,8 @@ public:
 
    virtual err_info *load (void);  // was desk->ensureMax
 
+   virtual err_info *reload (void);
+
    virtual err_info *create (void);
 
    virtual err_info *flush (void);

--- a/filepdf.cpp
+++ b/filepdf.cpp
@@ -60,6 +60,18 @@ err_info *Filepdf::load (void)
    }
 
 
+err_info *Filepdf::reload (void)
+   {
+   if (_pdfio)
+      {
+      delete _pdfio;
+      _pdfio = NULL;
+      }
+   _valid = false;
+   return load ();
+   }
+
+
   // was desk->ensureMax
 
 /** create the file (on the filesystem). It doesn't need to be written to

--- a/filepdf.h
+++ b/filepdf.h
@@ -59,6 +59,8 @@ public:
 
    virtual err_info *load (void);  // was desk->ensureMax
 
+   virtual err_info *reload (void);
+
    virtual err_info *create (void);
 
    virtual err_info *flush (void);

--- a/ocr.h
+++ b/ocr.h
@@ -38,6 +38,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 class QImage;
 class QString;
 
+struct err_info;
+
 
 class Ocr
    {

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -612,6 +612,19 @@ void Pagewidget::showPages (const QAbstractItemModel *model, const QModelIndex &
 //    qDebug () << "showPages" << model << index;
    _start = start;
    _count = count;
+
+   /* a remote stack may not have been fetched yet; get its content
+      now so the page count below is the real one */
+   if (index.isValid ())
+      {
+      Desktopmodel *contents = _modelconv->getDesktopmodel (model);
+      QModelIndex sindex = index;
+
+      _modelconv->indexToSource (model, sindex);
+      if (contents && sindex.isValid ())
+         contents->ensureContent (sindex);
+      }
+
    int pagecount = model->data (index, Desktopmodel::Role_pagecount).toInt ();
    if (_count == -1)
       _count = pagecount;

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -1142,7 +1142,26 @@ void Pagewidget::ocrPage (void)
       return;
       }
 
-   // pass the page to our OCR engine
+   /* if the page belongs to a stack in the model, go through it: a
+      remote stack is OCRed by the server, which also has the engine
+      installed centrally */
+   if (_model && _index.isValid ())
+      {
+      Desktopmodel *contents = _modelconv->getDesktopmodel (_model);
+      QModelIndex sindex = _index;
+
+      _modelconv->indexToSource (_model, sindex);
+      if (contents && sindex.isValid ())
+         {
+         err_info *err = contents->ocrPage (sindex, _pagenum, str);
+
+         if (!Mainwidget::singleton()->complain(err))
+            _ocr_edit->setText (str);
+         return;
+         }
+      }
+
+   // no stack (e.g. mid-scan): pass the page to our OCR engine
    err_info *err;
    Ocr *ocr = Ocr::getOcr (err);
 

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -45,6 +45,8 @@ HEADERS += builddate.h \
     err.h \
     mem.h \
     epeglite.h \
+    ocr.h \
+    ocrtess.h \
     zip.h \
     zip_p.h \
     zipentry_p.h \
@@ -67,6 +69,8 @@ SOURCES += searchserver.cpp \
     err.cpp \
     mem.cpp \
     epeglite.cpp \
+    ocr.cpp \
+    ocrtess.cpp \
     zip.cpp
 
 unix {

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -395,8 +395,12 @@ static QString wholeFilePathFor(const QString &repo, const QString &path)
 
 
 QString RemoteBackend::ensureCachedFile(const QString &repo,
-                                        const QString &relPath)
+                                        const QString &relPath,
+                                        bool *refreshed)
 {
+   if (refreshed)
+      *refreshed = false;
+
    QString cachePath = cachePathFor(repo, relPath);
    if (cachePath.isEmpty()) {
       _lastError = "cannot determine the server's cache directory";
@@ -454,6 +458,8 @@ QString RemoteBackend::ensureCachedFile(const QString &repo,
       if (ef.open(QIODevice::WriteOnly))
          ef.write(newEtag.toUtf8());
    }
+   if (refreshed)
+      *refreshed = true;
    return cachePath;
 }
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -536,6 +536,20 @@ bool RemoteBackend::uploadFile(const QString &repo, const QString &path,
 }
 
 
+bool RemoteBackend::ocrPage(const QString &repo, const QString &path,
+                            int page, QString *text)
+{
+   QJsonObject reply;
+
+   if (!postStackOp(repo, path + "/pages/" + QString::number(page),
+                    "/ocr", QJsonObject(), &reply))
+      return false;
+   if (text)
+      *text = reply.value("text").toString();
+   return true;
+}
+
+
 void RemoteBackend::subscribeEvents(const QString &repo)
 {
    if (_eventRepos.contains(repo))

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -431,6 +431,79 @@ bool RemoteBackend::updateAnnotations(const QString &repo,
 }
 
 
+bool RemoteBackend::deletePages(const QString &repo, const QString &path,
+                                const QList<int> &pages, QString *undoId)
+{
+   QJsonObject body, reply;
+   QJsonArray arr;
+
+   for (int page : pages)
+      arr.append(page);
+   body["pages"] = arr;
+   if (!postStackOp(repo, path + "/pages", "/delete", body, &reply))
+      return false;
+   if (undoId)
+      *undoId = reply.value("undoId").toString();
+   return true;
+}
+
+
+bool RemoteBackend::undeletePages(const QString &repo, const QString &path,
+                                  const QString &undoId)
+{
+   QJsonObject body;
+   body["undoId"] = undoId;
+   return postStackOp(repo, path + "/pages", "/undelete", body, nullptr);
+}
+
+
+bool RemoteBackend::unstackStack(const QString &repo, const QString &path,
+                                 int pagenum, int pagecount, bool remove,
+                                 const QString &suggestedName,
+                                 QString *newName)
+{
+   QJsonObject body, reply;
+   body["pagenum"]   = pagenum;
+   body["pagecount"] = pagecount;
+   body["remove"]    = remove;
+   if (!suggestedName.isEmpty())
+      body["newName"] = suggestedName;
+   if (!postStackOp(repo, path, "/unstack", body, &reply))
+      return false;
+   if (newName)
+      *newName = reply.value("name").toString();
+   return true;
+}
+
+
+bool RemoteBackend::stackStacks(const QString &repo, const QString &destPath,
+                                const QStringList &sources, int insertPage)
+{
+   QJsonObject body;
+   QJsonArray arr;
+
+   for (const QString &src : sources)
+      arr.append(src);
+   body["sources"] = arr;
+   if (insertPage > 0)
+      body["insertPage"] = insertPage;
+   return postStackOp(repo, destPath, "/stack", body, nullptr);
+}
+
+
+bool RemoteBackend::duplicateStack(const QString &repo, const QString &path,
+                                   QString *newName)
+{
+   QJsonObject reply;
+
+   if (!postStackOp(repo, path, "/duplicate", QJsonObject(), &reply))
+      return false;
+   if (newName)
+      *newName = reply.value("name").toString();
+   return true;
+}
+
+
 QString RemoteBackend::cacheRoot()
 {
    QString id = serverId();

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -6,13 +6,18 @@ License: GPL-2
 
 #include "backendstats.h"
 
+#include <QDebug>
+#include <QDir>
 #include <QEventLoop>
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QSaveFile>
+#include <QStandardPaths>
 #include <QUrlQuery>
 
 
@@ -271,7 +276,8 @@ quint64 RemoteBackend::fetchThumbnailAsync(const QString &repo,
 }
 
 
-QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery)
+QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery,
+                                       const QString &ifNoneMatch)
 {
    QUrl url(_baseUrl);
    int q = pathAndQuery.indexOf('?');
@@ -285,6 +291,8 @@ QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery)
    req.setTransferTimeout(kRequestTimeoutMs);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
+   if (!ifNoneMatch.isEmpty())
+      req.setRawHeader("If-None-Match", ifNoneMatch.toUtf8());
 
    QNetworkReply *reply = _nam->get(req);
 
@@ -342,6 +350,125 @@ bool RemoteBackend::transformPage(const QString &repo, const QString &path,
 }
 
 
+QString RemoteBackend::cacheRoot()
+{
+   QString id = serverId();
+   if (id.isEmpty())
+      return QString();
+   return QStandardPaths::writableLocation(
+              QStandardPaths::GenericCacheLocation)
+          + "/paperman/" + id;
+}
+
+
+QString RemoteBackend::cacheDirFor(const QString &repo,
+                                   const QString &dirInRepo)
+{
+   QString root = cacheRoot();
+   if (root.isEmpty())
+      return QString();
+   QString dir = root + "/" + repo;
+   if (!dirInRepo.isEmpty())
+      dir += "/" + dirInRepo;
+   return dir;
+}
+
+
+QString RemoteBackend::cachePathFor(const QString &repo,
+                                    const QString &relPath)
+{
+   QString root = cacheRoot();
+   if (root.isEmpty())
+      return QString();
+   return root + "/" + repo + "/" + relPath;
+}
+
+
+/* Build the "/file?repo=...&path=..." path-with-query string. */
+static QString wholeFilePathFor(const QString &repo, const QString &path)
+{
+   QUrlQuery q;
+   q.addQueryItem("repo", repo);
+   q.addQueryItem("path", path);
+   return "/file?" + q.toString();
+}
+
+
+QString RemoteBackend::ensureCachedFile(const QString &repo,
+                                        const QString &relPath)
+{
+   QString cachePath = cachePathFor(repo, relPath);
+   if (cachePath.isEmpty()) {
+      _lastError = "cannot determine the server's cache directory";
+      return QString();
+   }
+
+   QString etagPath = cachePath + ".etag";
+   QString etag;
+   bool haveCopy = QFile::exists(cachePath);
+   if (haveCopy) {
+      QFile ef(etagPath);
+      if (ef.open(QIODevice::ReadOnly))
+         etag = QString::fromUtf8(ef.readAll()).trimmed();
+   }
+
+   int status = 0;
+   QString newEtag;
+   QByteArray body = waitForReplyFull(
+       startGet(wholeFilePathFor(repo, relPath),
+                haveCopy ? etag : QString()),
+       &status, &newEtag);
+
+   if (status == 304)
+      return cachePath;          // cached copy is current
+
+   if (status != 200) {
+      /* Server unreachable or unhappy: fall back to the cached copy
+         if there is one, so already-fetched stacks stay viewable. */
+      if (haveCopy) {
+         qInfo() << "RemoteBackend: using cached copy of" << relPath
+                 << "after fetch error:" << _lastError;
+         return cachePath;
+      }
+      if (_lastError.isEmpty())
+         _lastError = QString("HTTP %1").arg(status);
+      return QString();
+   }
+
+   QDir().mkpath(QFileInfo(cachePath).path());
+   QSaveFile out(cachePath);
+   if (!out.open(QIODevice::WriteOnly)) {
+      _lastError = "cannot write cache file " + cachePath;
+      return QString();
+   }
+   out.write(body);
+   if (!out.commit()) {
+      _lastError = "cannot commit cache file " + cachePath;
+      return QString();
+   }
+
+   if (newEtag.isEmpty()) {
+      QFile::remove(etagPath);
+   } else {
+      QFile ef(etagPath);
+      if (ef.open(QIODevice::WriteOnly))
+         ef.write(newEtag.toUtf8());
+   }
+   return cachePath;
+}
+
+
+void RemoteBackend::invalidateCachedFile(const QString &repo,
+                                         const QString &relPath)
+{
+   QString cachePath = cachePathFor(repo, relPath);
+   if (cachePath.isEmpty())
+      return;
+   QFile::remove(cachePath);
+   QFile::remove(cachePath + ".etag");
+}
+
+
 QByteArray RemoteBackend::postRequest(const QString &path,
                                       const QByteArray &body)
 {
@@ -385,6 +512,29 @@ QByteArray RemoteBackend::waitForReply(QNetworkReply *reply)
       if (status >= 400)
          _lastError = QString("HTTP %1").arg(status);
    }
+   reply->deleteLater();
+   return data;
+}
+
+
+QByteArray RemoteBackend::waitForReplyFull(QNetworkReply *reply, int *status,
+                                           QString *etag)
+{
+   _lastError.clear();
+
+   QEventLoop loop;
+   QObject::connect(reply, &QNetworkReply::finished,
+                    &loop, &QEventLoop::quit);
+   loop.exec();
+
+   QByteArray data = reply->readAll();
+   *status = reply->attribute(
+                 QNetworkRequest::HttpStatusCodeAttribute).toInt();
+   *etag = QString::fromUtf8(reply->rawHeader("ETag"));
+   if (reply->error() != QNetworkReply::NoError && *status != 304)
+      _lastError = reply->errorString();
+   else if (*status >= 400)
+      _lastError = QString("HTTP %1").arg(*status);
    reply->deleteLater();
    return data;
 }

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -423,6 +423,14 @@ bool RemoteBackend::deleteStack(const QString &repo, const QString &path)
 }
 
 
+bool RemoteBackend::updateAnnotations(const QString &repo,
+                                      const QString &path,
+                                      const QJsonObject &updates)
+{
+   return postStackOp(repo, path, "/annotations", updates, nullptr);
+}
+
+
 QString RemoteBackend::cacheRoot()
 {
    QString id = serverId();

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -512,9 +512,11 @@ bool RemoteBackend::duplicateStack(const QString &repo, const QString &path,
 
 bool RemoteBackend::uploadFile(const QString &repo, const QString &path,
                                const QByteArray &bytes, QString *finalName,
-                               QString *etag)
+                               QString *etag, bool overwrite)
 {
    QString endpoint = "/v1/repos/" + repo + "/stacks/" + path + "/upload";
+   if (overwrite)
+      endpoint += "?overwrite=true";
 
    QByteArray resp = postRequest(endpoint, bytes,
                                  "application/octet-stream");
@@ -720,7 +722,13 @@ QByteArray RemoteBackend::postRequest(const QString &path,
                                       const QString &contentType)
 {
    QUrl url(_baseUrl);
-   url.setPath(path);
+   int q = path.indexOf('?');
+   if (q < 0) {
+      url.setPath(path);
+   } else {
+      url.setPath(path.left(q));
+      url.setQuery(path.mid(q + 1));
+   }
    QNetworkRequest req(url);
    req.setTransferTimeout(kRequestTimeoutMs);
    req.setRawHeader("X-Client-Id", _clientId.toUtf8());

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -504,6 +504,30 @@ bool RemoteBackend::duplicateStack(const QString &repo, const QString &path,
 }
 
 
+bool RemoteBackend::uploadFile(const QString &repo, const QString &path,
+                               const QByteArray &bytes, QString *finalName,
+                               QString *etag)
+{
+   QString endpoint = "/v1/repos/" + repo + "/stacks/" + path + "/upload";
+
+   QByteArray resp = postRequest(endpoint, bytes,
+                                 "application/octet-stream");
+   QJsonDocument doc = QJsonDocument::fromJson(resp);
+   if (!doc.isObject() || !doc.object().value("success").toBool(false)) {
+      if (_lastError.isEmpty())
+         _lastError = doc.isObject()
+                          ? doc.object().value("error").toString("upload failed")
+                          : QStringLiteral("invalid upload response");
+      return false;
+   }
+   if (finalName)
+      *finalName = doc.object().value("name").toString();
+   if (etag)
+      *etag = doc.object().value("etag").toString();
+   return true;
+}
+
+
 QString RemoteBackend::cacheRoot()
 {
    QString id = serverId();
@@ -630,13 +654,14 @@ void RemoteBackend::invalidateCachedFile(const QString &repo,
 
 
 QByteArray RemoteBackend::postRequest(const QString &path,
-                                      const QByteArray &body)
+                                      const QByteArray &body,
+                                      const QString &contentType)
 {
    QUrl url(_baseUrl);
    url.setPath(path);
    QNetworkRequest req(url);
    req.setTransferTimeout(kRequestTimeoutMs);
-   req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+   req.setHeader(QNetworkRequest::ContentTypeHeader, contentType);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
 

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -18,12 +18,17 @@ License: GPL-2
 #include <QNetworkRequest>
 #include <QSaveFile>
 #include <QStandardPaths>
+#include <QTimer>
 #include <QUrlQuery>
+#include <QUuid>
+
+#include <memory>
 
 
 RemoteBackend::RemoteBackend(const QUrl &baseUrl, QObject *parent)
    : QObject(parent)
    , _baseUrl(baseUrl)
+   , _clientId(QUuid::createUuid().toString(QUuid::WithoutBraces))
    , _nam(new QNetworkAccessManager(this))
 {
 }
@@ -289,6 +294,7 @@ QNetworkReply *RemoteBackend::startGet(const QString &pathAndQuery,
    }
    QNetworkRequest req(url);
    req.setTransferTimeout(kRequestTimeoutMs);
+   req.setRawHeader("X-Client-Id", _clientId.toUtf8());
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
    if (!ifNoneMatch.isEmpty())
@@ -528,6 +534,62 @@ bool RemoteBackend::uploadFile(const QString &repo, const QString &path,
 }
 
 
+void RemoteBackend::subscribeEvents(const QString &repo)
+{
+   if (_eventRepos.contains(repo))
+      return;
+   _eventRepos.insert(repo);
+   startEventStream(repo);
+}
+
+
+void RemoteBackend::startEventStream(const QString &repo)
+{
+   QUrl url(_baseUrl);
+   url.setPath("/v1/repos/" + repo + "/events");
+   QNetworkRequest req(url);
+   /* no transfer timeout: the stream stays open indefinitely */
+   req.setRawHeader("X-Client-Id", _clientId.toUtf8());
+   if (!_token.isEmpty())
+      req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());
+
+   QNetworkReply *reply = _nam->get(req);
+   auto buf = std::make_shared<QByteArray>();
+   QObject::connect(reply, &QNetworkReply::readyRead, this,
+       [this, reply, buf, repo]() {
+          *buf += reply->readAll();
+          int pos;
+          while ((pos = buf->indexOf("\n\n")) >= 0) {
+             QByteArray frame = buf->left(pos);
+             buf->remove(0, pos + 2);
+             int d = frame.indexOf("data: ");
+             if (d < 0)
+                continue;      // comment / keep-alive frame
+             QJsonDocument doc = QJsonDocument::fromJson(frame.mid(d + 6));
+             if (!doc.isObject())
+                continue;
+             QJsonObject o = doc.object();
+             if (o.value("origin").toString() == _clientId)
+                continue;      // our own change, already applied
+             emit stackEvent(o.value("repo").toString(repo),
+                             o.value("op").toString(),
+                             o.value("path").toString(),
+                             o.value("name").toString());
+          }
+       });
+   QObject::connect(reply, &QNetworkReply::finished, this,
+       [this, reply, repo]() {
+          reply->deleteLater();
+          /* reconnect unless the subscription was dropped */
+          if (_eventRepos.contains(repo))
+             QTimer::singleShot(3000, this, [this, repo]() {
+                if (_eventRepos.contains(repo))
+                   startEventStream(repo);
+             });
+       });
+}
+
+
 QString RemoteBackend::cacheRoot()
 {
    QString id = serverId();
@@ -661,6 +723,7 @@ QByteArray RemoteBackend::postRequest(const QString &path,
    url.setPath(path);
    QNetworkRequest req(url);
    req.setTransferTimeout(kRequestTimeoutMs);
+   req.setRawHeader("X-Client-Id", _clientId.toUtf8());
    req.setHeader(QNetworkRequest::ContentTypeHeader, contentType);
    if (!_token.isEmpty())
       req.setRawHeader("Authorization", "Bearer " + _token.toUtf8());

--- a/remotebackend.cpp
+++ b/remotebackend.cpp
@@ -350,6 +350,79 @@ bool RemoteBackend::transformPage(const QString &repo, const QString &path,
 }
 
 
+/* POST a JSON body to a per-stack endpoint and parse the reply.
+   Returns the reply object via *out (may be empty on transport
+   error); the return value is the "success" flag. */
+bool RemoteBackend::postStackOp(const QString &repo, const QString &path,
+                                const QString &verb, const QJsonObject &body,
+                                QJsonObject *out)
+{
+   QString endpoint = "/v1/repos/" + repo + "/stacks/" + path + verb;
+   QByteArray data = QJsonDocument(body).toJson(QJsonDocument::Compact);
+
+   QByteArray resp = postRequest(endpoint, data);
+   QJsonDocument doc = QJsonDocument::fromJson(resp);
+   if (!doc.isObject()) {
+      if (_lastError.isEmpty())
+         _lastError = "invalid response from " + verb;
+      if (out)
+         *out = QJsonObject();
+      return false;
+   }
+   if (out)
+      *out = doc.object();
+   if (doc.object().value("success").toBool(false))
+      return true;
+   _lastError = doc.object().value("error").toString(verb + " failed");
+   return false;
+}
+
+
+bool RemoteBackend::renameStack(const QString &repo, const QString &path,
+                                QString &newName, bool autoRename)
+{
+   QJsonObject body, reply;
+   body["newName"]    = newName;
+   body["autoRename"] = autoRename;
+   if (!postStackOp(repo, path, "/rename", body, &reply))
+      return false;
+   newName = reply.value("name").toString(newName);
+   return true;
+}
+
+
+bool RemoteBackend::renamePage(const QString &repo, const QString &path,
+                               int page, const QString &newName)
+{
+   QJsonObject body;
+   body["newName"] = newName;
+   return postStackOp(repo,
+                      path + "/pages/" + QString::number(page),
+                      "/rename", body, nullptr);
+}
+
+
+bool RemoteBackend::moveStack(const QString &repo, const QString &path,
+                              const QString &destDir, bool copy,
+                              QString *finalName)
+{
+   QJsonObject body, reply;
+   body["destDir"] = destDir;
+   body["copy"]    = copy;
+   if (!postStackOp(repo, path, "/move", body, &reply))
+      return false;
+   if (finalName)
+      *finalName = reply.value("name").toString();
+   return true;
+}
+
+
+bool RemoteBackend::deleteStack(const QString &repo, const QString &path)
+{
+   return postStackOp(repo, path, "/delete", QJsonObject(), nullptr);
+}
+
+
 QString RemoteBackend::cacheRoot()
 {
    QString id = serverId();

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -124,6 +124,12 @@ public:
     /** Delete a stack outright (no trash). */
     bool deleteStack(const QString &repo, const QString &path);
 
+    /** Write annotation fields into a stack on the server.  The
+     *  object's keys are wire annotation names (author/title/
+     *  keywords/notes/ocr) and the values the new text. */
+    bool updateAnnotations(const QString &repo, const QString &path,
+                           const class QJsonObject &updates);
+
     /** Name of the shared per-repo trash directory on the server. */
     static QString trashDirName() { return QStringLiteral(".maxview-trash"); }
 

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -104,6 +104,29 @@ public:
     bool transformPage(const QString &repo, const QString &path,
                        int page, const QString &op);
 
+    /** Rename a stack on the server.  On success @p newName holds the
+     *  final name the server chose (with autoRename it may differ
+     *  from the requested one).  Sync. */
+    bool renameStack(const QString &repo, const QString &path,
+                     QString &newName, bool autoRename = true);
+
+    /** Rename a page of a stack on the server.  @p page is 1-based. */
+    bool renamePage(const QString &repo, const QString &path,
+                    int page, const QString &newName);
+
+    /** Move (or copy) a stack to another directory in the same repo.
+     *  @p destDir is repo-relative; "" means the root.  On success
+     *  @p finalName holds the name in the destination, which differs
+     *  from the original on a collision. */
+    bool moveStack(const QString &repo, const QString &path,
+                   const QString &destDir, bool copy, QString *finalName);
+
+    /** Delete a stack outright (no trash). */
+    bool deleteStack(const QString &repo, const QString &path);
+
+    /** Name of the shared per-repo trash directory on the server. */
+    static QString trashDirName() { return QStringLiteral(".maxview-trash"); }
+
     /** Root of this server's on-disk file cache:
      *  <cache>/paperman/<serverId>.  Empty if the server id cannot be
      *  fetched (e.g. server unreachable and never seen before). */
@@ -148,6 +171,13 @@ private:
      *  not an error. */
     QByteArray waitForReplyFull(QNetworkReply *reply, int *status,
                                 QString *etag);
+
+    /** POST a JSON body to /v1/repos/{repo}/stacks/{path}{verb} and
+     *  parse the JSON reply into *out (optional).  Returns the reply's
+     *  success flag; on failure lastError() is set. */
+    bool postStackOp(const QString &repo, const QString &path,
+                     const QString &verb, const class QJsonObject &body,
+                     class QJsonObject *out);
 
     /** Construct an async GET against pathAndQuery.  Caller takes
      *  responsibility for the returned reply's signals; reply will

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -130,6 +130,37 @@ public:
     bool updateAnnotations(const QString &repo, const QString &path,
                            const class QJsonObject &updates);
 
+    /** Delete pages (1-based) from a stack on the server.  On success
+     *  @p undoId holds an opaque token which undeletePages() can
+     *  redeem to restore them; the server may forget it after a
+     *  while, so treat the undo as best-effort. */
+    bool deletePages(const QString &repo, const QString &path,
+                     const QList<int> &pages, QString *undoId);
+
+    /** Restore the pages removed by the deletePages() call that
+     *  returned @p undoId. */
+    bool undeletePages(const QString &repo, const QString &path,
+                       const QString &undoId);
+
+    /** Split @p pagecount pages starting at 1-based @p pagenum out of
+     *  a stack into a new stack in the same directory, removing them
+     *  from the source when @p remove is set.  @p suggestedName may
+     *  be empty; @p newName returns the name the server chose. */
+    bool unstackStack(const QString &repo, const QString &path,
+                      int pagenum, int pagecount, bool remove,
+                      const QString &suggestedName, QString *newName);
+
+    /** Append the pages of each source stack (repo-relative paths)
+     *  into @p destPath at 1-based @p insertPage (0 or past the end
+     *  appends), deleting the sources. */
+    bool stackStacks(const QString &repo, const QString &destPath,
+                     const QStringList &sources, int insertPage);
+
+    /** Copy a stack's file within its directory under a fresh name,
+     *  returned in @p newName. */
+    bool duplicateStack(const QString &repo, const QString &path,
+                        QString *newName);
+
     /** Name of the shared per-repo trash directory on the server. */
     static QString trashDirName() { return QStringLiteral(".maxview-trash"); }
 

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -104,6 +104,31 @@ public:
     bool transformPage(const QString &repo, const QString &path,
                        int page, const QString &op);
 
+    /** Root of this server's on-disk file cache:
+     *  <cache>/paperman/<serverId>.  Empty if the server id cannot be
+     *  fetched (e.g. server unreachable and never seen before). */
+    QString cacheRoot();
+
+    /** Directory caching files under @p dirInRepo of @p repo, without
+     *  a trailing slash.  Empty when cacheRoot() is empty.  The
+     *  directory is not created. */
+    QString cacheDirFor(const QString &repo, const QString &dirInRepo);
+
+    /** Cache pathname for a single repo file. */
+    QString cachePathFor(const QString &repo, const QString &relPath);
+
+    /** Make sure the cache holds a current copy of @p relPath in
+     *  @p repo: revalidate an existing copy with If-None-Match (a 304
+     *  costs no transfer) or download the bytes.  If the server cannot
+     *  be reached but a cached copy exists, that copy is returned so
+     *  already-fetched stacks stay viewable.  Returns the cache
+     *  pathname, or an empty string on failure (lastError() set). */
+    QString ensureCachedFile(const QString &repo, const QString &relPath);
+
+    /** Forget any cached copy of @p relPath (bytes and validator), so
+     *  the next ensureCachedFile() downloads afresh. */
+    void invalidateCachedFile(const QString &repo, const QString &relPath);
+
 signals:
     void browseDirectoryReady(quint64 token,
                               const DirectoryListing &listing);
@@ -114,10 +139,18 @@ private:
     QByteArray postRequest(const QString &path, const QByteArray &body);
     QByteArray waitForReply(QNetworkReply *reply);
 
+    /** waitForReply() variant that also surfaces the HTTP status code
+     *  and the response's ETag header (empty when absent).  A 304 is
+     *  not an error. */
+    QByteArray waitForReplyFull(QNetworkReply *reply, int *status,
+                                QString *etag);
+
     /** Construct an async GET against pathAndQuery.  Caller takes
      *  responsibility for the returned reply's signals; reply will
-     *  call deleteLater on itself once consumed. */
-    QNetworkReply *startGet(const QString &pathAndQuery);
+     *  call deleteLater on itself once consumed.  @p ifNoneMatch, when
+     *  non-empty, is sent as an If-None-Match header. */
+    QNetworkReply *startGet(const QString &pathAndQuery,
+                            const QString &ifNoneMatch = QString());
 
     /** Translate a /browse reply (body bytes + reply error state)
      *  into a typed DirectoryListing.  Shared by sync and async

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -122,8 +122,12 @@ public:
      *  costs no transfer) or download the bytes.  If the server cannot
      *  be reached but a cached copy exists, that copy is returned so
      *  already-fetched stacks stay viewable.  Returns the cache
-     *  pathname, or an empty string on failure (lastError() set). */
-    QString ensureCachedFile(const QString &repo, const QString &relPath);
+     *  pathname, or an empty string on failure (lastError() set).
+     *  @p refreshed, if non-null, is set true when new bytes were
+     *  written (so any parsed state is stale) and false when the
+     *  existing copy was already current. */
+    QString ensureCachedFile(const QString &repo, const QString &relPath,
+                             bool *refreshed = nullptr);
 
     /** Forget any cached copy of @p relPath (bytes and validator), so
      *  the next ensureCachedFile() downloads afresh. */

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -8,6 +8,7 @@ License: GPL-2
 #include "backend.h"
 
 #include <QObject>
+#include <QSet>
 #include <QString>
 #include <QUrl>
 
@@ -170,6 +171,16 @@ public:
                     const QByteArray &bytes, QString *finalName,
                     QString *etag);
 
+    /** Open (and keep open) the server's event stream for @p repo.
+     *  Each change made by another client is emitted as stackEvent();
+     *  our own changes are filtered out by client id.  The stream
+     *  reconnects automatically if it drops.  Idempotent. */
+    void subscribeEvents(const QString &repo);
+
+    /** Random id identifying this backend instance; sent with every
+     *  request so the server can mark events with their origin. */
+    QString clientId() const { return _clientId; }
+
     /** Name of the shared per-repo trash directory on the server. */
     static QString trashDirName() { return QStringLiteral(".maxview-trash"); }
 
@@ -207,6 +218,10 @@ signals:
                               const DirectoryListing &listing);
     void thumbnailReady(quint64 token, const QByteArray &jpegBytes);
 
+    /** A change made by another client arrived on the event stream */
+    void stackEvent(const QString &repo, const QString &op,
+                    const QString &path, const QString &name);
+
 private:
     QByteArray getRequest(const QString &pathAndQuery);
     QByteArray postRequest(const QString &path, const QByteArray &body,
@@ -239,13 +254,18 @@ private:
      *  paths. */
     DirectoryListing parseBrowseReply(QNetworkReply *reply);
 
+    /** (Re)connect the event stream for one repo. */
+    void startEventStream(const QString &repo);
+
     QUrl _baseUrl;
     QString _token;
     QString _serverId;
+    QString _clientId;
     QString _lastError;
     QNetworkAccessManager *_nam;
     class BackendStats *_stats = nullptr;
     quint64 _nextAsyncToken = 1;
+    QSet<QString> _eventRepos;  //!< repos with an event subscription
 };
 
 #endif // REMOTEBACKEND_H

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -164,12 +164,13 @@ public:
 
     /** Upload a whole file's bytes to the server at @p path (e.g. a
      *  stack scanned into a remote desk).  The server never
-     *  overwrites: on a name clash @p finalName differs from the
+     *  overwrites unless @p overwrite is set (used for the shared
+     *  desk file): on a name clash @p finalName differs from the
      *  requested one.  @p etag returns the stored file's validator,
      *  ready for the cache sidecar. */
     bool uploadFile(const QString &repo, const QString &path,
                     const QByteArray &bytes, QString *finalName,
-                    QString *etag);
+                    QString *etag, bool overwrite = false);
 
     /** Open (and keep open) the server's event stream for @p repo.
      *  Each change made by another client is emitted as stackEvent();

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -161,6 +161,15 @@ public:
     bool duplicateStack(const QString &repo, const QString &path,
                         QString *newName);
 
+    /** Upload a whole file's bytes to the server at @p path (e.g. a
+     *  stack scanned into a remote desk).  The server never
+     *  overwrites: on a name clash @p finalName differs from the
+     *  requested one.  @p etag returns the stored file's validator,
+     *  ready for the cache sidecar. */
+    bool uploadFile(const QString &repo, const QString &path,
+                    const QByteArray &bytes, QString *finalName,
+                    QString *etag);
+
     /** Name of the shared per-repo trash directory on the server. */
     static QString trashDirName() { return QStringLiteral(".maxview-trash"); }
 
@@ -200,7 +209,9 @@ signals:
 
 private:
     QByteArray getRequest(const QString &pathAndQuery);
-    QByteArray postRequest(const QString &path, const QByteArray &body);
+    QByteArray postRequest(const QString &path, const QByteArray &body,
+                           const QString &contentType
+                               = QStringLiteral("application/json"));
     QByteArray waitForReply(QNetworkReply *reply);
 
     /** waitForReply() variant that also surfaces the HTTP status code

--- a/remotebackend.h
+++ b/remotebackend.h
@@ -172,6 +172,12 @@ public:
                     const QByteArray &bytes, QString *finalName,
                     QString *etag, bool overwrite = false);
 
+    /** Run the server's OCR engine over 1-based page @p page of a
+     *  stack.  The server stores the text in the stack's ocr
+     *  annotation and returns it in @p text. */
+    bool ocrPage(const QString &repo, const QString &path, int page,
+                 QString *text);
+
     /** Open (and keep open) the server's event stream for @p repo.
      *  Each change made by another client is emitted as stackEvent();
      *  our own changes are filtered out by client id.  The stream

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -517,8 +517,20 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
     /* POST mutation routes (authenticated above).  These come before the
        GET routing chain, which assumes a GET. */
     if (method == "POST") {
-        if (path.startsWith("/v1/repos/") && path.endsWith("/transform"))
-            return handleTransform(path, params, authedUser);
+        if (path.startsWith("/v1/repos/")) {
+            if (path.endsWith("/transform"))
+                return handleTransform(path, params, authedUser);
+            /* the page-rename check must come before the stack rename:
+               both end in /rename */
+            if (path.endsWith("/rename") && path.contains("/pages/"))
+                return handleRenamePage(path, params, authedUser);
+            if (path.endsWith("/rename"))
+                return handleRename(path, params, authedUser);
+            if (path.endsWith("/move"))
+                return handleMove(path, params, authedUser);
+            if (path.endsWith("/delete"))
+                return handleDelete(path, params, authedUser);
+        }
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
                                 QString("POST not supported on this path"));
     }
@@ -806,25 +818,29 @@ QByteArray SearchServer::handleAuthLogin(const QHash<QString, QString> &params)
 }
 
 
-QByteArray SearchServer::handleTransform(const QString &path,
-                                         const QHash<QString, QString> &params,
-                                         const QString &authedUser)
+bool SearchServer::splitStackUrl(const QString &path, const QString &verb,
+                                 QString *repoName, QString *filePath)
 {
-    /* Path shape: /v1/repos/{repo}/stacks/{stackPath}/transform, where
+    /* Path shape: /v1/repos/{repo}/stacks/{stackPath}{verb}, where
        {stackPath} may itself contain '/' for subdirectories and is
        percent-encoded. */
     QString rest = path;
     rest.remove(0, QStringLiteral("/v1/repos/").size());
-    rest.chop(QStringLiteral("/transform").size());
+    rest.chop(verb.size());
     int sep = rest.indexOf("/stacks/");
     if (sep < 0)
-        return buildHttpResponse(400, "Bad Request", "application/json",
-                                 buildJsonResponse(false, "",
-                                     "Malformed transform path"));
-    QString repoName = urlDecode(rest.left(sep));
-    QString filePath = urlDecode(rest.mid(sep
-                                          + QStringLiteral("/stacks/").size()));
+        return false;
+    *repoName = QUrl::fromPercentEncoding(rest.left(sep).toUtf8());
+    *filePath = QUrl::fromPercentEncoding(
+        rest.mid(sep + QStringLiteral("/stacks/").size()).toUtf8());
+    return true;
+}
 
+QByteArray SearchServer::resolveStackTarget(const QString &repoName,
+                                            const QString &filePath,
+                                            const QString &authedUser,
+                                            StackTarget &out, bool mustExist)
+{
     // Security: prevent directory traversal
     if (filePath.isEmpty() || filePath.contains("..")
         || filePath.startsWith("/"))
@@ -856,6 +872,33 @@ QByteArray SearchServer::handleTransform(const QString &path,
                                          "Repository not found: " + repoName));
     }
 
+    out.repoName = repoName;
+    out.filePath = filePath;
+    out.repoPath = repoPath;
+    out.fullPath = repoPath + "/" + filePath;
+
+    if (mustExist && !QFileInfo::exists(out.fullPath))
+        return buildHttpResponse(404, "Not Found", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "File not found: " + filePath));
+    return QByteArray();
+}
+
+QByteArray SearchServer::handleTransform(const QString &path,
+                                         const QHash<QString, QString> &params,
+                                         const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/transform", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed transform path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
     // Parse the body: { "page": N, "op": "rotate90" }
     QByteArray body = params.value("__body__").toUtf8();
     QJsonParseError jerr;
@@ -874,13 +917,7 @@ QByteArray SearchServer::handleTransform(const QString &path,
        every page of the stack. */
     int page = obj.value("page").toInt(-1);
 
-    QString fullPath = repoPath + "/" + filePath;
-    QFileInfo fi(fullPath);
-    if (!fi.exists())
-        return buildHttpResponse(404, "Not Found", "application/json",
-                                 buildJsonResponse(false, "",
-                                     "File not found: " + filePath));
-
+    QFileInfo fi(target.fullPath);
     File::e_type type = File::typeFromName(fi.fileName());
     File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
                                   nullptr, type);
@@ -929,6 +966,264 @@ QByteArray SearchServer::handleTransform(const QString &path,
     /* The file's mtime has changed, so cached thumbnails and pages
        (whose cache keys include the mtime) will miss and be re-rendered
        on the next request; no explicit cache invalidation is needed. */
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
+}
+
+QString SearchServer::uniqueNameIn(const QString &dir, const QString &base,
+                                   const QString &ext)
+{
+    if (!QFileInfo::exists(dir + "/" + base + ext))
+        return base + ext;
+    for (int i = 1; i < 10000; i++) {
+        QString name = base + "_" + QString::number(i) + ext;
+        if (!QFileInfo::exists(dir + "/" + name))
+            return name;
+    }
+    return QString();
+}
+
+/* Parse a JSON object request body; returns false and fills *resp with
+   a 400 response when it is not one. */
+static bool parseJsonBody(const QHash<QString, QString> &params,
+                          QJsonObject *obj)
+{
+    QJsonParseError jerr;
+    QJsonDocument doc = QJsonDocument::fromJson(
+        params.value("__body__").toUtf8(), &jerr);
+    if (jerr.error != QJsonParseError::NoError || !doc.isObject())
+        return false;
+    *obj = doc.object();
+    return true;
+}
+
+QByteArray SearchServer::handleRename(const QString &path,
+                                      const QHash<QString, QString> &params,
+                                      const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/rename", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed rename path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {newName}"));
+    QString newName = obj.value("newName").toString();
+    bool autoRename = obj.value("autoRename").toBool(true);
+    if (newName.isEmpty() || newName.contains('/')
+        || newName.contains(".."))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Invalid new name"));
+
+    QFileInfo fi(target.fullPath);
+    QString dir = fi.absolutePath();
+    if (newName == fi.fileName())
+        ;   // nothing to do
+    else if (QFileInfo::exists(dir + "/" + newName)) {
+        if (!autoRename)
+            return buildHttpResponse(409, "Conflict", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Name already exists: " + newName));
+        QFileInfo ni(newName);
+        newName = uniqueNameIn(dir, ni.completeBaseName(),
+                               "." + ni.suffix());
+        if (newName.isEmpty())
+            return buildHttpResponse(409, "Conflict", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "No unique name available"));
+    }
+    if (newName != fi.fileName()
+        && !QFile::rename(target.fullPath, dir + "/" + newName))
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Rename failed"));
+
+    _log.log(ServerLog::ServeFile, target.filePath + " -> " + newName);
+    QJsonObject out;
+    out["success"] = true;
+    out["name"] = newName;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
+}
+
+QByteArray SearchServer::handleMove(const QString &path,
+                                    const QHash<QString, QString> &params,
+                                    const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/move", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed move path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {destDir}"));
+    QString destDir = obj.value("destDir").toString();
+    bool copy = obj.value("copy").toBool(false);
+    if (destDir.contains("..") || destDir.startsWith("/"))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Invalid destination"));
+
+    QString destPath = target.repoPath;
+    if (!destDir.isEmpty())
+        destPath += "/" + destDir;
+
+    /* the shared trash is created on demand; anything else must
+       already exist */
+    if (!QDir(destPath).exists()) {
+        if (destDir == trashDirName())
+            QDir().mkpath(destPath);
+        else
+            return buildHttpResponse(404, "Not Found", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Destination not found: "
+                                         + destDir));
+    }
+
+    QFileInfo fi(target.fullPath);
+    QString name = fi.fileName();
+    if (QFileInfo::exists(destPath + "/" + name)) {
+        name = uniqueNameIn(destPath, fi.completeBaseName() + "_move",
+                            "." + fi.suffix());
+        if (name.isEmpty())
+            return buildHttpResponse(409, "Conflict", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "No unique name available"));
+    }
+
+    bool ok = copy ? QFile::copy(target.fullPath, destPath + "/" + name)
+                   : QFile::rename(target.fullPath, destPath + "/" + name);
+    if (!ok)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     copy ? "Copy failed" : "Move failed"));
+
+    _log.log(ServerLog::ServeFile, target.filePath + " -> " + destDir
+             + "/" + name);
+    QJsonObject out;
+    out["success"] = true;
+    out["name"] = name;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
+}
+
+QByteArray SearchServer::handleDelete(const QString &path,
+                                      const QHash<QString, QString> &params,
+                                      const QString &authedUser)
+{
+    UNUSED(params);
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/delete", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed delete path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    if (!QFile::remove(target.fullPath))
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Delete failed"));
+
+    _log.log(ServerLog::ServeFile, "delete " + target.filePath);
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
+}
+
+QByteArray SearchServer::handleRenamePage(const QString &path,
+                                          const QHash<QString, QString> &params,
+                                          const QString &authedUser)
+{
+    /* Path shape: .../stacks/{path}/pages/{n}/rename */
+    QString rest = path;
+    rest.chop(QStringLiteral("/rename").size());
+    int sep = rest.lastIndexOf("/pages/");
+    if (sep < 0)
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed page-rename path"));
+    bool numOk = false;
+    int page = rest.mid(sep + QStringLiteral("/pages/").size())
+                   .toInt(&numOk);
+    if (!numOk || page < 1)
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Invalid page number"));
+
+    QString repoName, filePath;
+    if (!splitStackUrl(rest.left(sep), "", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed page-rename path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {newName}"));
+    QString newName = obj.value("newName").toString();
+
+    QFileInfo fi(target.fullPath);
+    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
+                                  nullptr, File::typeFromName(fi.fileName()));
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Cannot open file"));
+    err_info *err = file->load();
+    if (!err && page > file->pagecount()) {
+        delete file;
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Page out of range"));
+    }
+    if (!err)
+        err = file->renamePage(page - 1, newName);
+    if (!err)
+        err = file->flush();
+    if (err) {
+        QString msg = err->errstr;
+        delete file;
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", msg));
+    }
+    delete file;
+
+    _log.log(ServerLog::ServeFile, target.filePath + " page renamed");
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -520,18 +520,29 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         if (path.startsWith("/v1/repos/")) {
             if (path.endsWith("/transform"))
                 return handleTransform(path, params, authedUser);
-            /* the page-rename check must come before the stack rename:
-               both end in /rename */
+            /* the page-rename check must come before the stack rename
+               (both end in /rename); likewise pages/delete before the
+               stack delete */
             if (path.endsWith("/rename") && path.contains("/pages/"))
                 return handleRenamePage(path, params, authedUser);
             if (path.endsWith("/rename"))
                 return handleRename(path, params, authedUser);
             if (path.endsWith("/move"))
                 return handleMove(path, params, authedUser);
+            if (path.endsWith("/pages/delete"))
+                return handleDeletePages(path, params, authedUser);
+            if (path.endsWith("/pages/undelete"))
+                return handleUndeletePages(path, params, authedUser);
             if (path.endsWith("/delete"))
                 return handleDelete(path, params, authedUser);
             if (path.endsWith("/annotations"))
                 return handleUpdateAnnot(path, params, authedUser);
+            if (path.endsWith("/unstack"))
+                return handleUnstack(path, params, authedUser);
+            if (path.endsWith("/stack"))
+                return handleStack(path, params, authedUser);
+            if (path.endsWith("/duplicate"))
+                return handleDuplicate(path, params, authedUser);
         }
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
                                 QString("POST not supported on this path"));
@@ -1288,6 +1299,356 @@ QByteArray SearchServer::handleUpdateAnnot(const QString &path,
     _log.log(ServerLog::ServeFile, target.filePath + " annotations");
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
+}
+
+/* Open the target's file via the File classes and load it; returns
+   nullptr with *errMsg set on failure. */
+static File *openTargetFile(const QString &fullPath, QString *errMsg)
+{
+    QFileInfo fi(fullPath);
+    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
+                                  nullptr, File::typeFromName(fi.fileName()));
+    err_info *err = file ? file->load() : nullptr;
+    if (!file || err) {
+        *errMsg = err ? err->errstr : QStringLiteral("Cannot open file");
+        delete file;
+        return nullptr;
+    }
+    return file;
+}
+
+QByteArray SearchServer::handleDeletePages(const QString &path,
+                                           const QHash<QString, QString> &params,
+                                           const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/pages/delete", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed pages-delete path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj) || !obj.value("pages").isArray())
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {pages:[...]}"));
+
+    QString openFail;
+    File *file = openTargetFile(target.fullPath, &openFail);
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", openFail));
+
+    int pagecount = file->pagecount();
+    QBitArray pages(pagecount);
+    int count = 0;
+    for (const QJsonValue &v : obj.value("pages").toArray()) {
+        int n = v.toInt();
+        if (n < 1 || n > pagecount) {
+            delete file;
+            return buildHttpResponse(400, "Bad Request", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Page out of range"));
+        }
+        if (!pages.testBit(n - 1)) {
+            pages.setBit(n - 1);
+            count++;
+        }
+    }
+    if (!count || count >= pagecount) {
+        delete file;
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Must leave at least one page"));
+    }
+
+    QByteArray delInfo;
+    err_info *err = file->removePages(pages, delInfo, count);
+    delete file;
+    if (err)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", err->errstr));
+
+    PageUndo undo;
+    undo.fullPath = target.fullPath;
+    undo.pages = pages;
+    undo.delInfo = delInfo;
+    undo.count = count;
+    QString undoId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    _pageUndos[undoId] = undo;
+
+    _log.log(ServerLog::ServeFile, target.filePath + " pages deleted");
+    QJsonObject out;
+    out["success"] = true;
+    out["undoId"] = undoId;
+    out["count"] = count;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
+}
+
+QByteArray SearchServer::handleUndeletePages(const QString &path,
+                                             const QHash<QString, QString> &params,
+                                             const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/pages/undelete", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed pages-undelete path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    QString undoId;
+    if (parseJsonBody(params, &obj))
+        undoId = obj.value("undoId").toString();
+    auto it = _pageUndos.find(undoId);
+    if (undoId.isEmpty() || it == _pageUndos.end()
+        || it->fullPath != target.fullPath)
+        return buildHttpResponse(410, "Gone", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Unknown or expired undoId"));
+
+    QString openFail;
+    File *file = openTargetFile(target.fullPath, &openFail);
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", openFail));
+
+    err_info *err = file->restorePages(it->pages, it->delInfo, it->count);
+    delete file;
+    if (err)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", err->errstr));
+    _pageUndos.erase(it);
+
+    _log.log(ServerLog::ServeFile, target.filePath + " pages restored");
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
+}
+
+QByteArray SearchServer::handleUnstack(const QString &path,
+                                       const QHash<QString, QString> &params,
+                                       const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/unstack", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed unstack path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON"));
+    int pagenum = obj.value("pagenum").toInt();
+    int pagecount = obj.value("pagecount").toInt(1);
+    bool removePages = obj.value("remove").toBool(false);
+    QString newName = obj.value("newName").toString();
+
+    QString openFail;
+    File *file = openTargetFile(target.fullPath, &openFail);
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", openFail));
+
+    int srcCount = file->pagecount();
+    if (pagenum < 1 || pagecount < 1 || pagenum - 1 + pagecount > srcCount
+        || (removePages && pagecount >= srcCount)) {
+        delete file;
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Page range invalid"));
+    }
+
+    /* pick the destination name: the caller's suggestion, or the page
+       title, or a name built from the source, made unique on disk */
+    QFileInfo fi(target.fullPath);
+    QString ext = "." + fi.suffix();
+    QString base;
+    if (!newName.isEmpty() && !newName.contains('/')
+        && !newName.contains(".."))
+        base = QFileInfo(newName).completeBaseName();
+    if (base.isEmpty())
+        base = file->pageTitle(pagenum - 1);
+    if (base.isEmpty())
+        base = pagecount == 1
+            ? QString("%1_page_%2").arg(fi.completeBaseName())
+                  .arg(pagenum)
+            : QString("%1_pages_%2_to_%3").arg(fi.completeBaseName())
+                  .arg(pagenum).arg(pagenum + pagecount - 1);
+    QString uniq = uniqueNameIn(fi.absolutePath(), base, ext);
+    if (uniq.isEmpty()) {
+        delete file;
+        return buildHttpResponse(409, "Conflict", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "No unique name available"));
+    }
+
+    File *dest = File::createFile(fi.absolutePath() + "/", uniq, nullptr,
+                                  File::typeFromName(fi.fileName()));
+    err_info *err = dest ? dest->create() : nullptr;
+    if (!err)
+        err = file->unstackPages(pagenum - 1, pagecount, removePages, dest);
+    if (!err)
+        err = dest->flush();
+    if (!err)
+        err = file->flush();
+    delete dest;
+    delete file;
+    if (err)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", err->errstr));
+
+    _log.log(ServerLog::ServeFile, target.filePath + " unstacked");
+    QJsonObject out;
+    out["success"] = true;
+    out["name"] = uniq;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
+}
+
+QByteArray SearchServer::handleStack(const QString &path,
+                                     const QHash<QString, QString> &params,
+                                     const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/stack", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed stack path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj) || !obj.value("sources").isArray())
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be JSON {sources:[...]}"));
+
+    /* resolve every source first so a bad one aborts before anything
+       is modified */
+    QList<StackTarget> sources;
+    for (const QJsonValue &v : obj.value("sources").toArray()) {
+        StackTarget src;
+        QByteArray bad = resolveStackTarget(repoName, v.toString(),
+                                            authedUser, src);
+        if (!bad.isEmpty())
+            return bad;
+        if (File::typeFromName(src.fullPath)
+            != File::typeFromName(target.fullPath))
+            return buildHttpResponse(400, "Bad Request", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Source type differs: "
+                                         + src.filePath));
+        sources << src;
+    }
+    if (sources.isEmpty())
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "No sources given"));
+
+    QString openFail;
+    File *dest = openTargetFile(target.fullPath, &openFail);
+    if (!dest)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", openFail));
+
+    /* insertPage is 1-based; absent or past the end means append */
+    int insertPage = obj.value("insertPage").toInt(dest->pagecount() + 1);
+    dest->setPagenum(qBound(0, insertPage - 1, dest->pagecount()));
+
+    err_info *err = nullptr;
+    foreach (const StackTarget &src, sources) {
+        File *fsrc = openTargetFile(src.fullPath, &openFail);
+        if (!fsrc) {
+            err = err_make(ERRFN, ERR_could_not_open_file_for_reading1,
+                           qPrintable(src.filePath));
+            break;
+        }
+        int nextInsert = dest->pagenum() + fsrc->pagecount();
+        err = dest->stackStack(fsrc);
+        delete fsrc;
+        if (err)
+            break;
+        QFile::remove(src.fullPath);
+        dest->setPagenum(qMin(nextInsert, dest->pagecount()));
+    }
+    if (!err)
+        err = dest->flush();
+    delete dest;
+    if (err)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", err->errstr));
+
+    _log.log(ServerLog::ServeFile, target.filePath + " stacked");
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
+}
+
+QByteArray SearchServer::handleDuplicate(const QString &path,
+                                         const QHash<QString, QString> &params,
+                                         const QString &authedUser)
+{
+    UNUSED(params);
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/duplicate", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed duplicate path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QFileInfo fi(target.fullPath);
+    QString uniq = uniqueNameIn(fi.absolutePath(), fi.completeBaseName(),
+                                "." + fi.suffix());
+    if (uniq.isEmpty())
+        return buildHttpResponse(409, "Conflict", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "No unique name available"));
+    if (!QFile::copy(target.fullPath, fi.absolutePath() + "/" + uniq))
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Copy failed"));
+
+    _log.log(ServerLog::ServeFile, target.filePath + " -> " + uniq);
+    QJsonObject out;
+    out["success"] = true;
+    out["name"] = uniq;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
 }
 
 QString SearchServer::searchFiles(const QString &repoPath, const QString &searchPath,

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -257,6 +257,11 @@ void SearchServer::onClientDisconnected()
          it != _pendingExtractions.end(); ++it)
         it->waiters.removeAll(client);
 
+    // Drop any event subscription this socket held
+    for (int i = _eventClients.size() - 1; i >= 0; i--)
+        if (_eventClients[i].socket == client)
+            _eventClients.removeAt(i);
+
     client->deleteLater();
 }
 
@@ -451,6 +456,8 @@ void SearchServer::parseRequest(const QString &request, QString &method,
                 }
             } else if (headerName.toLower() == "if-none-match") {
                 params["__if_none_match__"] = headerValue;
+            } else if (headerName.toLower() == "x-client-id") {
+                params["__client_id__"] = headerValue;
             }
         }
     }
@@ -791,6 +798,9 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
 
         return response;
     }
+    else if (path.startsWith("/v1/repos/") && path.endsWith("/events")) {
+        return handleEvents(path, params, authedUser, client);
+    }
     else {
         return buildHttpResponse(404, "Not Found", "text/plain",
                                 QString("Endpoint not found"));
@@ -989,6 +999,8 @@ QByteArray SearchServer::handleTransform(const QString &path,
     /* The file's mtime has changed, so cached thumbnails and pages
        (whose cache keys include the mtime) will miss and be re-rendered
        on the next request; no explicit cache invalidation is needed. */
+    notifyStackEvent(target.repoName, "transform", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1073,6 +1085,8 @@ QByteArray SearchServer::handleRename(const QString &path,
                                      "Rename failed"));
 
     _log.log(ServerLog::ServeFile, target.filePath + " -> " + newName);
+    notifyStackEvent(target.repoName, "rename", target.filePath, newName,
+                     params.value("__client_id__"));
     QJsonObject out;
     out["success"] = true;
     out["name"] = newName;
@@ -1145,6 +1159,9 @@ QByteArray SearchServer::handleMove(const QString &path,
 
     _log.log(ServerLog::ServeFile, target.filePath + " -> " + destDir
              + "/" + name);
+    notifyStackEvent(target.repoName, "move", target.filePath,
+                     destDir.isEmpty() ? name : destDir + "/" + name,
+                     params.value("__client_id__"));
     QJsonObject out;
     out["success"] = true;
     out["name"] = name;
@@ -1176,6 +1193,8 @@ QByteArray SearchServer::handleDelete(const QString &path,
                                      "Delete failed"));
 
     _log.log(ServerLog::ServeFile, "delete " + target.filePath);
+    notifyStackEvent(target.repoName, "delete", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1247,6 +1266,8 @@ QByteArray SearchServer::handleRenamePage(const QString &path,
     delete file;
 
     _log.log(ServerLog::ServeFile, target.filePath + " page renamed");
+    notifyStackEvent(target.repoName, "renamePage", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1307,6 +1328,8 @@ QByteArray SearchServer::handleUpdateAnnot(const QString &path,
     delete file;
 
     _log.log(ServerLog::ServeFile, target.filePath + " annotations");
+    notifyStackEvent(target.repoName, "annotations", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1395,6 +1418,8 @@ QByteArray SearchServer::handleDeletePages(const QString &path,
     _pageUndos[undoId] = undo;
 
     _log.log(ServerLog::ServeFile, target.filePath + " pages deleted");
+    notifyStackEvent(target.repoName, "pagesDeleted", target.filePath, "",
+                     params.value("__client_id__"));
     QJsonObject out;
     out["success"] = true;
     out["undoId"] = undoId;
@@ -1446,6 +1471,8 @@ QByteArray SearchServer::handleUndeletePages(const QString &path,
     _pageUndos.erase(it);
 
     _log.log(ServerLog::ServeFile, target.filePath + " pages restored");
+    notifyStackEvent(target.repoName, "pagesRestored", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1532,6 +1559,8 @@ QByteArray SearchServer::handleUnstack(const QString &path,
                                  buildJsonResponse(false, "", err->errstr));
 
     _log.log(ServerLog::ServeFile, target.filePath + " unstacked");
+    notifyStackEvent(target.repoName, "unstack", target.filePath, uniq,
+                     params.value("__client_id__"));
     QJsonObject out;
     out["success"] = true;
     out["name"] = uniq;
@@ -1619,6 +1648,8 @@ QByteArray SearchServer::handleStack(const QString &path,
                                  buildJsonResponse(false, "", err->errstr));
 
     _log.log(ServerLog::ServeFile, target.filePath + " stacked");
+    notifyStackEvent(target.repoName, "stack", target.filePath, "",
+                     params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }
@@ -1679,6 +1710,8 @@ QByteArray SearchServer::handleUpload(const QString &path,
                                      "Cannot commit file"));
 
     _log.log(ServerLog::ServeFile, "upload " + target.filePath);
+    notifyStackEvent(target.repoName, "upload", target.filePath, name,
+                     params.value("__client_id__"));
     QJsonObject outObj;
     outObj["success"] = true;
     outObj["name"] = name;
@@ -1686,6 +1719,81 @@ QByteArray SearchServer::handleUpload(const QString &path,
     return buildHttpResponse(200, "OK", "application/json",
                              QString::fromUtf8(QJsonDocument(outObj).toJson(
                                  QJsonDocument::Compact)));
+}
+
+QByteArray SearchServer::handleEvents(const QString &path,
+                                      const QHash<QString, QString> &params,
+                                      const QString &authedUser,
+                                      QTcpSocket *client)
+{
+    UNUSED(params);
+    QString rest = path;
+    rest.remove(0, QStringLiteral("/v1/repos/").size());
+    rest.chop(QStringLiteral("/events").size());
+    QString repoName = QUrl::fromPercentEncoding(rest.toUtf8());
+
+    if (!authedUser.isEmpty() && !_users.repoAllowed(authedUser, repoName))
+        return buildHttpResponse(403, "Forbidden", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "User not permitted to access repository: "
+                                     + repoName));
+
+    /* the response never completes: send the SSE header now and keep
+       the socket registered for event frames */
+    /* No Content-Length and Connection: close makes the body
+       close-delimited, so the client keeps reading frames until the
+       stream really ends. */
+    QByteArray headers;
+    headers += "HTTP/1.1 200 OK\r\n";
+    headers += "Content-Type: text/event-stream\r\n";
+    headers += "Cache-Control: no-cache\r\n";
+    headers += "Access-Control-Allow-Origin: *\r\n";
+    headers += "Connection: close\r\n";
+    headers += "\r\n";
+    headers += ": connected\n\n";
+    client->write(headers);
+    client->flush();
+
+    EventClient ec;
+    ec.socket = client;
+    ec.repoName = repoName;
+    _eventClients << ec;
+    qDebug().noquote() << "SearchServer: event subscriber for" << repoName;
+    return QByteArray();
+}
+
+void SearchServer::notifyStackEvent(const QString &repoName,
+                                    const QString &op, const QString &path,
+                                    const QString &name,
+                                    const QString &clientId)
+{
+    if (_eventClients.isEmpty())
+        return;
+
+    QJsonObject data;
+    data["repo"] = repoName;
+    data["op"] = op;
+    data["path"] = path;
+    if (!name.isEmpty())
+        data["name"] = name;
+    if (!clientId.isEmpty())
+        data["origin"] = clientId;
+    QByteArray frame = "event: stackChanged\ndata: "
+        + QJsonDocument(data).toJson(QJsonDocument::Compact) + "\n\n";
+
+    for (int i = _eventClients.size() - 1; i >= 0; i--) {
+        EventClient &ec = _eventClients[i];
+
+        if (!ec.socket
+            || ec.socket->state() != QAbstractSocket::ConnectedState) {
+            _eventClients.removeAt(i);
+            continue;
+        }
+        if (ec.repoName == repoName) {
+            ec.socket->write(frame);
+            ec.socket->flush();
+        }
+    }
 }
 
 QByteArray SearchServer::handleDuplicate(const QString &path,
@@ -1718,6 +1826,8 @@ QByteArray SearchServer::handleDuplicate(const QString &path,
                                      "Copy failed"));
 
     _log.log(ServerLog::ServeFile, target.filePath + " -> " + uniq);
+    notifyStackEvent(target.repoName, "duplicate", target.filePath, uniq,
+                     params.value("__client_id__"));
     QJsonObject out;
     out["success"] = true;
     out["name"] = uniq;

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -21,6 +21,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
  Public License can be found in the /usr/share/common-licenses/GPL file.
 */
 
+#include "ocr.h"
 #include "searchserver.h"
 #include "localbackend.h"
 #include "serverlog.h"
@@ -535,6 +536,8 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         if (path.startsWith("/v1/repos/")) {
             if (path.endsWith("/transform"))
                 return handleTransform(path, params, authedUser);
+            if (path.endsWith("/ocr") && path.contains("/pages/"))
+                return handleOcrPage(path, params, authedUser);
             /* the page-rename check must come before the stack rename
                (both end in /rename); likewise pages/delete before the
                stack delete */
@@ -1272,6 +1275,113 @@ QByteArray SearchServer::handleRenamePage(const QString &path,
                              buildJsonResponse(true, "", ""));
 }
 
+/* Open the target's file via the File classes and load it; returns
+   nullptr with *errMsg set on failure. */
+static File *openTargetFile(const QString &fullPath, QString *errMsg)
+{
+    QFileInfo fi(fullPath);
+    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
+                                  nullptr, File::typeFromName(fi.fileName()));
+    err_info *err = file ? file->load() : nullptr;
+    if (!file || err) {
+        *errMsg = err ? err->errstr : QStringLiteral("Cannot open file");
+        delete file;
+        return nullptr;
+    }
+    return file;
+}
+
+QByteArray SearchServer::handleOcrPage(const QString &path,
+                                       const QHash<QString, QString> &params,
+                                       const QString &authedUser)
+{
+    /* Path shape: .../stacks/{path}/pages/{n}/ocr */
+    QString rest = path;
+    rest.chop(QStringLiteral("/ocr").size());
+    int sep = rest.lastIndexOf("/pages/");
+    if (sep < 0)
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed ocr path"));
+    bool numOk = false;
+    int page = rest.mid(sep + QStringLiteral("/pages/").size())
+                   .toInt(&numOk);
+    if (!numOk || page < 1)
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Invalid page number"));
+
+    QString repoName, filePath;
+    if (!splitStackUrl(rest.left(sep), "", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed ocr path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    err_info *err;
+    Ocr *ocr = Ocr::getOcr(err);
+    if (!ocr)
+        return buildHttpResponse(501, "Not Implemented", "application/json",
+                                 buildJsonResponse(false, "",
+                                     err ? err->errstr
+                                         : "No OCR engine available"));
+
+    QString openFail;
+    File *file = openTargetFile(target.fullPath, &openFail);
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", openFail));
+    if (page > file->pagecount()) {
+        delete file;
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Page out of range"));
+    }
+
+    QImage image;
+    QSize size, trueSize;
+    int bpp;
+    err = file->getImage(page - 1, false, image, size, trueSize, bpp,
+                         false);
+
+    QString text;
+    if (!err)
+        err = ocr->imageToText(image, text);
+
+    /* store the text the way the GUI does, in the stack's ocr
+       annotation, so search and the annotations pane see it */
+    if (!err) {
+        QHash<int, QString> updates;
+        updates[File::Annot_ocr] = text;
+        err = file->putAnnot(updates);
+    }
+    if (!err)
+        err = file->flush();
+    if (err) {
+        QString msg = err->errstr;
+        delete file;
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", msg));
+    }
+    delete file;
+
+    _log.log(ServerLog::ServeFile, target.filePath + " ocr");
+    notifyStackEvent(target.repoName, "annotations", target.filePath, "",
+                     params.value("__client_id__"));
+    QJsonObject out;
+    out["success"] = true;
+    out["text"] = text;
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(out).toJson(
+                                 QJsonDocument::Compact)));
+}
+
 QByteArray SearchServer::handleUpdateAnnot(const QString &path,
                                            const QHash<QString, QString> &params,
                                            const QString &authedUser)
@@ -1332,22 +1442,6 @@ QByteArray SearchServer::handleUpdateAnnot(const QString &path,
                      params.value("__client_id__"));
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
-}
-
-/* Open the target's file via the File classes and load it; returns
-   nullptr with *errMsg set on failure. */
-static File *openTargetFile(const QString &fullPath, QString *errMsg)
-{
-    QFileInfo fi(fullPath);
-    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
-                                  nullptr, File::typeFromName(fi.fileName()));
-    err_info *err = file ? file->load() : nullptr;
-    if (!file || err) {
-        *errMsg = err ? err->errstr : QStringLiteral("Cannot open file");
-        delete file;
-        return nullptr;
-    }
-    return file;
 }
 
 QByteArray SearchServer::handleDeletePages(const QString &path,

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -1682,10 +1682,13 @@ QByteArray SearchServer::handleUpload(const QString &path,
                                  buildJsonResponse(false, "",
                                      "Directory not found"));
 
-    /* never overwrite: a name clash (e.g. two clients scanning at
-       once) gets a fresh name, reported back to the caller */
+    /* Never overwrite by default: a name clash (e.g. two clients
+       scanning at once) gets a fresh name, reported back to the
+       caller.  ?overwrite=true replaces in place, for files like the
+       shared desk file whose identity is its name. */
+    bool overwrite = params.value("overwrite") == "true";
     QString name = fi.fileName();
-    if (QFileInfo::exists(target.fullPath)) {
+    if (!overwrite && QFileInfo::exists(target.fullPath)) {
         name = uniqueNameIn(fi.absolutePath(), fi.completeBaseName(),
                             "." + fi.suffix());
         if (name.isEmpty())

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -530,6 +530,8 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                 return handleMove(path, params, authedUser);
             if (path.endsWith("/delete"))
                 return handleDelete(path, params, authedUser);
+            if (path.endsWith("/annotations"))
+                return handleUpdateAnnot(path, params, authedUser);
         }
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
                                 QString("POST not supported on this path"));
@@ -1224,6 +1226,66 @@ QByteArray SearchServer::handleRenamePage(const QString &path,
     delete file;
 
     _log.log(ServerLog::ServeFile, target.filePath + " page renamed");
+    return buildHttpResponse(200, "OK", "application/json",
+                             buildJsonResponse(true, "", ""));
+}
+
+QByteArray SearchServer::handleUpdateAnnot(const QString &path,
+                                           const QHash<QString, QString> &params,
+                                           const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/annotations", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed annotations path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target);
+    if (!fail.isEmpty())
+        return fail;
+
+    QJsonObject obj;
+    if (!parseJsonBody(params, &obj))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Body must be a JSON object"));
+
+    /* accept any subset of the known annotation fields; unknown keys
+       are an error so typos don't silently discard an update */
+    QHash<int, QString> updates;
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        File::e_annot type;
+        if (!File::annotFromWireName(it.key(), type))
+            return buildHttpResponse(400, "Bad Request", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "Unknown annotation: " + it.key()));
+        updates[type] = it.value().toString();
+    }
+
+    QFileInfo fi(target.fullPath);
+    File *file = File::createFile(fi.absolutePath() + "/", fi.fileName(),
+                                  nullptr, File::typeFromName(fi.fileName()));
+    if (!file)
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Cannot open file"));
+    err_info *err = file->load();
+    if (!err)
+        err = file->putAnnot(updates);
+    if (!err)
+        err = file->flush();
+    if (err) {
+        QString msg = err->errstr;
+        delete file;
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "", msg));
+    }
+    delete file;
+
+    _log.log(ServerLog::ServeFile, target.filePath + " annotations");
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
 }

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -441,6 +441,8 @@ void SearchServer::parseRequest(const QString &request, QString &method,
                         headerValue.mid(QStringLiteral("Bearer ").size())
                                    .trimmed();
                 }
+            } else if (headerName.toLower() == "if-none-match") {
+                params["__if_none_match__"] = headerValue;
             }
         }
     }
@@ -678,7 +680,7 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
         }
 
         return getFile(repoPath, filePath, type, page, wantPageCount,
-                       client);
+                       client, params.value("__if_none_match__"));
     }
     else if (path == "/thumbnail") {
         QString filePath = params.value("path", "");
@@ -1107,7 +1109,8 @@ QString SearchServer::listRepositories(const QString &user)
 
 QByteArray SearchServer::getFile(const QString &repoPath, const QString &filePath,
                                  const QString &type, int page,
-                                 bool wantPageCount, QTcpSocket *client)
+                                 bool wantPageCount, QTcpSocket *client,
+                                 const QString &ifNoneMatch)
 {
     // Security: Prevent directory traversal
     if (filePath.contains("..") || filePath.startsWith("/")) {
@@ -1237,9 +1240,30 @@ QByteArray SearchServer::getFile(const QString &repoPath, const QString &filePat
         contentType = "application/octet-stream";
     }
 
+    /* A whole-file download carries an ETag so a client holding a
+     * cached copy can revalidate it with If-None-Match and skip the
+     * transfer when nothing changed.  Size plus mtime is enough to
+     * spot any change the server itself could see. */
+    QString etag = fileEtag(fileInfo);
+    if (!ifNoneMatch.isEmpty() && ifNoneMatch == etag) {
+        QByteArray response;
+        response += "HTTP/1.1 304 Not Modified\r\n";
+        response += "ETag: " + etag.toUtf8() + "\r\n";
+        response += "Connection: close\r\n";
+        response += "\r\n";
+        return response;
+    }
+
     _log.log(ServerLog::ServeFile, filePath);
-    streamFile(fullPath, contentType, client);
+    streamFile(fullPath, contentType, client, etag);
     return QByteArray();
+}
+
+QString SearchServer::fileEtag(const QFileInfo &info)
+{
+    return QString("\"%1-%2\"")
+        .arg(info.size())
+        .arg(info.lastModified().toMSecsSinceEpoch());
 }
 
 QString SearchServer::buildJsonResponse(bool success, const QString &data,
@@ -1297,7 +1321,8 @@ QByteArray SearchServer::buildHttpResponse(int statusCode, const QString &status
 
 void SearchServer::streamFile(const QString &filePath,
                               const QString &contentType,
-                              QTcpSocket *client)
+                              QTcpSocket *client,
+                              const QString &etag)
 {
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -1317,6 +1342,8 @@ void SearchServer::streamFile(const QString &filePath,
     headers += "HTTP/1.1 200 OK\r\n";
     headers += "Content-Type: " + contentType.toUtf8() + "\r\n";
     headers += "Content-Length: " + QByteArray::number(size) + "\r\n";
+    if (!etag.isEmpty())
+        headers += "ETag: " + etag.toUtf8() + "\r\n";
     headers += "Access-Control-Allow-Origin: *\r\n";
     headers += "Connection: close\r\n";
     headers += "\r\n";

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -37,6 +37,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QDateTime>
 #include <QStandardPaths>
 #include <QUrl>
+#include <QSaveFile>
 #include <QUuid>
 #include <QDebug>
 #include <QProcess>
@@ -312,6 +313,13 @@ void SearchServer::onReadyRead()
 
     parseRequest(request, method, path, params);
 
+    /* parseRequest() hands the body around as a QString, which
+       mangles binary data; stash the raw bytes for handlers that
+       need them (e.g. file upload) */
+    if (contentLength > 0)
+        params["__body_b64__"] = QString::fromLatin1(
+            full.mid(headerEnd + 4, contentLength).toBase64());
+
     // Reconstruct the request URI for logging
     QString requestUri = path;
     QStringList queryParts;
@@ -543,6 +551,8 @@ QByteArray SearchServer::handleRequest(const QString &method, const QString &pat
                 return handleStack(path, params, authedUser);
             if (path.endsWith("/duplicate"))
                 return handleDuplicate(path, params, authedUser);
+            if (path.endsWith("/upload"))
+                return handleUpload(path, params, authedUser);
         }
         return buildHttpResponse(405, "Method Not Allowed", "text/plain",
                                 QString("POST not supported on this path"));
@@ -1611,6 +1621,71 @@ QByteArray SearchServer::handleStack(const QString &path,
     _log.log(ServerLog::ServeFile, target.filePath + " stacked");
     return buildHttpResponse(200, "OK", "application/json",
                              buildJsonResponse(true, "", ""));
+}
+
+QByteArray SearchServer::handleUpload(const QString &path,
+                                      const QHash<QString, QString> &params,
+                                      const QString &authedUser)
+{
+    QString repoName, filePath;
+    if (!splitStackUrl(path, "/upload", &repoName, &filePath))
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Malformed upload path"));
+    StackTarget target;
+    QByteArray fail = resolveStackTarget(repoName, filePath, authedUser,
+                                         target, /*mustExist=*/false);
+    if (!fail.isEmpty())
+        return fail;
+
+    QByteArray bytes = QByteArray::fromBase64(
+        params.value("__body_b64__").toLatin1());
+    if (bytes.isEmpty())
+        return buildHttpResponse(400, "Bad Request", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Empty upload body"));
+
+    QFileInfo fi(target.fullPath);
+    if (!QDir(fi.absolutePath()).exists())
+        return buildHttpResponse(404, "Not Found", "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Directory not found"));
+
+    /* never overwrite: a name clash (e.g. two clients scanning at
+       once) gets a fresh name, reported back to the caller */
+    QString name = fi.fileName();
+    if (QFileInfo::exists(target.fullPath)) {
+        name = uniqueNameIn(fi.absolutePath(), fi.completeBaseName(),
+                            "." + fi.suffix());
+        if (name.isEmpty())
+            return buildHttpResponse(409, "Conflict", "application/json",
+                                     buildJsonResponse(false, "",
+                                         "No unique name available"));
+    }
+
+    QString outPath = fi.absolutePath() + "/" + name;
+    QSaveFile out(outPath);
+    if (!out.open(QIODevice::WriteOnly)) {
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Cannot write file"));
+    }
+    out.write(bytes);
+    if (!out.commit())
+        return buildHttpResponse(500, "Internal Server Error",
+                                 "application/json",
+                                 buildJsonResponse(false, "",
+                                     "Cannot commit file"));
+
+    _log.log(ServerLog::ServeFile, "upload " + target.filePath);
+    QJsonObject outObj;
+    outObj["success"] = true;
+    outObj["name"] = name;
+    outObj["etag"] = fileEtag(QFileInfo(outPath));
+    return buildHttpResponse(200, "OK", "application/json",
+                             QString::fromUtf8(QJsonDocument(outObj).toJson(
+                                 QJsonDocument::Compact)));
 }
 
 QByteArray SearchServer::handleDuplicate(const QString &path,

--- a/searchserver.h
+++ b/searchserver.h
@@ -40,6 +40,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <memory>
 
+#include <QFileInfo>
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QString>
@@ -256,12 +257,20 @@ private:
      * @param page           Extract single page (0 = return whole file)
      * @param wantPageCount  Return page count as JSON instead of file data
      * @param client         Client socket (needed for async PDF extraction)
+     * @param ifNoneMatch    Client's If-None-Match header; when it matches
+     *                       the file's current ETag a whole-file request
+     *                       returns 304 with no body
      * @return HTTP response, or empty QByteArray if the response is deferred
      */
     QByteArray getFile(const QString &repoPath, const QString &filePath,
                        const QString &type = "original", int page = 0,
                        bool wantPageCount = false,
-                       QTcpSocket *client = nullptr);
+                       QTcpSocket *client = nullptr,
+                       const QString &ifNoneMatch = QString());
+
+    /** ETag for a file: its size and mtime, quoted.  Any change the
+     *  server can observe changes the tag. */
+    static QString fileEtag(const QFileInfo &info);
 
     /**
      * Convert a non-PDF file to PDF, caching the result
@@ -360,10 +369,12 @@ private:
      * @param filePath    Path to the file to send
      * @param contentType MIME type for the Content-Type header
      * @param client      Client socket to write to
+     * @param etag        ETag header value to send (omitted if empty)
      */
     void streamFile(const QString &filePath,
                     const QString &contentType,
-                    QTcpSocket *client);
+                    QTcpSocket *client,
+                    const QString &etag = QString());
 
     /**
      * URL decode a string

--- a/searchserver.h
+++ b/searchserver.h
@@ -220,6 +220,86 @@ private:
                                const QHash<QString, QString> &params,
                                const QString &authedUser);
 
+    /** Target of a per-stack mutation URL. */
+    struct StackTarget {
+        QString repoName;   //!< repository basename
+        QString filePath;   //!< path relative to the repository root
+        QString repoPath;   //!< absolute repository root
+        QString fullPath;   //!< absolute path of the stack's file
+    };
+
+    /**
+     * Split a /v1/repos/{repo}/stacks/{path}{verb} URL into repo and
+     * stack path.  @p verb is the trailing part including its leading
+     * slash (e.g. "/rename").  Returns false if the URL is malformed.
+     */
+    static bool splitStackUrl(const QString &path, const QString &verb,
+                              QString *repoName, QString *filePath);
+
+    /**
+     * Validate a stack target: path traversal, the per-user repo
+     * allowlist and repository existence; when @p mustExist is true
+     * the file itself must exist too.
+     *
+     * @return empty QByteArray on success (out filled in), or the
+     * HTTP error response to send
+     */
+    QByteArray resolveStackTarget(const QString &repoName,
+                                  const QString &filePath,
+                                  const QString &authedUser,
+                                  StackTarget &out, bool mustExist = true);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/rename
+     *
+     * Body {newName, autoRename}.  Renames the file within its
+     * directory; with autoRename a colliding name gets _1, _2...
+     * appended.  Returns {success, name} with the final name.
+     */
+    QByteArray handleRename(const QString &path,
+                            const QHash<QString, QString> &params,
+                            const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/move
+     *
+     * Body {destDir, copy}.  Moves (or copies) the file to another
+     * directory in the same repository; destDir is repo-relative and
+     * "" means the root.  The trash directory is created on demand;
+     * any other destination must exist.  A name collision appends
+     * _move_1 etc.  Returns {success, name} with the final name.
+     */
+    QByteArray handleMove(const QString &path,
+                          const QHash<QString, QString> &params,
+                          const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/delete
+     *
+     * Removes the file outright (no trash).
+     */
+    QByteArray handleDelete(const QString &path,
+                            const QHash<QString, QString> &params,
+                            const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/pages/{n}/rename
+     *
+     * Body {newName}.  Renames a page within the stack via the File
+     * classes; n is 1-based.
+     */
+    QByteArray handleRenamePage(const QString &path,
+                                const QHash<QString, QString> &params,
+                                const QString &authedUser);
+
+    /** Name of the shared trash directory within a repository. */
+    static const char *trashDirName() { return ".maxview-trash"; }
+
+    /** Find a filename not present in @p dir by appending _1, _2...
+     *  to @p base.  Returns base+ext unchanged if that is free. */
+    static QString uniqueNameIn(const QString &dir, const QString &base,
+                                const QString &ext);
+
     /**
      * Search for files matching a pattern
      * @param repoPath    Repository root path

--- a/searchserver.h
+++ b/searchserver.h
@@ -351,6 +351,18 @@ private:
                            const QString &authedUser);
 
     /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/upload
+     *
+     * The raw request body is the whole file's bytes (e.g. a stack
+     * scanned on a client).  Writes it at {path}; a name clash gets a
+     * fresh name.  Returns {name, etag} so the caller can label its
+     * cached copy as current.
+     */
+    QByteArray handleUpload(const QString &path,
+                            const QHash<QString, QString> &params,
+                            const QString &authedUser);
+
+    /**
      * Handle POST /v1/repos/{repo}/stacks/{path}/duplicate
      *
      * Body {}.  Copies the stack's file within its directory under a

--- a/searchserver.h
+++ b/searchserver.h
@@ -292,6 +292,17 @@ private:
                                 const QHash<QString, QString> &params,
                                 const QString &authedUser);
 
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/annotations
+     *
+     * Body is a JSON object with any subset of author/title/keywords/
+     * notes/ocr; the named fields are written into the stack's
+     * annotation block via the File classes.
+     */
+    QByteArray handleUpdateAnnot(const QString &path,
+                                 const QHash<QString, QString> &params,
+                                 const QString &authedUser);
+
     /** Name of the shared trash directory within a repository. */
     static const char *trashDirName() { return ".maxview-trash"; }
 

--- a/searchserver.h
+++ b/searchserver.h
@@ -620,6 +620,39 @@ private:
     };
     QHash<QString, ConvertProgress> _convertProgress;  //!< Keyed by source path
 
+    /**
+     * Handle GET /v1/repos/{repo}/events
+     *
+     * Registers the client for server-sent events and writes the SSE
+     * response header; the socket then stays open and receives a
+     * `stackChanged` frame for every successful mutation in the
+     * repository.  Returns an empty QByteArray (async response).
+     */
+    QByteArray handleEvents(const QString &path,
+                            const QHash<QString, QString> &params,
+                            const QString &authedUser, QTcpSocket *client);
+
+    /**
+     * Send a stackChanged event to every subscriber of @p repoName.
+     *
+     * @param repoName  Repository the change happened in
+     * @param op        Operation name (rename, move, delete, ...)
+     * @param path      Repo-relative path of the affected stack
+     * @param name      New name, for ops that produce one (else empty)
+     * @param clientId  X-Client-Id of the originating request, echoed
+     *                  so that client can ignore its own change
+     */
+    void notifyStackEvent(const QString &repoName, const QString &op,
+                          const QString &path, const QString &name,
+                          const QString &clientId);
+
+    /** One SSE subscriber */
+    struct EventClient {
+        QTcpSocket *socket;
+        QString repoName;
+    };
+    QList<EventClient> _eventClients;
+
     /** Recovery data held for a pages/delete call until its undoId is
      *  redeemed (or the server restarts) */
     struct PageUndo {

--- a/searchserver.h
+++ b/searchserver.h
@@ -45,6 +45,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QTcpSocket>
 #include <QString>
 #include <QStringList>
+#include <QBitArray>
 #include <QHash>
 #include <QMap>
 #include <QDateTime>
@@ -303,6 +304,63 @@ private:
                                  const QHash<QString, QString> &params,
                                  const QString &authedUser);
 
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/pages/delete
+     *
+     * Body {pages:[n,...]} with 1-based page numbers.  Removes the
+     * pages from the stack and stores the recovery data server-side,
+     * returning {undoId} as an opaque token for pages/undelete.
+     */
+    QByteArray handleDeletePages(const QString &path,
+                                 const QHash<QString, QString> &params,
+                                 const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/pages/undelete
+     *
+     * Body {undoId}.  Restores the pages removed by the matching
+     * pages/delete call.  An unknown or already-redeemed id is 410
+     * Gone; the recovery data does not survive a server restart.
+     */
+    QByteArray handleUndeletePages(const QString &path,
+                                   const QHash<QString, QString> &params,
+                                   const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/unstack
+     *
+     * Body {pagenum, pagecount, remove, newName}.  Copies @c pagecount
+     * pages starting at 1-based @c pagenum into a new stack in the
+     * same directory (named newName, made unique), removing them from
+     * the source when @c remove is set.  Returns {name}.
+     */
+    QByteArray handleUnstack(const QString &path,
+                             const QHash<QString, QString> &params,
+                             const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/stack
+     *
+     * Body {sources:[path,...], insertPage}.  Appends the pages of
+     * each source stack into the target at 1-based insertPage (or the
+     * end), deleting the source files.  All stacks must be the same
+     * type.
+     */
+    QByteArray handleStack(const QString &path,
+                           const QHash<QString, QString> &params,
+                           const QString &authedUser);
+
+    /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/duplicate
+     *
+     * Body {}.  Copies the stack's file within its directory under a
+     * fresh name and returns {name}.  Format conversion is not
+     * supported here yet.
+     */
+    QByteArray handleDuplicate(const QString &path,
+                               const QHash<QString, QString> &params,
+                               const QString &authedUser);
+
     /** Name of the shared trash directory within a repository. */
     static const char *trashDirName() { return ".maxview-trash"; }
 
@@ -549,6 +607,16 @@ private:
         int totalPages;   //!< Total pages in the source file
     };
     QHash<QString, ConvertProgress> _convertProgress;  //!< Keyed by source path
+
+    /** Recovery data held for a pages/delete call until its undoId is
+     *  redeemed (or the server restarts) */
+    struct PageUndo {
+        QString fullPath;   //!< Absolute path of the mutated file
+        QBitArray pages;    //!< Which pages were removed
+        QByteArray delInfo; //!< Opaque recovery blob from removePages()
+        int count;          //!< Number of removed pages
+    };
+    QHash<QString, PageUndo> _pageUndos;  //!< Keyed by undoId
 };
 
 #endif // __searchserver_h

--- a/searchserver.h
+++ b/searchserver.h
@@ -294,6 +294,17 @@ private:
                                 const QString &authedUser);
 
     /**
+     * Handle POST /v1/repos/{repo}/stacks/{path}/pages/{n}/ocr
+     *
+     * Renders 1-based page n, runs the OCR engine over it, stores the
+     * text in the stack's ocr annotation and returns {text}.  501 if
+     * no OCR engine is available on the server.
+     */
+    QByteArray handleOcrPage(const QString &path,
+                             const QHash<QString, QString> &params,
+                             const QString &authedUser);
+
+    /**
      * Handle POST /v1/repos/{repo}/stacks/{path}/annotations
      *
      * Body is a JSON object with any subset of author/title/keywords/

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1800,6 +1800,77 @@ void TestSearchServer::testDesktopRemoteSimpleOps()
     server.stop();
 }
 
+
+/* read one annotation straight from the server's file on disk */
+static QString serverAnnot(const QString &dir, const QString &fname,
+                           File::e_annot type)
+{
+    File *f = File::createFile(dir, fname, nullptr,
+                               File::typeFromName(fname));
+    QString text;
+    if (f && !f->load())
+        f->getAnnot(type, text);
+    delete f;
+    return text;
+}
+
+void TestSearchServer::testDesktopRemoteAnnotations()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+    QVERIFY(!model.ensureContent(stack));
+
+    QString oldAuthor = serverAnnot(dir, "testfile.max",
+                                    File::Annot_author);
+
+    // update through the desktop; the server's file follows
+    QHash<int, QString> updates;
+    updates[File::Annot_author] = "A. Writer";
+    updates[File::Annot_title] = "Remote title";
+    model.updateAnnot(stack, updates);
+
+    QCOMPARE(serverAnnot(dir, "testfile.max", File::Annot_author),
+             QString("A. Writer"));
+    QCOMPARE(serverAnnot(dir, "testfile.max", File::Annot_title),
+             QString("Remote title"));
+
+    // the cached copy shows the new values without a refetch
+    QCOMPARE(model.getAnnot(stack, File::Annot_author),
+             QString("A. Writer"));
+
+    // undo restores the previous value on the server
+    model.getUndoStack()->undo();
+    QCOMPARE(serverAnnot(dir, "testfile.max", File::Annot_author),
+             oldAuthor);
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -18,6 +18,7 @@
 #include "../dirmodel.h"
 #include "../desktopundo.h"
 #include "../file.h"
+#include "../filemax.h"
 #include "../measure.h"
 #include "../remotebackend.h"
 #include "../searchserver.h"
@@ -1968,6 +1969,79 @@ void TestSearchServer::testDesktopRemoteStructuralOps()
     QVERIFY(QFile::exists(dir + names[0]));
     QCOMPARE(serverPagecount(dir, names[0]), pagecount);
     QCOMPARE(model.rowCount(parent), rowsBefore + 1);
+
+    server.stop();
+}
+
+
+void TestSearchServer::testDesktopRemoteScan()
+{
+    /* Scanning into a remote desk builds the stack in the local cache
+       and uploads the finished file on confirm; a cancelled scan
+       leaves no trace on either side. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    int rowsBefore = model.rowCount(parent);
+
+    /* a fake scanned page: 64x48 grey */
+    auto makePage = [](Filemaxpage &mp, const QString &title) {
+        int w = 64, h = 48;
+        QByteArray data(w * h, '\x80');
+        QString name = title;
+        mp.addData(w, h, 8, w, name, false, false, 1, data, w * h);
+        QVERIFY(!mp.compress());
+    };
+
+    // scan a one-page stack and confirm it
+    QVERIFY(!model.beginScan(parent, "scanned"));
+    Filemaxpage page;
+    makePage(page, "page 1");
+    QVERIFY(!model.addPageToScan(&page, ""));
+    QString fname;
+    QVERIFY(!model.confirmScan(&fname));
+
+    QVERIFY(QFile::exists(dir + fname));
+    QCOMPARE(serverPagecount(dir, fname), 1);
+    QCOMPARE(model.rowCount(parent), rowsBefore + 1);
+
+    // the uploaded copy's validator lets a fresh session revalidate
+    QModelIndex ind = model.index(fname, parent);
+    QVERIFY(ind.isValid());
+    File *f = model.getFile(ind);
+    QVERIFY(f);
+    QVERIFY(QFile::exists(f->pathname() + ".etag"));
+
+    // a cancelled scan leaves nothing behind
+    QVERIFY(!model.beginScan(parent, "aborted"));
+    Filemaxpage page2;
+    makePage(page2, "page 1");
+    QVERIFY(!model.addPageToScan(&page2, ""));
+    QVERIFY(!model.cancelScan());
+    QCOMPARE(model.rowCount(parent), rowsBefore + 1);
+    QVERIFY(!QFile::exists(dir + "aborted.max"));
 
     server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1717,6 +1717,89 @@ void TestSearchServer::testMutationEndpoints()
     server.stop();
 }
 
+
+void TestSearchServer::testDesktopRemoteSimpleOps()
+{
+    /* Rename, trash and delete of remote stacks driven through the
+       desktop, including the undo round-trips. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+
+    // rename through the desktop; the server's file follows
+    model.renameStack(stack, "renamed");
+    QVERIFY(QFile::exists(dir + "renamed.max"));
+    QVERIFY(!QFile::exists(dir + "testfile.max"));
+    QVERIFY(model.index("renamed.max", parent).isValid());
+
+    // and undo brings the old name back
+    model.getUndoStack()->undo();
+    QVERIFY(QFile::exists(dir + "testfile.max"));
+    QVERIFY(!QFile::exists(dir + "renamed.max"));
+
+    // rename a page on the server via the desktop
+    stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+    QVERIFY(!model.ensureContent(stack));
+    QString pageName = "remote page";
+    QVERIFY(!model.opRenamePage(stack, 0, pageName));
+    {
+        File *f = File::createFile(dir, "testfile.max", nullptr,
+                                   File::Type_max);
+        QVERIFY(f && !f->load());
+        QCOMPARE(f->pageTitle(0), QString("remote page"));
+        delete f;
+    }
+
+    // trash through the desktop: the server file moves into the trash
+    QModelIndexList list;
+    list << stack;
+    int rowsBefore = model.rowCount(parent);
+    model.trashStacks(list, parent);
+    QVERIFY(!QFile::exists(dir + "testfile.max"));
+    QVERIFY(QFile::exists(dir + ".maxview-trash/testfile.max"));
+    QCOMPARE(model.rowCount(parent), rowsBefore - 1);
+
+    // undo the trashing: the file comes back
+    model.getUndoStack()->undo();
+    QVERIFY(QFile::exists(dir + "testfile.max"));
+    QVERIFY(!QFile::exists(dir + ".maxview-trash/testfile.max"));
+    QCOMPARE(model.rowCount(parent), rowsBefore);
+
+    // delete outright
+    stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+    QVERIFY(!model.opDeleteStack(stack));
+    QVERIFY(!QFile::exists(dir + "testfile.max"));
+    QCOMPARE(model.rowCount(parent), rowsBefore - 1);
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -116,6 +116,9 @@ static TestSearchServer::Response sendRaw(const QByteArray &request,
     int totalWait = 0;
     while (socket.state() == QAbstractSocket::ConnectedState
            && totalWait < timeoutMs) {
+        /* the server runs in this same process, so its sockets only
+           make progress when the main event loop spins */
+        QCoreApplication::processEvents();
         if (socket.waitForReadyRead(200))
             raw += socket.readAll();
         totalWait += 200;
@@ -1625,6 +1628,91 @@ void TestSearchServer::testDesktopRemoteOpenStack()
     int tbpp;
     QVERIFY(!model3.getImage(stack3, 0, false, turned, tsz1, tsz2, tbpp));
     QCOMPARE(turned.size(), QSize(before.height(), before.width()));
+
+    server.stop();
+}
+
+
+void TestSearchServer::testMutationEndpoints()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    auto makeFile = [&](const QString &name, const QByteArray &content) {
+        QFile f(tmpDir.path() + "/" + name);
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write(content);
+    };
+    makeFile("one.max", "contents one");
+    makeFile("two.max", "contents two");
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+
+    QString base = QString("/v1/repos/%1/stacks/").arg(repo);
+
+    // plain rename
+    auto r = postJson(base + "one.max/rename",
+                      R"({"newName":"first.max"})");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    QVERIFY(!QFile::exists(tmpDir.path() + "/one.max"));
+    QVERIFY(QFile::exists(tmpDir.path() + "/first.max"));
+
+    // a collision with autoRename picks a fresh name
+    r = postJson(base + "two.max/rename",
+                 R"({"newName":"first.max","autoRename":true})");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    QJsonObject obj = QJsonDocument::fromJson(r.body).object();
+    QCOMPARE(obj.value("name").toString(), QString("first_1.max"));
+    QVERIFY(QFile::exists(tmpDir.path() + "/first_1.max"));
+
+    // a collision without autoRename is refused
+    r = postJson(base + "first_1.max/rename",
+                 R"({"newName":"first.max","autoRename":false})");
+    QVERIFY2(r.header.contains("409"), qPrintable(r.header));
+
+    // move to the trash creates it on demand
+    r = postJson(base + "first.max/move",
+                 R"({"destDir":".maxview-trash"})");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    QVERIFY(QFile::exists(tmpDir.path()
+                          + "/.maxview-trash/first.max"));
+
+    // moving back out of the trash
+    r = postJson(base + ".maxview-trash/first.max/move",
+                 R"({"destDir":""})");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    QVERIFY(QFile::exists(tmpDir.path() + "/first.max"));
+
+    // a move to a missing directory is refused
+    r = postJson(base + "first.max/move",
+                 R"({"destDir":"nosuchdir"})");
+    QVERIFY2(r.header.contains("404"), qPrintable(r.header));
+
+    // delete removes the file outright
+    r = postJson(base + "first_1.max/delete", "{}");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    QVERIFY(!QFile::exists(tmpDir.path() + "/first_1.max"));
+
+    // traversal is rejected
+    r = postJson(base + "..%2Fescape.max/rename",
+                 R"({"newName":"x.max"})");
+    QVERIFY2(r.header.contains("400"), qPrintable(r.header));
+
+    // a page rename lands in the stack itself
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    r = postJson(base + "testfile.max/pages/1/rename",
+                 R"({"newName":"my page"})");
+    QVERIFY2(r.header.contains("200"), qPrintable(r.header));
+    {
+        File *f = File::createFile(tmpDir.path() + "/", "testfile.max",
+                                   nullptr, File::Type_max);
+        QVERIFY(f && !f->load());
+        QCOMPARE(f->pageTitle(0), QString("my page"));
+        delete f;
+    }
 
     server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -28,6 +28,7 @@
 #include <QBuffer>
 #include <QFont>
 #include <QImage>
+#include <QRegularExpression>
 
 #include "test_searchserver.h"
 
@@ -1034,6 +1035,64 @@ void TestSearchServer::testFileEndpoint()
     // Test absolute path prevention
     resp = get("/file?path=/etc/passwd");
     QVERIFY(resp.header.contains("400") || resp.body.contains("Invalid file path"));
+
+    server.stop();
+}
+
+/* GET with an If-None-Match header, for the ETag revalidation test */
+static TestSearchServer::Response getConditional(const QString &path,
+                                                 const QString &etag,
+                                                 int port)
+{
+    QByteArray req;
+    req += "GET " + path.toUtf8() + " HTTP/1.1\r\n";
+    req += "Host: localhost\r\n";
+    if (!etag.isEmpty())
+        req += "If-None-Match: " + etag.toUtf8() + "\r\n";
+    req += "Connection: close\r\n";
+    req += "\r\n";
+    return sendRaw(req, port, 5000);
+}
+
+void TestSearchServer::testFileEtag()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    QFile testFile(tmpDir.path() + "/tagged.max");
+    QVERIFY(testFile.open(QIODevice::WriteOnly));
+    testFile.write("original bytes");
+    testFile.close();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+
+    // a whole-file download carries an ETag
+    auto resp = get("/file?path=tagged.max");
+    QVERIFY(resp.ok());
+    QRegularExpression re("ETag: (\"[^\"]+\")");
+    auto m = re.match(resp.header);
+    QVERIFY2(m.hasMatch(), qPrintable(resp.header));
+    QString etag = m.captured(1);
+
+    // revalidating with the same tag returns 304 and no body
+    auto cond = getConditional("/file?path=tagged.max", etag, PORT);
+    QVERIFY2(cond.header.contains("304"), qPrintable(cond.header));
+    QVERIFY(cond.body.isEmpty());
+
+    // a stale tag still gets the full file
+    auto stale = getConditional("/file?path=tagged.max", "\"0-0\"", PORT);
+    QVERIFY(stale.ok());
+    QCOMPARE(stale.body, QByteArray("original bytes"));
+
+    /* changing the file changes the tag, so the old tag misses; the
+       mtime may not tick over within the test, but the size does */
+    QVERIFY(testFile.open(QIODevice::WriteOnly));
+    testFile.write("changed bytes, now longer");
+    testFile.close();
+    auto changed = getConditional("/file?path=tagged.max", etag, PORT);
+    QVERIFY(changed.ok());
+    QCOMPARE(changed.body, QByteArray("changed bytes, now longer"));
 
     server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1871,6 +1871,107 @@ void TestSearchServer::testDesktopRemoteAnnotations()
     server.stop();
 }
 
+
+/* page count of the server's file on disk */
+static int serverPagecount(const QString &dir, const QString &fname)
+{
+    File *f = File::createFile(dir, fname, nullptr,
+                               File::typeFromName(fname));
+    int count = -1;
+    if (f && !f->load())
+        count = f->pagecount();
+    delete f;
+    return count;
+}
+
+void TestSearchServer::testDesktopRemoteStructuralOps()
+{
+    /* Page deletion, unstacking and duplication of remote stacks
+       driven through the desktop, with their undo round-trips. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+    QVERIFY(!model.ensureContent(stack));
+
+    int pagecount = model.data(stack,
+                               Desktopmodel::Role_pagecount).toInt();
+    QVERIFY(pagecount >= 2);
+    int rowsBefore = model.rowCount(parent);
+
+    // delete the last page through the desktop
+    QBitArray pages(pagecount);
+    pages.setBit(pagecount - 1);
+    model.deletePages(stack, pages);
+    QCOMPARE(serverPagecount(dir, "testfile.max"), pagecount - 1);
+    QCOMPARE(model.data(stack, Desktopmodel::Role_pagecount).toInt(),
+             pagecount - 1);
+
+    // undo redeems the server-side undoId and restores the page
+    model.getUndoStack()->undo();
+    QCOMPARE(serverPagecount(dir, "testfile.max"), pagecount);
+    QCOMPARE(model.data(stack, Desktopmodel::Role_pagecount).toInt(),
+             pagecount);
+
+    // unstack the first page into a new stack
+    model.unstackPage(stack, 0, true);
+    QCOMPARE(model.rowCount(parent), rowsBefore + 1);
+    QCOMPARE(serverPagecount(dir, "testfile.max"), pagecount - 1);
+    QModelIndex unstacked;
+    for (int row = 0; row < model.rowCount(parent); row++) {
+        QModelIndex ind = model.index(row, 0, parent);
+        if (ind != stack)
+            unstacked = ind;
+    }
+    QVERIFY(unstacked.isValid());
+    QString newName = model.data(unstacked,
+                                 Desktopmodel::Role_filename).toString();
+    QCOMPARE(serverPagecount(dir, newName), 1);
+
+    // undo stacks the page back and removes the new stack
+    model.getUndoStack()->undo();
+    QCOMPARE(model.rowCount(parent), rowsBefore);
+    QCOMPARE(serverPagecount(dir, "testfile.max"), pagecount);
+    QVERIFY(!QFile::exists(dir + newName));
+
+    // duplicate (copy) the stack
+    QModelIndexList list;
+    QStringList names;
+    stack = model.index("testfile.max", parent);
+    list << stack;
+    QVERIFY(!model.opDuplicateStacks(list, parent, names,
+                                     File::Type_other, 3));
+    QCOMPARE(names.size(), 1);
+    QVERIFY(QFile::exists(dir + names[0]));
+    QCOMPARE(serverPagecount(dir, names[0]), pagecount);
+    QCOMPARE(model.rowCount(parent), rowsBefore + 1);
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1097,6 +1097,66 @@ void TestSearchServer::testFileEtag()
     server.stop();
 }
 
+void TestSearchServer::testRemoteFileCache()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    QFile src(tmpDir.path() + "/cached.max");
+    QVERIFY(src.open(QIODevice::WriteOnly));
+    src.write("cache me");
+    src.close();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+
+    RemoteBackend backend(QUrl(QString("http://localhost:%1").arg(PORT)));
+
+    // first fetch downloads the bytes and records the validator
+    QString cachePath = backend.ensureCachedFile(repo, "cached.max");
+    QVERIFY2(!cachePath.isEmpty(),
+             qPrintable(backend.lastError()));
+    QFile cached(cachePath);
+    QVERIFY(cached.open(QIODevice::ReadOnly));
+    QCOMPARE(cached.readAll(), QByteArray("cache me"));
+    cached.close();
+    QVERIFY(QFile::exists(cachePath + ".etag"));
+
+    /* a revalidation must not rewrite the cached copy: plant a
+       sentinel and check the 304 leaves it alone */
+    QVERIFY(cached.open(QIODevice::WriteOnly));
+    cached.write("sentinel");
+    cached.close();
+    QCOMPARE(backend.ensureCachedFile(repo, "cached.max"), cachePath);
+    QVERIFY(cached.open(QIODevice::ReadOnly));
+    QCOMPARE(cached.readAll(), QByteArray("sentinel"));
+    cached.close();
+
+    // a changed server file misses the validator and is downloaded
+    QVERIFY(src.open(QIODevice::WriteOnly));
+    src.write("new server bytes");
+    src.close();
+    QCOMPARE(backend.ensureCachedFile(repo, "cached.max"), cachePath);
+    QVERIFY(cached.open(QIODevice::ReadOnly));
+    QCOMPARE(cached.readAll(), QByteArray("new server bytes"));
+    cached.close();
+
+    // invalidation drops the copy and the validator
+    backend.invalidateCachedFile(repo, "cached.max");
+    QVERIFY(!QFile::exists(cachePath));
+    QVERIFY(!QFile::exists(cachePath + ".etag"));
+
+    // with the server stopped, a cached copy still serves
+    QCOMPARE(backend.ensureCachedFile(repo, "cached.max"), cachePath);
+    server.stop();
+    QCOMPARE(backend.ensureCachedFile(repo, "cached.max"), cachePath);
+    QVERIFY(cached.open(QIODevice::ReadOnly));
+    QCOMPARE(cached.readAll(), QByteArray("new server bytes"));
+    cached.close();
+}
+
 void TestSearchServer::testFilePageCount()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -29,6 +29,7 @@
 #include <QBuffer>
 #include <QFont>
 #include <QImage>
+#include <QPainter>
 #include <QRegularExpression>
 
 #include "test_searchserver.h"
@@ -2180,6 +2181,71 @@ void TestSearchServer::testDesktopRemoteSharedPositions()
     QVERIFY(stack2.isValid());
     QCOMPARE(model2.data(stack2, Desktopmodel::Role_position).toPoint(),
              target);
+
+    server.stop();
+}
+
+
+void TestSearchServer::testRemoteOcr()
+{
+    /* OCR of a remote stack runs on the server, which stores the text
+       in the stack's ocr annotation and returns it. */
+    if (!QFile::exists("/usr/bin/tesseract"))
+        QSKIP("tesseract is not installed");
+
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    /* a page with large, clean text for the engine to find */
+    {
+        QImage page(500, 140, QImage::Format_RGB32);
+        page.fill(Qt::white);
+        QPainter paint(&page);
+        paint.setPen(Qt::black);
+        QFont font;
+        font.setPointSize(40);
+        paint.setFont(font);
+        paint.drawText(page.rect(), Qt::AlignCenter, "HELLO WORLD");
+        paint.end();
+        QVERIFY(page.save(dir + "readme.jpg", "JPG"));
+    }
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("readme.jpg", parent);
+    QVERIFY(stack.isValid());
+    QVERIFY(!model.ensureContent(stack));
+
+    QString text;
+    err_info *e = model.ocrPage(stack, 0, text);
+    QVERIFY2(!e, e ? e->errstr : "");
+    QVERIFY2(text.contains("HELLO"), qPrintable(text));
+
+    // the text is stored in the stack's annotation on the server
+    QVERIFY(serverAnnot(dir, "readme.jpg",
+                        File::Annot_ocr).contains("HELLO"));
+
+    // and mirrored onto the cached copy
+    QVERIFY(model.getAnnot(stack, File::Annot_ocr).contains("HELLO"));
 
     server.stop();
 }

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -1521,6 +1521,114 @@ void TestSearchServer::testDesktopRemoteTransform()
     server.stop();
 }
 
+
+void TestSearchServer::testDesktopRemoteOpenStack()
+{
+    /* Opening a remote stack must fetch the whole file into the disk
+       cache and parse it with the real file class, so its pages render
+       exactly as a local open of the same file does. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+
+    // before the fetch the stack is a shell with no pages known
+    QCOMPARE(model.data(stack, Desktopmodel::Role_pagecount).toInt(), 0);
+
+    // fetch and parse the file
+    err_info *e = model.ensureContent(stack);
+    QVERIFY2(!e, e ? e->errstr : "");
+
+    // page count and page images now match a local open of the source
+    File *local = File::createFile(dir, "testfile.max", nullptr,
+                                   File::Type_max);
+    QVERIFY(local);
+    QVERIFY(!local->load());
+    QVERIFY(local->pagecount() > 0);
+    QCOMPARE(model.data(stack, Desktopmodel::Role_pagecount).toInt(),
+             local->pagecount());
+
+    for (int page = 0; page < local->pagecount(); page++) {
+        QImage rimg, limg;
+        QSize rsz, rtsz, lsz, ltsz;
+        int rbpp, lbpp;
+
+        err_info *re = model.getImage(stack, page, false, rimg, rsz,
+                                      rtsz, rbpp);
+        QVERIFY2(!re, re ? re->errstr : "");
+        QVERIFY(!local->getImage(page, false, limg, lsz, ltsz, lbpp,
+                                 false));
+        QCOMPARE(rimg, limg);
+        QCOMPARE(rbpp, lbpp);
+    }
+    delete local;
+
+    /* a fresh session (new model) reuses the cached copy: the open
+       costs a revalidation, not a download */
+    Desktopmodel model2(nullptr);
+    Desktopmodelconv conv2(&model2);
+    model2.setModelConv(&conv2);
+    model2.setDirmodel(&dirmodel);
+    QModelIndex parent2 = model2.showDir(root, root, &meas);
+    QVERIFY(parent2.isValid());
+    QModelIndex stack2 = model2.index("testfile.max", parent2);
+    QVERIFY(stack2.isValid());
+    err_info *e2 = model2.ensureContent(stack2);
+    QVERIFY2(!e2, e2 ? e2->errstr : "");
+    QVERIFY(model2.data(stack2, Desktopmodel::Role_pagecount).toInt() > 0);
+
+    /* rotate the file on the server behind our back; yet another
+       session must spot the stale cache on revalidation and re-read
+       the changed bytes */
+    QSize before = serverTestPageSize(dir, "testfile.max", 0);
+    auto xf = postJson(
+        QString("/v1/repos/%1/stacks/testfile.max/transform").arg(repo),
+        R"({"page":1,"op":"rotate90"})");
+    QVERIFY2(xf.header.contains("200"), qPrintable(xf.header));
+
+    Desktopmodel model3(nullptr);
+    Desktopmodelconv conv3(&model3);
+    model3.setModelConv(&conv3);
+    model3.setDirmodel(&dirmodel);
+    QModelIndex parent3 = model3.showDir(root, root, &meas);
+    QVERIFY(parent3.isValid());
+    QModelIndex stack3 = model3.index("testfile.max", parent3);
+    QVERIFY(stack3.isValid());
+    err_info *e3 = model3.ensureContent(stack3);
+    QVERIFY2(!e3, e3 ? e3->errstr : "");
+
+    QImage turned;
+    QSize tsz1, tsz2;
+    int tbpp;
+    QVERIFY(!model3.getImage(stack3, 0, false, turned, tsz1, tsz2, tbpp));
+    QCOMPARE(turned.size(), QSize(before.height(), before.width()));
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -2046,6 +2046,79 @@ void TestSearchServer::testDesktopRemoteScan()
     server.stop();
 }
 
+
+void TestSearchServer::testRemoteEvents()
+{
+    /* One client's mutation reaches another client's event stream;
+       the originator does not hear its own echo.  A desktop showing
+       the directory picks the change up and refreshes. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    RemoteBackend listener(url);
+    QSignalSpy spy(&listener, &RemoteBackend::stackEvent);
+    listener.subscribeEvents(repo);
+    QTest::qWait(200);   // let the stream connect
+
+    // a change made by a different client arrives as an event
+    RemoteBackend actor(url);
+    QString newName = "moved.max";
+    QVERIFY2(actor.renameStack(repo, "testfile.max", newName),
+             qPrintable(actor.lastError()));
+    /* the event may already have arrived while the sync rename was
+       spinning the event loop */
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(3000));
+    QCOMPARE(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    QCOMPARE(args[0].toString(), repo);
+    QCOMPARE(args[1].toString(), QString("rename"));
+    QCOMPARE(args[2].toString(), QString("testfile.max"));
+    QCOMPARE(args[3].toString(), QString("moved.max"));
+
+    // the listener's own change does not echo back to it
+    QString backName = "testfile.max";
+    QVERIFY(listener.renameStack(repo, "moved.max", backName));
+    QTest::qWait(500);
+    QCOMPARE(spy.count(), 0);
+
+    /* a desktop showing the directory refreshes on another client's
+       change */
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QVERIFY(model.index("testfile.max", parent).isValid());
+
+    QVERIFY(actor.renameStack(repo, "testfile.max", newName));
+    /* wait for the event to arrive and the queued refresh to run */
+    bool renamed = false;
+    for (int i = 0; i < 50 && !renamed; i++) {
+        QTest::qWait(100);
+        parent = model.index(root + "/", QModelIndex());
+        renamed = parent.isValid()
+            && model.index("moved.max", parent).isValid();
+    }
+    QVERIFY(renamed);
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -2119,6 +2119,71 @@ void TestSearchServer::testRemoteEvents()
     server.stop();
 }
 
+
+void TestSearchServer::testDesktopRemoteSharedPositions()
+{
+    /* Stack positions on a remote desk live in the server's
+       .paperdesk file, so every client sees the same layout. */
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    QVERIFY(copyTestFile("testfile.max", tmpDir.path()) > 0);
+    QString dir = tmpDir.path() + "/";
+    QString repo = QFileInfo(tmpDir.path()).fileName();
+
+    SearchServer server(tmpDir.path(), PORT);
+    QVERIFY(server.start());
+    QTest::qWait(100);
+    QUrl url(QString("http://localhost:%1").arg(PORT));
+
+    Dirmodel dirmodel;
+    QString err;
+    QVERIFY2(dirmodel.addRemoteRepository(url, &err),
+             err.toUtf8().constData());
+
+    Desktopmodel model(nullptr);
+    Desktopmodelconv conv(&model);
+    model.setModelConv(&conv);
+    model.setDirmodel(&dirmodel);
+
+    QString root = url.toString() + "/" + repo;
+    Measure meas(qApp->style(), QFont());
+    QModelIndex parent = model.showDir(root, root, &meas);
+    QVERIFY(parent.isValid());
+    QModelIndex stack = model.index("testfile.max", parent);
+    QVERIFY(stack.isValid());
+
+    // move the stack; the layout must land on the server at once
+    QPoint target(432, 210);
+    QModelIndexList list;
+    QList<QPoint> newpos;
+    list << stack;
+    newpos << target;
+    model.opMoveStacks(list, parent, newpos);
+    QVERIFY(QFile::exists(dir + ".paperdesk"));
+    {
+        QFile pd(dir + ".paperdesk");
+        QVERIFY(pd.open(QIODevice::ReadOnly));
+        QVERIFY(pd.readAll().contains("testfile.max"));
+    }
+
+    // the desk file must not show up as a stack
+    QVERIFY(!model.index(".paperdesk", parent).isValid());
+
+    // a second client sees the same position
+    Desktopmodel model2(nullptr);
+    Desktopmodelconv conv2(&model2);
+    model2.setModelConv(&conv2);
+    model2.setDirmodel(&dirmodel);
+    QModelIndex parent2 = model2.showDir(root, root, &meas);
+    QVERIFY(parent2.isValid());
+    QModelIndex stack2 = model2.index("testfile.max", parent2);
+    QVERIFY(stack2.isValid());
+    QCOMPARE(model2.data(stack2, Desktopmodel::Role_position).toPoint(),
+             target);
+
+    server.stop();
+}
+
 void TestSearchServer::testTransformEndpointErrors()
 {
     QTemporaryDir tmpDir;

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -80,6 +80,9 @@ private slots:
    void testRemoteBackendTransform();
    void testDesktopRemoteTransform();
 
+   //! Opening a remote stack fetches the file and renders real pages
+   void testDesktopRemoteOpenStack();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -64,6 +64,9 @@ private slots:
    void testReposEndpoint();
    void testSearchWithRepo();
    void testFileEndpoint();
+
+   //! Whole-file downloads carry an ETag; If-None-Match revalidates
+   void testFileEtag();
    void testFilePageCount();
    void testFilePageExtract();
    void testLargePdfProgressive();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -92,6 +92,9 @@ private slots:
    //! Annotation updates on a remote stack reach the server, with undo
    void testDesktopRemoteAnnotations();
 
+   //! Page delete/unstack/duplicate of remote stacks, with undo
+   void testDesktopRemoteStructuralOps();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -83,6 +83,9 @@ private slots:
    //! Opening a remote stack fetches the file and renders real pages
    void testDesktopRemoteOpenStack();
 
+   //! Rename/move/delete/page-rename endpoints mutate server files
+   void testMutationEndpoints();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -104,6 +104,9 @@ private slots:
    //! Stack positions are shared through the server's desk file
    void testDesktopRemoteSharedPositions();
 
+   //! OCR of a remote stack runs on the server and stores the text
+   void testRemoteOcr();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -86,6 +86,9 @@ private slots:
    //! Rename/move/delete/page-rename endpoints mutate server files
    void testMutationEndpoints();
 
+   //! Desktop rename/trash/delete of remote stacks, with undo
+   void testDesktopRemoteSimpleOps();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -95,6 +95,9 @@ private slots:
    //! Page delete/unstack/duplicate of remote stacks, with undo
    void testDesktopRemoteStructuralOps();
 
+   //! Scanning into a remote desk uploads the stack on confirm
+   void testDesktopRemoteScan();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -67,6 +67,9 @@ private slots:
 
    //! Whole-file downloads carry an ETag; If-None-Match revalidates
    void testFileEtag();
+
+   //! RemoteBackend caches whole files on disk and revalidates them
+   void testRemoteFileCache();
    void testFilePageCount();
    void testFilePageExtract();
    void testLargePdfProgressive();

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -101,6 +101,9 @@ private slots:
    //! Another client's change arrives on the event stream
    void testRemoteEvents();
 
+   //! Stack positions are shared through the server's desk file
+   void testDesktopRemoteSharedPositions();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -89,6 +89,9 @@ private slots:
    //! Desktop rename/trash/delete of remote stacks, with undo
    void testDesktopRemoteSimpleOps();
 
+   //! Annotation updates on a remote stack reach the server, with undo
+   void testDesktopRemoteAnnotations();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);

--- a/test/test_searchserver.h
+++ b/test/test_searchserver.h
@@ -98,6 +98,9 @@ private slots:
    //! Scanning into a remote desk uploads the stack on confirm
    void testDesktopRemoteScan();
 
+   //! Another client's change arrives on the event stream
+   void testRemoteEvents();
+
 private:
    // HTTP GET returning split header and body
    Response get(const QString &path, int timeoutMs = 5000);


### PR DESCRIPTION
This makes a repository served by paperman-server as usable as a local
one, implementing steps 2-7 of doc/client_server_plan.md on top of the
already-merged page-transform endpoint.

Opening a remote stack downloads the whole file into a per-server disk
cache (revalidated with ETag/If-None-Match, so a re-open costs a 304)
and parses it with the ordinary file classes, so the page view, preview
pane and page text work exactly as they do locally. Every mutation the
desktop offers - rename (stack and page), trash and untrash,
move-to-dir, delete, annotations, page delete and undelete (with the
recovery data held server-side behind an opaque undoId), unstack,
stack and duplicate - gains a server endpoint and a remote branch in
the corresponding op, so undo and redo work unchanged. Scanning into a
remote directory builds the stack in the cache and uploads the
finished file on confirm. Stack positions are shared through the
server's .paperdesk file, so every client sees the same layout. A
server-sent event stream notifies other clients of each change, and
the desktop refreshes affected directories automatically, filtering
out echoes of its own changes by client id. OCR runs on the server,
storing the text in the stack's ocr annotation.

Along the way the tests caught several pre-existing bugs, fixed here:
Filemax operations which assumed the GUI had already opened the file or
loaded its chunks (putAnnot, ensure_all_chunks, restorePages) crashed
or failed when the server called them straight after load(); restoring
deleted pages doubled the page list; and jpeg OCR text was silently
dropped because the annotation tag table was one entry short.

Each step is covered by end-to-end tests that drive Desktopmodel
against an in-process server over real HTTP; the suite passes with
this series applied to current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuJ6u4Q43PFHDsNmhRQcA