### PR TITLE
Fix scanner crash, reconnect settings loss and page-restore doubling

### DIFF
--- a/epeglite.cpp
+++ b/epeglite.cpp
@@ -178,8 +178,13 @@ _emit_message (j_common_ptr cinfo, int msg_level)
       (*err->pub.output_message) (cinfo);
     /* Always count warnings in num_warnings. */
     err->pub.num_warnings++;
-    err->last_valid_row = decomp->output_scanline * decomp->scale_denom / decomp->scale_num;
-printf ("valid row = %d\n", err->last_valid_row);
+    /* Record how far the decode got, so a short data stream can shrink
+       the preview.  Warnings can also arrive while the header is still
+       being parsed, before the scale is set up; the scanline count
+       means nothing then (and the scale would divide by zero). */
+    if (err->decode_started && decomp->scale_num)
+      err->last_valid_row = decomp->output_scanline * decomp->scale_denom
+                            / decomp->scale_num;
   } else {
     /* It's a trace message.  Show it if trace_level >= msg_level. */
     if (err->pub.trace_level >= msg_level)
@@ -191,6 +196,9 @@ static Epeg_Image *
 _epeg_open_header(Epeg_Image *im)
 {
 	struct jpeg_source_mgr *src_mgr = NULL;
+
+	im->jerr.decode_started = 0;
+	im->jerr.last_valid_row = -1;
 
 	im->in.jinfo.err = jpeg_std_error(&(im->jerr.pub));
 	im->jerr.pub.error_exit = _epeg_fatal_error_handler;
@@ -455,14 +463,26 @@ int epeg_raw(Epeg_Image *im, int stride)
 int epeg_copy(Epeg_Image *im, int width, int height, int stride)
 {
     char *p, *s, *d, *end;
-    int y, nc, in_stride;
+    int y, nc, in_stride, line;
+
+    /* nothing decoded, or no output buffer allocated (epeg_raw()
+       failed): there is nothing to copy and nowhere to put it */
+    if (!im->pixels || !im->out.mem.data || !*im->out.mem.data)
+        return 1;
+
+    /* the output buffer holds out.h lines; never copy more */
+    if (height > im->out.h)
+        height = im->out.h;
 
     nc = im->in.jinfo.output_components;
 
     p = (char *)*im->out.mem.data;
     in_stride = im->in.jinfo.output_width * nc;
 
-//    printf ("epeg_copy size = %d\n", height *
+    /* the decoded lines hold in_stride bytes; the output lines are
+       padded to a word boundary, so copy the shorter of the two and
+       whiten the padding */
+    line = stride < in_stride ? stride : in_stride;
 
     // copy each line, reversing red and blue, and inverting
     for (y = 0; y < height; y++)
@@ -473,7 +493,11 @@ int epeg_copy(Epeg_Image *im, int width, int height, int stride)
         d [2] = s [0];
         }
        else
-           memcpy (p + stride * y, (char *)im->pixels + in_stride * (height - 1 - y), stride);
+        {
+        memcpy (p + stride * y, (char *)im->pixels + in_stride * (height - 1 - y), line);
+        if (line < stride)
+            memset (p + stride * y + line, 0xff, stride - line);
+        }
    return 0;
 }
 
@@ -757,6 +781,7 @@ static int _epeg_decode(Epeg_Image *im)
 	jpeg_start_decompress(&(im->in.jinfo));
 
     im->jerr.last_valid_row = -1;
+    im->jerr.decode_started = 1;
 	for (y = 0; y < (int)im->in.jinfo.output_height; y++)
 		im->lines[y] = im->pixels + (y * im->in.jinfo.output_components * im->in.jinfo.output_width);
 	while (im->in.jinfo.output_scanline < im->in.jinfo.output_height)

--- a/epeglite.h
+++ b/epeglite.h
@@ -57,6 +57,7 @@ struct _epeg_error_mgr
 	struct     jpeg_error_mgr pub;
 	jmp_buf    setjmp_buffer;
     int        last_valid_row;
+    int        decode_started;  /* scanline count is meaningful */
 };
 
 typedef struct _Epeg_Image

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -2284,6 +2284,13 @@ err_info *Filemax::ensure_all_chunks (void)
 
    if (_all_chunks_loaded)
       return NULL;
+
+   /* reading the chunks (and the titles below) needs the file open;
+      a caller fresh from load() has it closed */
+   bool wasOpen = _fin != NULL;
+   if (!wasOpen)
+      CALL (ensure_open ());
+
    for (i = 0, pos = _chunk0_start; i < _chunks.size ();
         i++)
       {
@@ -2309,6 +2316,8 @@ err_info *Filemax::ensure_all_chunks (void)
    for (int i = 0; i < _pages.size (); i++)
       ensure_titlestr (i, _pages [i]);
 
+   if (!wasOpen)
+      ensure_closed ();
    return NULL;
    }
 
@@ -5810,9 +5819,12 @@ err_info *Filemax::restorePages (QBitArray &pages,
 
    CALL (ensure_all_chunks ());
 
-   // create new page_info structure
+   /* Create the new page list.  Reserve only: the loop below appends,
+      so sizing the vector here would leave newcount default-built
+      pages in front and double the stack. */
    newcount = _pages.size () + count;
-   QVector<page_info> dest_pages (newcount);
+   QVector<page_info> dest_pages;
+   dest_pages.reserve (newcount);
 
    // count how many pages are to be deleted
    int srcnum;

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -282,25 +282,43 @@ void QScanner::setFormat (format_t f, bool select_compression)
 /**  */
 bool QScanner::reconnect()
    {
-   // Snapshot current scanner state so we can restore it after the
-   // teardown. Without this the scanner reverts to defaults on every
-   // reconnect, regardless of which (if any) preset is selected in the
-   // UI.
-   int saved_x_dpi = -1, saved_y_dpi = -1;
-   int saved_brightness = INT_MIN, saved_contrast = INT_MIN;
-   int saved_exposure = INT_MIN;
-   bool saved_duplex = false, saved_adf = false;
-   format_t saved_format = other;
+   /* Snapshot the value of every settable option so it can be restored
+      after the teardown.  Without this the scanner reverts to defaults
+      on every reconnect, and anything not on some hand-picked list -
+      page size, scan area, compression, the Fujitsu's buffer mode and
+      friends - silently goes back to its default.  Options are keyed
+      by name, since their numbers can move on the fresh handle. */
+   struct SavedOption
+      {
+      QByteArray name;
+      QByteArray value;
+      SANE_Value_Type type;
+      };
+   QList<SavedOption> saved;
+
    if (mOpenOk)
       {
-      saved_x_dpi      = xResolutionDpi ();
-      saved_y_dpi      = yResolutionDpi ();
-      saved_duplex     = duplex ();
-      saved_adf        = useAdf ();
-      saved_format     = format ();
-      saved_brightness = getBrightness ();
-      saved_contrast   = getContrast ();
-      saved_exposure   = getExposure ();
+      int count = optionCount ();
+
+      for (int i = 1; i < count; i++)
+         {
+         const SANE_Option_Descriptor *desc
+               = do_sane_get_option_descriptor (mDeviceHandle, i);
+
+         if (!desc || !desc->name || !desc->name[0])
+            continue;
+         if (desc->type == SANE_TYPE_GROUP || desc->type == SANE_TYPE_BUTTON)
+            continue;
+         if (!SANE_OPTION_IS_ACTIVE (desc->cap)
+            || !SANE_OPTION_IS_SETTABLE (desc->cap))
+            continue;
+         QByteArray value ((int)desc->size, '\0');
+         if (do_sane_control_option (mDeviceHandle, i,
+               SANE_ACTION_GET_VALUE, value.data (), 0)
+               != SANE_STATUS_GOOD)
+            continue;
+         saved << SavedOption { desc->name, value, desc->type };
+         }
       }
 
    // Close the handle, then fully tear down the SANE backend and bring it
@@ -328,25 +346,35 @@ bool QScanner::reconnect()
    if (!openDevice ())
       return false;
 
-   // Restore the snapshot to the fresh handle.
-   if (saved_x_dpi > 0)
-      setDpi (saved_x_dpi);
-   if (saved_y_dpi > 0 && saved_y_dpi != saved_x_dpi && mOptionYRes != -1)
-      {
-      SANE_Word w = saved_y_dpi;
-      setOption (mOptionYRes, &w);
-      }
-   if (saved_adf)
-      setAdf (true);
-   if (saved_duplex)
-      setDuplex (true);
-   setFormat (saved_format);
-   if (saved_brightness != INT_MIN)
-      setBrightness (saved_brightness);
-   if (saved_contrast != INT_MIN)
-      setContrast (saved_contrast);
-   if (saved_exposure != INT_MIN)
-      setExposure (saved_exposure);
+   /* Restore the snapshot to the fresh handle.  Options are applied in
+      their original order, which puts source and mode (early options)
+      before the geometry that depends on them.  Setting one option can
+      change which others are active or what ranges they allow, so a
+      second pass picks up any that could not be applied the first time
+      or were clamped by a constraint that has since relaxed. */
+   for (int pass = 0; pass < 2; pass++)
+      foreach (const SavedOption &so, saved)
+         {
+         int num = findOption (so.name.constData ());
+
+         if (num < 0 || !isOptionActive (num))
+            continue;
+         const SANE_Option_Descriptor *desc
+               = do_sane_get_option_descriptor (mDeviceHandle, num);
+         if (!desc || desc->type != so.type
+            || (int)desc->size != so.value.size ())
+            continue;
+
+         // skip options which already have the right value
+         QByteArray current ((int)desc->size, '\0');
+         if (do_sane_control_option (mDeviceHandle, num,
+               SANE_ACTION_GET_VALUE, current.data (), 0)
+               == SANE_STATUS_GOOD && current == so.value)
+            continue;
+
+         QByteArray value = so.value;   // the backend may modify it
+         setOption (num, value.data ());
+         }
 
    return true;
    }

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -1,5 +1,7 @@
 #include <QtTest/QtTest>
 
+#include <sane/saneopts.h>
+
 #include "pscan.h"
 #include "qscandialog.h"
 #include "qscanner.h"
@@ -227,10 +229,55 @@ void TestQscanner::testReconnectPreservesSettings()
    // Set non-default values directly via QScanner.
    scanner.setDpi (400);
    QCOMPARE (scanner.xResolutionDpi (), 400);
+   scanner.setBrightness (17);
+   scanner.setContrast (-9);
+
+   /* the geometry options too: a Legal-length page and scan window,
+      plus a small top margin, must survive the reconnect */
+   int pageHeight = scanner.findOption ("page-height");
+   int bry = scanner.getBryOption ();
+   int tly = scanner.findOption (SANE_NAME_SCAN_TL_Y);
+   QVERIFY (pageHeight != -1);
+   QVERIFY (bry != -1);
+   QVERIFY (tly != -1);
+   SANE_Word legal = SANE_FIX (355.6);
+   SANE_Word margin = SANE_FIX (5.0);
+   scanner.setOption (pageHeight, &legal);
+   scanner.setOption (bry, &legal);
+   scanner.setOption (tly, &margin);
+
+   /* the backend stores millimetres in scanner units, so read-backs
+      can be a fraction of a millimetre off */
+   auto nearMm = [&](int opt, SANE_Word want) {
+      return qAbs (SANE_UNFIX (scanner.saneWordValue (opt))
+                   - SANE_UNFIX (want)) < 0.1;
+   };
+   QVERIFY (nearMm (pageHeight, legal));
+
+   /* a string option stands in for things like the Fujitsu's buffer
+      mode, which no hand-picked restore list would ever cover */
+   int compress = scanner.findOption ("compression");
+   QVERIFY (compress != -1);
+   char jpegName[] = "JPEG";
+   scanner.setOption (compress, jpegName);
+   QCOMPARE (scanner.saneStringValue (compress), QString ("JPEG"));
 
    // After reconnect the settings should still be there, without any
    // explicit reapply by the caller.
    QVERIFY (scanner.reconnect ());
    QCOMPARE (scanner.xResolutionDpi (), 400);
    QCOMPARE (scanner.yResolutionDpi (), 400);
+   QCOMPARE (scanner.getBrightness (), 17);
+   QCOMPARE (scanner.getContrast (), -9);
+
+   /* option numbers may have moved on the fresh handle; look the
+      geometry up again by name */
+   pageHeight = scanner.findOption ("page-height");
+   bry = scanner.getBryOption ();
+   tly = scanner.findOption (SANE_NAME_SCAN_TL_Y);
+   QVERIFY (nearMm (pageHeight, legal));
+   QVERIFY (nearMm (bry, legal));
+   QVERIFY (nearMm (tly, margin));
+   compress = scanner.findOption ("compression");
+   QCOMPARE (scanner.saneStringValue (compress), QString ("JPEG"));
 }

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -5,6 +5,9 @@
 
 #include "../filemax.h"
 #include "../utils.h"
+
+#include <QBuffer>
+#include <QPainter>
 #include "test.h"
 
 #include "test_utils.h"
@@ -455,4 +458,80 @@ void TestUtils::testUserName()
    struct passwd *pw = getpwuid(getuid());
    QVERIFY(pw != nullptr);
    QCOMPARE(utilUserName(), QString(pw->pw_name));
+}
+
+
+/* a colour JPEG with enough rows that /24 previews are a few pixels */
+static QByteArray makeTestJpeg(int width, int height, bool grey)
+{
+   QImage img(width, height,
+              grey ? QImage::Format_Grayscale8 : QImage::Format_RGB32);
+   img.fill(Qt::white);
+   QPainter paint(&img);
+   paint.fillRect(0, 0, width / 2, height, Qt::black);
+   paint.end();
+
+   QByteArray jpeg;
+   QBuffer buf(&jpeg);
+   buf.open(QIODevice::WriteOnly);
+   img.save(&buf, "JPG");
+   return jpeg;
+}
+
+void TestUtils::testJpegThumbnailCorrupt()
+{
+   /* A scanner can deliver short or misframed JPEG data (e.g. when the
+      scan window does not match the paper); the thumbnailer must cope
+      rather than writing through an unallocated buffer. */
+   QByteArray good = makeTestJpeg(480, 720, false);
+   byte *dest;
+   int destSize;
+   cpoint size;
+
+   // sanity: the intact picture thumbnails fine
+   dest = nullptr;
+   destSize = 0;
+   QVERIFY(jpeg_thumbnail((byte *)good.data(), good.size(), &dest,
+                          &destSize, &size) != 0);
+   QVERIFY(dest != nullptr);
+   free(dest);
+
+   /* truncated mid-stream: decode stops early and the preview shrinks,
+      but whatever comes back must be consistent */
+   QByteArray cut = good.left(good.size() / 2);
+   dest = nullptr;
+   destSize = 0;
+   jpeg_thumbnail((byte *)cut.data(), cut.size(), &dest, &destSize, &size);
+   if (dest)
+      free(dest);
+
+   /* A stray start-of-image marker in the stream: libjpeg warns while
+      the header is still being parsed, which used to divide by zero in
+      the warning handler (the decode scale is not set up yet).  The
+      decode either fails cleanly with no output buffer, or recovers
+      and produces a thumbnail; either way it must not crash. */
+   QByteArray twoSoi = good;
+   int insert = twoSoi.indexOf((char)0xda);   // just before scan data
+   if (insert < 0)
+      insert = twoSoi.size() / 4;
+   twoSoi.insert(insert + 100, "\xff\xd8", 2);
+   dest = nullptr;
+   destSize = 0;
+   int rc = jpeg_thumbnail((byte *)twoSoi.data(), twoSoi.size(), &dest,
+                           &destSize, &size);
+   if (rc == 0)
+      QVERIFY(dest == nullptr);
+   if (dest)
+      free(dest);
+
+   /* the same again for a greyscale picture, whose copy-out path pads
+      each row and must not read past the decoded data */
+   QByteArray greyCut = makeTestJpeg(444, 720, true);
+   greyCut.truncate(greyCut.size() / 2);
+   dest = nullptr;
+   destSize = 0;
+   jpeg_thumbnail((byte *)greyCut.data(), greyCut.size(), &dest,
+                  &destSize, &size);
+   if (dest)
+      free(dest);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -32,6 +32,9 @@ private slots:
 
    //! Test preview encode/decode against the greyscale test image
    void testPreviewFromJpeg();
+
+   //! jpeg_thumbnail() survives truncated and corrupt JPEG data
+   void testJpegThumbnailCorrupt();
 private:
    // Create files in a temporary directory structure used for testing
    void createDirStructure(QTemporaryDir& tmp);

--- a/utils.cpp
+++ b/utils.cpp
@@ -125,16 +125,22 @@ int jpeg_thumbnail (byte *data, int insize, byte **destp, int *dest_sizep, cpoin
 //   epeg_encode                    (im);
    stride = (sizep->x * im->in.jinfo.num_components + 3) & ~3;
 
-   epeg_raw                    (im, stride);
-#if 1 // don't do this for now */
+   if (epeg_raw (im, stride))
+      {
+      /* the data was too corrupt to decode at all; there is no
+         thumbnail and, crucially, no output buffer was allocated, so
+         copying would write through a wild pointer */
+      *dest_sizep = 0;
+      epeg_close (im);
+      return 0;
+      }
    valid = im->last_valid_row;
-   if (valid != -1 && valid < im->in.h)
+   if (valid != -1 && valid / CONFIG_preview_scale < sizep->y)
       {
       printf ("data short - shrink preview from %d to %d\n", sizep->y, valid / CONFIG_preview_scale);
       sizep->y = valid / CONFIG_preview_scale;    // shrink preview
       *dest_sizep = stride * sizep->y;
       }
-#endif
    epeg_copy (im, sizep->x, sizep->y, stride);
    epeg_close                     (im);
    return valid;


### PR DESCRIPTION
Three fixes from chasing the letter/legal scanning problems, on top of
the already-merged toggle fixes (the branch is rebased onto master so
only the new commits appear).

Thumbnailing corrupt JPEG data from a scanner (for example when the
scan window does not match the paper) could crash in three ways: a
divide-by-zero in the libjpeg warning handler while the header is
still being parsed, heap corruption when a fatal decode error leaves
the output buffer unallocated but the copy runs anyway, and a read
overrun in the greyscale copy-out. All are guarded now, a page that
cannot be decoded simply gets no preview, and the per-row 'valid row'
console spam is gone.

Reconnecting after a scanner error used to restore only a hand-picked
list of settings, so the page size, scan area, compression and device
options like the Fujitsu's buffer mode reverted to defaults. The
snapshot now covers every active, settable option, keyed by name, and
is applied back in two passes so options gated on source or mode are
restored too.

The branch also carries the fix for restorePages() doubling the page
list, which the regression test merged with 'filemax: Open the file
before restoring deleted pages' currently fails on master (restoring
into a vector pre-sized to the final count and then appending). This
is the same commit as in the remote-repository series and will drop
out of whichever merges second.

The full suite passes on this branch (178 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuJ6u4Q43PFHDsNmhRQcA