### PR TITLE
Build and test paperman on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,54 @@ jobs:
       - name: Run parallel conversion test
         run: scripts/test_parallel.sh
 
+  windows:
+    name: Windows (MSYS2 MinGW64, Qt6) desktop app + server + C++ tests
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-qt6-base
+            mingw-w64-x86_64-qt6-scxml
+            mingw-w64-x86_64-poppler-qt6
+            mingw-w64-x86_64-podofo
+            mingw-w64-x86_64-libtiff
+            mingw-w64-x86_64-libjpeg-turbo
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-poppler
+            mingw-w64-x86_64-ghostscript
+            mingw-w64-x86_64-tesseract-ocr
+            mingw-w64-x86_64-tesseract-data-eng
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-python-reportlab
+            mingw-w64-x86_64-python-pillow
+            mingw-w64-x86_64-python-numpy
+
+      - name: Build desktop app
+        run: qmake6 paperman.pro -o Makefile.win && make -k -f Makefile.win -j$(nproc)
+
+      - name: Build server
+        run: |
+          qmake6 paperman-server.pro -o server.mk
+          echo '#define SERVER_BUILD_DATE "CI"' > builddate.h
+          make -k -f server.mk -j$(nproc)
+
+      - name: Generate test data
+        run: python3 scripts/make_test_files.py
+
+      - name: Run Qt unit tests
+        run: QT_QPA_PLATFORM=offscreen ./paperman.exe -t
+
   flutter:
     name: Flutter app + widget tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
             qt5-qmake qtbase5-dev qtbase5-dev-tools libqt5sql5-sqlite \
             libpoppler-qt5-dev libpodofo-dev \
             libtiff-dev libsane-dev libjpeg-dev zlib1g-dev \
-            imagemagick tesseract-ocr tesseract-ocr-eng \
+            imagemagick tesseract-ocr tesseract-ocr-eng libimage-exiftool-perl \
             python3-reportlab python3-pil python3-numpy \
             poppler-utils
 
       - name: Build desktop app
-        run: qmake paperman.pro && make -f Makefile -j$(nproc)
+        run: qmake paperman.pro CONFIG+=test && make -f Makefile -j$(nproc)
 
       - name: Build server
         run: |
@@ -61,12 +61,12 @@ jobs:
             libpoppler-qt6-dev libpodofo-dev \
             qt6-scxml-dev libqt6statemachine6 \
             libtiff-dev libsane-dev libjpeg-dev zlib1g-dev \
-            imagemagick tesseract-ocr tesseract-ocr-eng \
+            imagemagick tesseract-ocr tesseract-ocr-eng libimage-exiftool-perl \
             python3-reportlab python3-pil python3-numpy \
             poppler-utils
 
       - name: Build desktop app
-        run: qmake6 paperman.pro -o Makefile.qt6 && make -f Makefile.qt6 -j$(nproc)
+        run: qmake6 paperman.pro CONFIG+=test -o Makefile.qt6 && make -f Makefile.qt6 -j$(nproc)
 
       - name: Build server
         run: |
@@ -120,7 +120,7 @@ jobs:
             mingw-w64-x86_64-python-numpy
 
       - name: Build desktop app
-        run: qmake6 paperman.pro -o Makefile.win && make -k -f Makefile.win -j$(nproc)
+        run: qmake6 paperman.pro CONFIG+=test -o Makefile.win && make -k -f Makefile.win -j$(nproc)
 
       - name: Build server
         run: |
@@ -132,7 +132,8 @@ jobs:
         run: python3 scripts/make_test_files.py
 
       - name: Run Qt unit tests
-        run: QT_QPA_PLATFORM=offscreen ./paperman.exe -t
+        # fail a hung test quickly rather than after QtTest's five minutes
+        run: QT_QPA_PLATFORM=offscreen QTEST_FUNCTION_TIMEOUT=60000 ./paperman.exe -t
 
   flutter:
     name: Flutter app + widget tests

--- a/desk.cpp
+++ b/desk.cpp
@@ -1127,9 +1127,10 @@ err_info *Desk::moveFromDir (QString &fromDir, QString &trashname, QString &file
    QDir dir;
    QString from = fromDir + "/" + trashname;
    QString to = _dir + filename;
-   if (!dir.rename (from, to))
+   QString error;
+   if (!utilRenameFile (from, to, &error))
       return err_make (ERRFN, ERR_could_not_rename_file2, qPrintable (from),
-            qPrintable (to));
+            qPrintable (to + ": " + error));
    fnew = createFile (_dir, filename);
    newFile (fnew);
    return NULL;

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -2102,6 +2102,20 @@ void Desktopmodel::addFilesToDesk (QString dir, QStringList &fnamelist)
    }
 
 
+void Desktopmodel::releaseFilesInDesk (QString dir, QStringList &fnamelist)
+   {
+   QModelIndex parent = index (dir, QModelIndex ());
+
+   if (!parent.isValid ())
+      return;
+
+   QModelIndexList list = listFromFilenames (fnamelist, parent);
+   foreach (QModelIndex ind, list)
+      if (ind.isValid ())
+         getFile (ind)->release ();
+   }
+
+
 void Desktopmodel::removeFilesFromDesk (QString dir, QStringList &fnamelist)
    {
    QModelIndex parent = index (dir, QModelIndex ());

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -365,6 +365,13 @@ public:
       function handle that. It simply removes the files from the desk */
    void removeFilesFromDesk (QString dir, QStringList &fnamelist);
 
+   /** release any open handles on files in a desk, if it is loaded, so
+       that they can be renamed (see File::release())
+
+      \param dir        directory of the desk
+      \param fnamelist  files to release */
+   void releaseFilesInDesk (QString dir, QStringList &fnamelist);
+
    /** clear all files in a desk */
    void clearAll (QModelIndex &parent);
 

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -614,6 +614,11 @@ err_info *Desktopmodel::opUntrashStacks (QStringList &trashlist, QModelIndex par
       return e;
       }
 
+   /* the source desk, if loaded, still has the files open: let go of
+      them so they can be renamed */
+   if (!copy && !src.isEmpty ())
+      releaseFilesInDesk (src, trashlist);
+
    /* first, move all the trashed files back into the current directory,
       creating a list of the new File * records thus created. If
       an error occurs, stop where we got up to (with the one that caused

--- a/dmop.cpp
+++ b/dmop.cpp
@@ -46,6 +46,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "desk.h"
 #include "file.h"
 #include "ocr.h"
+#include <QDir>
+
 #include "op.h"
 #include "remotebackend.h"
 #include "utils.h"
@@ -1302,7 +1304,7 @@ err_info *Desktopmodel::packageFiles (QModelIndexList &slist,
 
    // name of first file will be used for the zip name
    fname = getFile (slist [0])->filename ();
-   QString dir = QString ("%1/").arg (P_tmpdir);
+   QString dir = QDir::tempPath () + "/";
 
    // put the path on front of each file
    foreach (QModelIndex ind, slist)

--- a/epeglite.cpp
+++ b/epeglite.cpp
@@ -31,7 +31,10 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <jerror.h>
 
+/* MinGW has no fmemopen(), so fall back to a temporary file there */
+#ifndef _WIN32
 #define HAVE_FMEMOPEN
+#endif
 #define NOWARNINGS
 
 // predeclarations

--- a/file.cpp
+++ b/file.cpp
@@ -714,9 +714,10 @@ err_info *File::move (QString &newDir, QString &newName, bool copy)
          ERR_could_not_copy_file2, qPrintable (oldPath),
                   qPrintable (newPath));
    CALL (release ());
-   if (!dir.rename (oldPath, newPath))
+   QString error;
+   if (!utilRenameFile (oldPath, newPath, &error))
       return err_make (ERRFN, ERR_could_not_rename_file2, qPrintable (oldPath),
-                  qPrintable (newPath));
+                  qPrintable (newPath + ": " + error));
    utilSetGroup(newPath);
 
    return NULL;

--- a/file.cpp
+++ b/file.cpp
@@ -657,6 +657,7 @@ err_info *File::rename (QString &fname, bool auto_rename)
 
    if (file.exists ())
       return err_make (ERRFN, ERR_file_already_exists1,qPrintable (name));
+   CALL (release ());
    err = ::rename (qPrintable (oldname), qPrintable (newname));
    if (err)
       return err_make (ERRFN, ERR_could_not_execute1, "rename");
@@ -712,6 +713,7 @@ err_info *File::move (QString &newDir, QString &newName, bool copy)
       return err_subsume (ERRFN, copyFile (oldPath, newPath),
          ERR_could_not_copy_file2, qPrintable (oldPath),
                   qPrintable (newPath));
+   CALL (release ());
    if (!dir.rename (oldPath, newPath))
       return err_make (ERRFN, ERR_could_not_rename_file2, qPrintable (oldPath),
                   qPrintable (newPath));

--- a/file.cpp
+++ b/file.cpp
@@ -1056,7 +1056,7 @@ err_info *File::duplicateToDesk (Desk *desk, File::e_type type, QString &uniq,
    // and directory (the same one as this file, or the temp dir)
    QString dir = _dir;
    if (!desk)
-      dir = QString ("%1/").arg (P_tmpdir);
+      dir = QDir::tempPath () + "/";
 
    // do a plain file copy if allowed to
    if (type == Type_other)

--- a/file.h
+++ b/file.h
@@ -271,6 +271,11 @@ public:
 
    virtual err_info *flush (void) = 0;
 
+   /** drop any handles held open on the file, so that it can be renamed
+       or replaced. Windows refuses to rename a file which is open. The
+       next access reopens the file, so the object stays usable */
+   virtual err_info *release (void) { return NULL; }
+
    virtual err_info *remove (void) = 0;
 
    /**

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -3459,7 +3459,7 @@ static void TIFFFlushData1 (TIFF *tiff)
 
 #define  is2DEncoding(sp) \
    (sp->b.groupoptions & GROUP3OPT_2DENCODING)
-#define  isAligned(p,t) ((((u_long)(p)) & (sizeof (t)-1)) == 0)
+#define  isAligned(p,t) ((((uintptr_t)(p)) & (sizeof (t)-1)) == 0)
 #define  TIFFroundup(x, y) (TIFFhowmany(x,y)*((uint32_t)(y)))
 #define  TIFFhowmany(x, y) ((((uint32_t)(x))+(((uint32_t)(y))-1))/((uint32_t)(y)))
 
@@ -4574,7 +4574,7 @@ static int add_image_header (chunk_info &chunk, byte *buf)
    ptr [12] = chunk.parts.size ();
 
    iptr = (unsigned *)(buf + POS_part0);
-   assert (!((long int)iptr & 3));
+   assert (!((uintptr_t)iptr & 3));
    for (i = 0; i < chunk.parts.size (); i++, iptr += 2)
       {
       part_info &part = chunk.parts [i];

--- a/filepdf.cpp
+++ b/filepdf.cpp
@@ -81,7 +81,11 @@ err_info *Filepdf::create (void)
    {
    if (!_pdfio)
       _pdfio = new Pdfio (_pathname);
-   return _pdfio->create ();
+   CALL (_pdfio->create ());
+
+   // the document is in memory, so there is nothing for load() to open
+   _valid = true;
+   return NULL;
    }
 
 

--- a/filepdf.cpp
+++ b/filepdf.cpp
@@ -38,6 +38,7 @@ Filepdf::Filepdf (const QString &dir, const QString &filename, Desk *desk)
    : File (dir, filename, desk, Type_pdf)
    {
    _pdfio = 0;
+   _released_pages = 1;
    }
 
 
@@ -90,6 +91,21 @@ err_info *Filepdf::flush (void)
    }
 
 
+err_info *Filepdf::release (void)
+   {
+   /* both PoDoFo and poppler keep the file open, so drop them; load()
+      creates a fresh Pdfio from the (possibly new) pathname */
+   if (_pdfio)
+      {
+      _released_pages = _pdfio->numPages ();
+      delete _pdfio;
+      _pdfio = nullptr;
+      }
+   _valid = false;
+   return NULL;
+   }
+
+
 
 
 err_info *Filepdf::remove (void)
@@ -110,7 +126,7 @@ int Filepdf::pagecount (void)
    {
    if (_pdfio)
       return _pdfio->numPages ();
-   return 1;
+   return _released_pages;
    }
 
 

--- a/filepdf.h
+++ b/filepdf.h
@@ -65,6 +65,8 @@ public:
 
    virtual err_info *flush (void);
 
+   virtual err_info *release (void);
+
    virtual err_info *remove (void);
 
 
@@ -133,4 +135,5 @@ public:
 
 private:
    Pdfio *_pdfio;
+   int _released_pages;  //!< page count remembered across release()
    };

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -183,7 +183,12 @@ void Mainwidget::saveSettings (void)
 bool Mainwidget::complain(err_info *err)
 {
    if (err)
-      QMessageBox::warning (0, "Maxview", err->errstr);
+      {
+      if (utilTestMode())
+         qWarning() << "Error:" << err->errstr;
+      else
+         QMessageBox::warning (0, "Maxview", err->errstr);
+      }
 
    return err != nullptr;
 }

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -28,7 +28,9 @@ C           copy        scan and print to default printer, save to 'photocopy' f
 
 #include <unistd.h>
 #include <getopt.h>
+#ifndef _WIN32
 #include <sys/resource.h>
+#endif
 
 #include <QDebug>
 #include <QDir>
@@ -608,6 +610,7 @@ int main (int argc, char *argv[])
    QString adjust_name;
    QString serverUrl;                     // --server URL
 
+#ifndef Q_OS_WIN
    struct rlimit limit;
 
    if (!getrlimit(RLIMIT_NOFILE, &limit) && limit.rlim_cur < 20000) {
@@ -618,6 +621,7 @@ int main (int argc, char *argv[])
       if (setrlimit(RLIMIT_NOFILE, &limit))
          qDebug() << "Setting nofile limit failed";
    }
+#endif
 
    while (c = getopt_long (argc, argv, "hj:m:o:p:q:s:t",
                            long_options, NULL), c != -1)
@@ -725,7 +729,7 @@ int main (int argc, char *argv[])
       {
       useGUI = false;
       // Force offscreen platform for console mode
-      setenv("QT_QPA_PLATFORM", "offscreen", 1);
+      qputenv("QT_QPA_PLATFORM", "offscreen");
       }
 
    if (!need_gui && op_type == -1 && !useGUI)
@@ -1107,6 +1111,11 @@ int main (int argc, char *argv[])
          maxdesk.buildIndex (index, fname);
 #endif
       }
+
+   /* the command-line operations fall through to here; without an explicit
+      return GCC treats the end of the function as unreachable and MinGW
+      builds die with an illegal instruction */
+   return 0;
    }
 
 

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -829,6 +829,7 @@ int main (int argc, char *argv[])
          }
 #else
          qInfo() << "Use this to build with tests: qmake CONFIG+=test";
+         return 1;
 #endif
          break;
          }

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -65,6 +65,7 @@ C           copy        scan and print to default printer, save to 'photocopy' f
 #include "maxview.h"
 #include "ocr.h"
 #include "op.h"
+#include "utils.h"
 #include "searchindex.h"
 #include "test/test.h"
 
@@ -818,6 +819,15 @@ int main (int argc, char *argv[])
 #ifdef ENABLE_TEST
          {
          const char *filter = (optind < argc) ? argv[optind] : nullptr;
+
+         /* keep the results visible if a test hangs and is killed, and
+            report errors to the console rather than in a dialog */
+         setvbuf (stdout, NULL, _IONBF, 0);
+         utilSetTestMode (true);
+
+         /* on Windows Qt sends test results and log messages to the
+            debugger unless told to use stderr */
+         qputenv ("QT_FORCE_STDERR_LOGGING", "1");
          char *qt_argv[] = { argv[0], nullptr };
          int qt_argc = 1;
          int result = test_run(qt_argc, qt_argv, &app, filter);

--- a/ocromni.cpp
+++ b/ocromni.cpp
@@ -27,7 +27,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifdef CONFIG_use_omnipage
 #include <dlfcn.h>
+#endif
 
 #include <QDataStream>
 #include <QDebug>

--- a/ocrtess.cpp
+++ b/ocrtess.cpp
@@ -22,16 +22,14 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
 #include <QDataStream>
 #include <QDebug>
+#include <QDir>
 #include <QFile>
 #include <QImage>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QTemporaryFile>
 
 #include "err.h"
 
@@ -51,63 +49,62 @@ Ocrtess::~Ocrtess ()
    }
 
 
+/* tesseract is found on the PATH, so this works with a distribution
+   package on Linux and an MSYS2 or installer package on Windows */
+static QString tesseractPath (void)
+   {
+   return QStandardPaths::findExecutable ("tesseract");
+   }
+
+
 err_info *Ocrtess::init (void)
    {
-   QFile file ("/usr/bin/tesseract");
-
-   if (!file.exists ())
+   if (tesseractPath ().isEmpty ())
       return err_make (ERRFN, ERR_ocr_engine_not_present_or_broken2,
-         "tesseract", "/usr/bin/tesseract does not exist");
+         "tesseract", "tesseract is not on the PATH");
    return NULL;
    }
 
 
 err_info *Ocrtess::imageToText (QImage &image, QString &text)
    {
-   char base [200], tmp [200], tmp2 [200], out [200];
-   char cmd [430];
-   int fd;
-
    // this function should really use tesseract as a library
 
-   /* sadly:
+   QString exe = tesseractPath ();
+   if (exe.isEmpty ())
+      return err_make (ERRFN, ERR_ocr_engine_not_present_or_broken2,
+         "tesseract", "tesseract is not on the PATH");
 
-     1. tesseract only accepts 1bpp uncompressed tiff
-     2. QT only writes 8bpp tiff
-
-     so we:
-
-     1. Write png
-     2. Convert to tif with 'convert' */
-   sprintf (base, "%s/maxviewXXXXXX", P_tmpdir);
-   fd = mkstemp (base);
-   if (fd < 0)
+   /* tesseract reads PNG directly and writes <base>.txt, so give it a
+      unique base name in the temporary directory */
+   QTemporaryFile base (QDir::tempPath () + "/maxviewXXXXXX");
+   if (!base.open ())
       return err_make (ERRFN, ERR_could_not_make_temporary_file);
-   close (fd);
-   strncpy (tmp, base, sizeof(tmp));
-   strncat (tmp, ".png", sizeof(tmp) - strlen(tmp) - 1);
-   qDebug () << image.depth ();
-   image.save (tmp, "PNG");
+   QString tmp = base.fileName () + ".png";
+   QString out = base.fileName () + ".txt";
+   if (!image.save (tmp, "PNG"))
+      return err_make (ERRFN, ERR_cannot_open_file1, qPrintable (tmp));
 
-   strncpy (tmp2, base, sizeof(tmp2));
-   strncat (tmp2, ".tif", sizeof(tmp2) - strlen(tmp2) - 1);
-   int errnum = err_systemf ("convert %s %s", tmp, tmp2);
-   if (errnum)
-      return err_make (ERRFN, ERR_could_not_execute1, "convert");
+   QProcess proc;
+   proc.start (exe, QStringList () << tmp << base.fileName ());
+   bool ok = proc.waitForFinished (-1) && proc.exitStatus () == QProcess::NormalExit
+             && proc.exitCode () == 0;
+   QFile::remove (tmp);
+   if (!ok)
+      {
+      QFile::remove (out);
+      return err_make (ERRFN, ERR_tesseract_not_present2, qPrintable (exe),
+                       proc.readAllStandardError ().constData ());
+      }
 
-   strncpy (out, base, sizeof(tmp));
-   snprintf (cmd, sizeof(cmd), "/usr/bin/tesseract %s %s", tmp2, out);
-   errnum = err_systemf (cmd);
-   if (errnum)
-      return err_make (ERRFN, ERR_tesseract_not_present2, cmd, strerror (errno));
-
-   strncat (out, ".txt", sizeof(out) - strlen(out) - 1);
    QFile file (out);
    if (!file.open (QIODevice::ReadOnly))
-      return err_make (ERRFN, ERR_cannot_open_file1, out);
+      return err_make (ERRFN, ERR_cannot_open_file1, qPrintable (out));
 
    QByteArray ba = file.readAll ();
-   text = ba.constData ();
+   file.close ();
+   QFile::remove (out);
+   text = QString::fromUtf8 (ba);
    return NULL;
    }
 

--- a/paperman-server.cpp
+++ b/paperman-server.cpp
@@ -38,8 +38,14 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#define isatty _isatty
+#else
 #include <termios.h>
 #include <unistd.h>
+#endif
 
 void printUsage(const char *progName)
 {
@@ -69,14 +75,23 @@ static QString readPasswordHidden(const QString &prompt)
 {
     std::cout << prompt.toStdString() << std::flush;
 
-    termios oldt;
     bool echoToggled = false;
+#ifdef Q_OS_WIN
+    HANDLE hin = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD oldMode = 0;
+    if (isatty(fileno(stdin)) && GetConsoleMode(hin, &oldMode)) {
+        if (SetConsoleMode(hin, oldMode & ~ENABLE_ECHO_INPUT))
+            echoToggled = true;
+    }
+#else
+    termios oldt;
     if (isatty(fileno(stdin)) && tcgetattr(fileno(stdin), &oldt) == 0) {
         termios newt = oldt;
         newt.c_lflag &= ~(tcflag_t)ECHO;
         if (tcsetattr(fileno(stdin), TCSANOW, &newt) == 0)
             echoToggled = true;
     }
+#endif
 
     char buf[256];
     QString line;
@@ -87,7 +102,11 @@ static QString readPasswordHidden(const QString &prompt)
     }
 
     if (echoToggled) {
+#ifdef Q_OS_WIN
+        SetConsoleMode(hin, oldMode);
+#else
         tcsetattr(fileno(stdin), TCSANOW, &oldt);
+#endif
         std::cout << "\n";
     }
     return line;

--- a/paperman-server.pro
+++ b/paperman-server.pro
@@ -79,5 +79,14 @@ unix {
     INSTALLS += target
 }
 
+win32 {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += libpodofo
+    equals(QT_MAJOR_VERSION, 6): PKGCONFIG += poppler-qt6
+    equals(QT_MAJOR_VERSION, 5): PKGCONFIG += poppler-qt5
+    CONFIG -= debug_and_release
+    DESTDIR = .
+}
+
 message("Building Paperman Search Server")
 message("Run 'qmake && make' to build")

--- a/paperman.pro
+++ b/paperman.pro
@@ -308,6 +308,9 @@ test {
 
     QMAKE_CXXFLAGS += -DENABLE_TEST
     QT += concurrent
+    # a GUI-subsystem executable has no stdout on Windows, so the test
+    # results would be lost
+    win32: CONFIG += console
 }
 
 # tif_fax3sm.c   - causes tifflib to break

--- a/paperman.pro
+++ b/paperman.pro
@@ -45,7 +45,17 @@ equals(QT_MAJOR_VERSION, 5) {
 #LIBS += -lkernelapi -Wl,-rpath-link,$$OCRLIBPATH,-rpath,$$OCRLIBPATH
 
 LIBS += -lpodofo
-LIBS += -ltiff -lsane -ljpeg -lz -ldl
+LIBS += -ltiff -ljpeg -lz
+
+# There is no libsane on Windows: build against the bundled headers and a
+# stub library, leaving only the simulated scanner. dlsym() is only used to
+# look up the optional sane_read_dup() extension, so it goes too
+win32 {
+    INCLUDEPATH += win32
+    SOURCES += win32/sanestub.cpp
+} else {
+    LIBS += -lsane -ldl
+}
 
 INCLUDEPATH += qi /usr/local/lib
 INCLUDEPATH += $$OCRINCPATH
@@ -307,10 +317,24 @@ test {
 #release
 
 
-unix {
-    UI_DIR = .ui
-    MOC_DIR = .moc
-    OBJECTS_DIR = .obj
+# Keep the generated files out of the source directory. This must apply on
+# every platform: the server build shares the directory and would otherwise
+# pick up these objects, compiled with widgets, instead of its own
+UI_DIR = .ui
+MOC_DIR = .moc
+OBJECTS_DIR = .obj
+
+win32 {
+    # MSYS2 lays the headers out under the toolchain prefix; qmake does not
+    # know about them, so ask pkg-config for poppler and podofo
+    CONFIG += link_pkgconfig
+    PKGCONFIG += libpodofo
+    equals(QT_MAJOR_VERSION, 6): PKGCONFIG += poppler-qt6
+    equals(QT_MAJOR_VERSION, 5): PKGCONFIG += poppler-qt5
+    # the tests run with the source directory as the working directory, so
+    # keep the executable next to the sources rather than in debug/release
+    CONFIG -= debug_and_release
+    DESTDIR = .
 }
 
 QT += xml

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -183,6 +183,14 @@ err_info *Pdfio::close (void)
       QFile::remove (tmpname);
       return make_error (eCode);
       }
+
+   /* drop both libraries' views of the old file first: Windows will not
+      remove or rename a file which is still open */
+   delete _doc;
+   _doc = 0;
+#ifdef CONFIG_use_poppler
+   _pop.reset();
+#endif
    if (QFile::exists (_pathname))
       QFile::remove (_pathname);
    if (!QFile::rename (tmpname, _pathname))
@@ -190,11 +198,6 @@ err_info *Pdfio::close (void)
             qPrintable (tmpname), qPrintable (_pathname));
 
    // reopen both libraries' views of the new file
-   delete _doc;
-   _doc = 0;
-#ifdef CONFIG_use_poppler
-   _pop.reset();
-#endif
    return open ();
    }
 

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -31,6 +31,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "err.h"
 #include "file.h"
 #include "pdfio.h"
+#include "utils.h"
 
 
 #define EXCEPTIONS
@@ -191,11 +192,10 @@ err_info *Pdfio::close (void)
 #ifdef CONFIG_use_poppler
    _pop.reset();
 #endif
-   if (QFile::exists (_pathname))
-      QFile::remove (_pathname);
-   if (!QFile::rename (tmpname, _pathname))
+   QString error;
+   if (!utilReplaceFile (tmpname, _pathname, &error))
       return err_make (ERRFN, ERR_could_not_rename_file2,
-            qPrintable (tmpname), qPrintable (_pathname));
+            qPrintable (tmpname), qPrintable (_pathname + ": " + error));
 
    // reopen both libraries' views of the new file
    return open ();

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -101,6 +101,13 @@ err_info *Pdfio::find_page (int pagenum, std::unique_ptr<Poppler::Page> &page)
 
 err_info *Pdfio::open (void)
    {
+   /* a document from an earlier open() or create() would otherwise leak,
+      keeping the file open, which stops it being renamed on Windows */
+   if (_doc)
+      {
+      delete _doc;
+      _doc = 0;
+      }
 #ifdef CONFIG_use_poppler
 #if QT_VERSION >= 0x060000
    _pop = Poppler::Document::load (_pathname);

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -46,6 +46,17 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 using namespace PoDoFo;
 
 
+/* PoDoFo 1.x reworked its API: pages live in a PdfPageCollection,
+   images are created by the document and described by PdfImageInfo,
+   the content tokenizer became PdfContentStreamReader and most accessors
+   return references rather than pointers. Debian and Ubuntu still ship
+   0.9.8 while MSYS2 (used for the Windows build) has 1.x, so support
+   both */
+#if PODOFO_VERSION_MAJOR >= 1
+#define PODOFO_1X
+#endif
+
+
 Pdfio::Pdfio (const QString &fname)
    {
    _doc = 0;
@@ -53,7 +64,9 @@ Pdfio::Pdfio (const QString &fname)
    _pop = nullptr;
 #endif
    _pathname = fname;
+#ifndef PODOFO_1X
    PoDoFo::PdfError::EnableDebug(false);
+#endif
    }
 
 
@@ -126,11 +139,21 @@ err_info *Pdfio::create (void)
 //       qDebug () << _pathname;
       _doc = new PdfMemDocument ();
       //FIXME: put proper fields in here
+#ifdef PODOFO_1X
+      PdfMetadata &meta = _doc->GetMetadata ();
+
+      meta.SetCreator (PdfString ("Maxview - manage your paper"));
+      meta.SetAuthor (PdfString ("Simon Glass"));
+      meta.SetTitle (PdfString (""));
+      meta.SetSubject (PdfString (""));
+      meta.SetKeywords (std::vector<std::string> {"sep", "sep"});
+#else
       _doc->GetInfo()->SetCreator ( PdfString("Maxview - manage your paper") );
       _doc->GetInfo()->SetAuthor  ( PdfString("Simon Glass") );
       _doc->GetInfo()->SetTitle   ( PdfString("") );
       _doc->GetInfo()->SetSubject ( PdfString("") );
       _doc->GetInfo()->SetKeywords( PdfString("sep;sep;") );
+#endif
       }
    catch (const PdfError &eCode)
       {
@@ -149,7 +172,11 @@ err_info *Pdfio::close (void)
 
    try
       {
+#ifdef PODOFO_1X
+      _doc->Save (tmpname.toLatin1 ().constData());
+#else
       _doc->Write (tmpname.toLatin1 ().constData());
+#endif
       }
    catch (const PdfError &eCode)
       {
@@ -172,11 +199,73 @@ err_info *Pdfio::close (void)
    }
 
 
+#ifdef PODOFO_1X
+
+/* PoDoFo 1.x helpers */
+
+/* scale an image to fill the page, keeping its aspect ratio, and draw it
+   at the bottom left */
+static void draw_scaled (PdfPage &page, const PdfImage &image)
+   {
+   PdfPainter painter;
+   Rect rect = page.GetRect ();
+   double xscale = rect.Width / image.GetWidth ();
+   double yscale = rect.Height / image.GetHeight ();
+   double scale = qMin (xscale, yscale);
+
+   painter.SetCanvas (page);
+   painter.DrawImage (image, rect.X, rect.Y, scale, scale);
+   painter.FinishDrawing ();
+   }
+
+
+/* store uncompressed pixel data in an image, flate-compressing it. Uses
+   the raw path so 1-bit images are supported */
+static void set_image_pixels (PdfImage &image, const QByteArray &ba,
+                              int width, int height, int depth)
+   {
+   PdfImageInfo info;
+
+   info.Width = width;
+   info.Height = height;
+   info.BitsPerComponent = depth == 1 ? 1 : 8;
+   info.ColorSpace = depth <= 8 ? PdfColorSpaceType::DeviceGray
+         : PdfColorSpaceType::DeviceRGB;
+   image.SetDataRaw (bufferview (ba.constData (), ba.size ()), info);
+
+   /* SetDataRaw() stores the bytes as they are, so compress them now */
+   SpanStreamDevice stream (bufferview (ba.constData (), ba.size ()));
+   image.GetObject ().GetOrCreateStream ().SetData (stream,
+         PdfFilterList {PdfFilterType::FlateDecode}, false);
+   }
+
+#endif
+
+
 err_info *Pdfio::addPage (const Filepage *mp)
    {
    mytry
       {
       Q_ASSERT (_doc);
+#ifdef PODOFO_1X
+      PdfPage &page = _doc->GetPages ().CreatePage (PdfPageSize::A4);
+
+      QImage imthumb;
+      QByteArray ba = mp->getThumbnailRaw (false, imthumb, false);
+      std::unique_ptr<PdfImage> thumb = _doc->CreateImage ();
+
+      set_image_pixels (*thumb, ba, imthumb.width (), imthumb.height (),
+                        imthumb.depth ());
+      page.GetDictionary ().AddKey (PdfName ("Thumb"),
+            PdfObject (thumb->GetObject ().GetIndirectReference ()));
+
+      // now the main image
+      std::unique_ptr<PdfImage> image = _doc->CreateImage ();
+
+      ba = mp->copyData (mp->_depth == 1, true);
+      set_image_pixels (*image, ba, mp->_width, mp->_height, mp->_depth);
+      draw_scaled (page, *image);
+#else
 //       _doc = new PdfMemDocument (_fname.latin1 ());
       PdfPage *page;
       PdfPainter painter;
@@ -243,6 +332,7 @@ err_info *Pdfio::addPage (const Filepage *mp)
          scale = yscale;
       painter.DrawImage (rect.GetLeft (), rect.GetBottom (), image, scale, scale);
       painter.FinishPage();
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)
@@ -260,6 +350,22 @@ err_info *Pdfio::addPageJpeg(const QByteArray &jpegData, int width, int height,
    mytry
       {
       Q_ASSERT (_doc);
+#ifdef PODOFO_1X
+      PdfPage &page = _doc->GetPages ().CreatePage (PdfPageSize::A4);
+      std::unique_ptr<PdfImage> image = _doc->CreateImage ();
+      PdfImageInfo info;
+
+      /* Write the pre-compressed JPEG stream with DCTDecode filter */
+      info.Width = width;
+      info.Height = height;
+      info.BitsPerComponent = 8;
+      info.Filters = PdfFilterList {PdfFilterType::DCTDecode};
+      info.ColorSpace = colour ? PdfColorSpaceType::DeviceRGB
+            : PdfColorSpaceType::DeviceGray;
+      image->SetDataRaw (bufferview (jpegData.constData (), jpegData.size ()),
+                         info);
+      draw_scaled (page, *image);
+#else
       PdfPage *page;
       PdfPainter painter;
 
@@ -287,6 +393,7 @@ err_info *Pdfio::addPageJpeg(const QByteArray &jpegData, int width, int height,
       painter.DrawImage (rect.GetLeft (), rect.GetBottom (), image,
                          scale, scale);
       painter.FinishPage();
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)
@@ -300,6 +407,12 @@ err_info *Pdfio::addPageJpeg(const QByteArray &jpegData, int width, int height,
 
 err_info *Pdfio::make_error (const PdfError &eCode)
    {
+#ifdef PODOFO_1X
+   eCode.PrintErrorMsg ();
+   for (const PdfErrorInfo &info : eCode.GetCallStack ())
+      qDebug () << info.GetInformation ().c_str ();
+   return err_make (ERRFN, ERR_pdf_creation_error1, eCode.what ());
+#else
    TDequeErrorInfo info = eCode.GetCallstack ();
    TCIDequeErrorInfo it = info.begin ();
 
@@ -310,6 +423,18 @@ err_info *Pdfio::make_error (const PdfError &eCode)
       it++;
       }
    return err_make (ERRFN, ERR_pdf_creation_error1, eCode.ErrorMessage (eCode.GetError()));
+#endif
+   }
+
+
+/* returns the /Rotate value of a page, normalised to 0-359 */
+int Pdfio::page_rotation (int pagenum) const
+   {
+#ifdef PODOFO_1X
+   return (int)_doc->GetPages ().GetPageAt (pagenum).GetRotation () % 360;
+#else
+   return ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360) % 360;
+#endif
    }
 
 
@@ -375,8 +500,7 @@ err_info *Pdfio::getImageSize (int pagenum, bool preview, QSize &size,
 
          /* a 90 or 270 degree /Rotate swaps the displayed dimensions,
             to match the rotated image apply_rotation() produces */
-         int rot = ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360)
-               % 360;
+         int rot = page_rotation (pagenum);
          if (rot == 90 || rot == 270)
             size.transpose ();
          return NULL;
@@ -420,8 +544,7 @@ QImage Pdfio::apply_rotation (int pagenum, const QImage &image) const
 
    /* /Rotate is the clockwise rotation a viewer applies to the page,
       so map it to the matching image transform */
-   int rotation = ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360)
-         % 360;
+   int rotation = page_rotation (pagenum);
    switch (rotation)
       {
       case 90 :
@@ -451,12 +574,15 @@ void Pdfio::get_image_details (const PdfDictionary *dict, int &width, int &heigh
    width = pwidth->GetNumber();
    height = pheight->GetNumber();
    int bpc = pbits->GetNumber();
+#ifdef PODOFO_1X
+   QString cs = pcolor && pcolor->IsName ()
+         ? QString::fromStdString (std::string (pcolor->GetName ().GetString ()))
+         : QString ();
+#else
    QString cs = pcolor->GetName().GetName ().c_str ();
-   EPdfColorSpace space = cs == "DeviceRGB" ? ePdfColorSpace_DeviceRGB
-         : cs == "DeviceGray" ? ePdfColorSpace_DeviceGray
-         : ePdfColorSpace_DeviceGray;
+#endif
    bpp = bpc;
-   if (space == ePdfColorSpace_DeviceRGB)
+   if (cs == "DeviceRGB")
       bpp *= 3;
    }
 
@@ -481,9 +607,18 @@ err_info *Pdfio::getImage (QString fname, int pagenum, QImage &image, double xsc
 
          get_image_details (dict, width, height, bpp);
          // qDebug () << "image" << width << height << bpp;
+#ifdef PODOFO_1X
+         /* GetCopy() decodes the stream and throws for filters it cannot
+            handle, such as DCTDecode, which drops us into the poppler
+            fallback below */
+         charbuff copy = obj->MustGetStream ().GetCopy ();
+         char *buff = copy.data ();
+         long len = copy.size ();
+#else
          char *buff;
          pdf_long len;
          obj->GetStream()->GetFilteredCopy (&buff, &len);
+#endif
 //          qDebug () << buff << len;
          int stride = (width * bpp + 7) / 8;
 //         qDebug () << "width" << width << "bpp" << bpp << "stride" << stride
@@ -535,12 +670,22 @@ err_info *Pdfio::rotatePage (int pagenum, int degrees)
       CALL (open ());
    try
       {
+#ifdef PODOFO_1X
+      PdfPageCollection &pages = _doc->GetPages ();
+
+      if (pagenum < 0 || (unsigned)pagenum >= pages.GetCount ())
+         return err_make (ERRFN, ERR_could_not_find_image_chunk_for_page1,
+               pagenum + 1);
+      PdfPage &page = pages.GetPageAt (pagenum);
+      page.SetRotation ((page.GetRotation () + degrees) % 360);
+#else
       PdfPage *page = _doc->GetPage (pagenum);
 
       if (!page)
          return err_make (ERRFN, ERR_could_not_find_image_chunk_for_page1,
                pagenum + 1);
       page->SetRotation ((page->GetRotation () + degrees) % 360);
+#endif
       }
    catch (const PdfError &eCode)
       {
@@ -567,10 +712,74 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
    {
    if (!_doc)
       return 0;
+   bool image_only = true;
+   QString image_name;
+   PdfReference ref;
+
+   dict = 0;
+#ifdef PODOFO_1X
+   /* walk the content stream: the page is a plain image if it only
+      uses the transform, state and Do operators */
+   PdfPage &page = _doc->GetPages ().GetPageAt (pagenum);
+   PdfContentReaderArgs args;
+
+   // report Do as a plain operator rather than resolving the XObject
+   args.Flags = (PdfContentReaderFlags)
+         ((int)PdfContentReaderFlags::SkipFollowFormXObjects
+          | (int)PdfContentReaderFlags::SkipHandleNonFormXObjects);
+   PdfContentStreamReader reader (page, args);
+   PdfContent content;
+
+   while (image_only && reader.TryReadNext (content))
+      {
+      switch (content.GetType ())
+         {
+         case PdfContentType::Operator :
+            {
+            PdfOperator op = content.GetOperator ();
+            const PdfVariantStack &stack = content.GetStack ();
+
+            if (op != PdfOperator::q && op != PdfOperator::Q
+                && op != PdfOperator::cm && op != PdfOperator::Do)
+               image_only = false;
+            if (op == PdfOperator::Do && stack.GetSize () == 1
+                && stack [0].IsName () && image_name.isEmpty ())
+               image_name = QString::fromStdString (
+                     std::string (stack [0].GetName ().GetString ()));
+            break;
+            }
+
+         case PdfContentType::UnexpectedKeyword :
+            image_only = false;
+            break;
+
+         default :
+            break;
+         }
+      }
+   if (!image_only)
+      return 0;
+
+   /* find the XObject the page draws: the one named by Do if we saw it,
+      otherwise the last one in the resources */
+   const PdfResources &res = page.GetResources ();
+   const PdfObject *xobjects = res.GetDictionary ().FindKey ("XObject");
+   if (xobjects && xobjects->IsDictionary ())
+      {
+      for (auto &pair : xobjects->GetDictionary ())
+         {
+         if (!pair.second.IsReference ())
+            continue;
+         ref = pair.second.GetReference ();
+         if (QString::fromStdString (std::string (pair.first.GetString ()))
+             == image_name)
+            break;
+         }
+      }
+#else
    PdfPage *page = _doc->GetPage (pagenum);
    const PdfObject *obj = page->GetContents ();
 
-   dict = 0;
 //    qDebug () << "has stream" << _pathname << obj->HasStream ();
    PdfContentsTokenizer token (page); //stream->Get(), stream->GetLength());
    EPdfContentsType t;
@@ -578,9 +787,8 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
    char str [10], *s;
    const char *p;
    PdfVariant var;
-   bool ok, image_only = true;
+   bool ok;
    QList <PdfVariant> stack;
-   QString image_name;
 
 //    qDebug () << "decoding file" << _pathname;
    QString allowed = ",cm,q,Q,Do,";
@@ -615,7 +823,6 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
    if (!image_only)
       return 0;
    obj = page->GetResources ();
-   PdfReference ref;
    QString refstr;
 
    if (obj->IsDictionary ())
@@ -643,6 +850,7 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
             }
          }
       }
+#endif
 
 //    qDebug () << "ref" << ref.ToString ().c_str ();
    return get_xobject_image (ref, dict);
@@ -662,8 +870,12 @@ const PdfObject *Pdfio::get_thumbnail_obj (int pagenum, const PdfDictionary *&di
    {
    if (!_doc)
       return 0;
+#ifdef PODOFO_1X
+   const PdfObject *obj = &_doc->GetPages ().GetPageAt (pagenum).GetObject ();
+#else
    const PdfPage *page = _doc->GetPage (pagenum);
    const PdfObject *obj = page->GetObject ();
+#endif
    const PdfObject *thumb;
 
    thumb = obj->GetDictionary().GetKey ("Thumb");
@@ -684,11 +896,17 @@ const PdfObject *Pdfio::get_xobject_image (const PdfReference &ref, const PdfDic
       return 0;
    dict = &obj->GetDictionary();
 
-   const PdfObject* pObjType = dict->GetKey( PdfName::KeyType );
-   const PdfObject* pObjSubType = dict->GetKey( PdfName::KeySubtype );
+   const PdfObject* pObjType = dict->GetKey( "Type" );
+   const PdfObject* pObjSubType = dict->GetKey( "Subtype" );
+#ifdef PODOFO_1X
+   if( ( pObjType && pObjType->IsName() && ( pObjType->GetName().GetString() == "XObject" ) ) ||
+      ( pObjSubType && pObjSubType->IsName() && ( pObjSubType->GetName().GetString() == "Image" ) ) )
+      return obj;
+#else
    if( ( pObjType && pObjType->IsName() && ( pObjType->GetName().GetName() == "XObject" ) ) ||
       ( pObjSubType && pObjSubType->IsName() && ( pObjSubType->GetName().GetName() == "Image" ) ) )
       return obj;
+#endif
    return 0;
    }
 
@@ -697,7 +915,11 @@ err_info *Pdfio::appendFrom (Pdfio *from)
 {
    mytry
       {
+#ifdef PODOFO_1X
+      _doc->GetPages ().AppendDocumentPages (*from->_doc);
+#else
       _doc->Append (*from->_doc);
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)
@@ -714,7 +936,11 @@ err_info *Pdfio::appendPages (Pdfio *from)
 {
    mytry
       {
+#ifdef PODOFO_1X
+      _doc->GetPages ().AppendDocumentPages (*from->_doc);
+#else
       _doc->Append (*from->_doc);
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)
@@ -730,7 +956,11 @@ err_info *Pdfio::insertPages (Pdfio *from, int start, int count)
 {
    mytry
       {
+#ifdef PODOFO_1X
+      _doc->GetPages ().AppendDocumentPages (*from->_doc, start, count);
+#else
       _doc->InsertPages (*from->_doc, start, count);
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)
@@ -747,7 +977,12 @@ err_info *Pdfio::deletePages (int start, int count)
 {
    mytry
       {
+#ifdef PODOFO_1X
+      for (int i = 0; i < count; i++)
+         _doc->GetPages ().RemovePageAt (start);
+#else
       _doc->DeletePages (start, count);
+#endif
       }
 #ifdef EXCEPTIONS
    catch (const PdfError &eCode)

--- a/pdfio.h
+++ b/pdfio.h
@@ -207,6 +207,9 @@ protected:
       \returns the rotated image */
    QImage apply_rotation (int pagenum, const QImage &image) const;
 
+   /** returns the /Rotate value of a page, normalised to 0-359 */
+   int page_rotation (int pagenum) const;
+
    err_info *make_error (const PoDoFo::PdfError &eCode);
 
 private:

--- a/qi/qextensionwidget.cpp
+++ b/qi/qextensionwidget.cpp
@@ -508,7 +508,7 @@ void QExtensionWidget::initWidget()
   QLabel* templabel = new QLabel(tr("Temporary directory:"),opage);
   QHBoxLayout* temphb = new QHBoxLayout(opage);
   mpEditTempPath = new QLineEdit(temphb);
-  mpEditTempPath->setText(xmlConfig->stringValue("TEMP_PATH","/tmp"));
+  mpEditTempPath->setText(xmlConfig->stringValue("TEMP_PATH",QDir::tempPath()));
   mpButtonTempPath = new QToolButton(temphb);
   mpButtonTempPath->setPixmap(*pixmap);
   connect(mpButtonTempPath,SIGNAL(clicked()),this,
@@ -656,7 +656,7 @@ void QExtensionWidget::slotChangeDocPath()
 void QExtensionWidget::slotChangeTempPath()
 {
 #if 0 //s
-  QString old_temp = xmlConfig->stringValue("TEMP_PATH","/tmp");
+  QString old_temp = xmlConfig->stringValue("TEMP_PATH",QDir::tempPath());
   QFileDialogExt fd(old_temp,QString(),this,"",true);
   fd.setMode(Q3FileDialog::DirectoryOnly);
   fd.setWindowTitle(tr("Select a directory"));
@@ -710,7 +710,7 @@ void QExtensionWidget::accept()
   if(checkTempPath(mpEditTempPath->text()))
     xmlConfig->setStringValue("TEMP_PATH",mpEditTempPath->text());
   else
-    xmlConfig->setStringValue("TEMP_PATH","/tmp/");
+    xmlConfig->setStringValue("TEMP_PATH",QDir::tempPath() + "/");
   xmlConfig->setIntValue("VIEWER_UNDO_STEPS",mpUndoSpin->value());
   xmlConfig->setIntValue("FILTER_PREVIEW_SIZE",mpFilterSizeSpin->value());
   xmlConfig->setIntValue("DISPLAY_SUBSYSTEM",mpDisplaySubsystemCombo->currentIndex());

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -90,7 +90,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef Q_OS_WIN
 #include <sys/wait.h>
+#endif
 
 extern "C"
 {

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -37,7 +37,9 @@ extern "C"
 #include <sane/sane.h>
 }
 #include <sane/saneopts.h>
+#ifndef Q_OS_WIN
 #include <dlfcn.h>
+#endif
 #include <limits.h>
 #include <math.h>
 #include <unistd.h>
@@ -1224,7 +1226,9 @@ static sane_read_dup_fn lookup_read_dup (void)
    static bool tried = false;
    if (!tried)
       {
+#ifndef Q_OS_WIN
       fn = (sane_read_dup_fn) dlsym (RTLD_DEFAULT, "sane_read_dup");
+#endif
       tried = true;
       }
    return fn;

--- a/qscannersetupdlg.cpp
+++ b/qscannersetupdlg.cpp
@@ -622,9 +622,7 @@ void QScannerSetupDlg::initConfig()
   inst_dir = "/usr/local";
 #endif
   if(inst_dir.right(1) != "/") inst_dir += "/";
-  temp_dir = getenv("TEMP");
-  if(temp_dir.isEmpty())
-    temp_dir = "/tmp/";
+  temp_dir = QDir::tempPath() + "/";
 /*
   xmlConfig->setVersion(VERSION);
   xmlConfig->setFilePath(QDir::homePath()+
@@ -634,7 +632,7 @@ void QScannerSetupDlg::initConfig()
   xmlConfig->setStringValue("CURVE_SAVE_PATH", QDir::homePath());
   xmlConfig->setStringValue("CURVE_OPEN_PATH", QDir::homePath());
   //main settings
-  xmlConfig->setStringValue("TEMP_PATH","/tmp/");
+  xmlConfig->setStringValue("TEMP_PATH",QDir::tempPath() + "/");
   xmlConfig->setIntValue("SCAN_MODE",0);
   xmlConfig->setIntValue("METRIC_SYSTEM",int(QIN::Millimetre));
   xmlConfig->setBoolValue("IO_MODE",true);

--- a/scripts/make_test_files.py
+++ b/scripts/make_test_files.py
@@ -17,6 +17,8 @@ from reportlab.pdfgen import canvas
 # All generated files go here
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'test', 'files')
 PAPERMAN = os.path.join(os.path.dirname(__file__), '..', 'paperman')
+if os.name == 'nt':
+    PAPERMAN += '.exe'
 
 
 def _plasma_layer(rng, xgrid, ygrid, channels):

--- a/searchserver.cpp
+++ b/searchserver.cpp
@@ -57,6 +57,13 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QJsonArray>
 #endif
 
+/* The server keeps its page, thumbnail and conversion caches in the
+ * platform temporary directory */
+static QString cacheDirPath(const QString &name)
+{
+    return QDir::tempPath() + "/paperman-" + name;
+}
+
 static QString formatSize(qint64 bytes)
 {
     if (bytes < 1024)
@@ -2171,7 +2178,7 @@ QByteArray SearchServer::getFile(const QString &repoPath, const QString &filePat
             }
         } else {
             // For native PDFs, extract the page using Ghostscript
-            QString cacheDir = "/tmp/paperman-pages";
+            QString cacheDir = cacheDirPath("pages");
             QDir().mkpath(cacheDir);
 
             QString cacheKeyData = filePath + "_page"
@@ -2485,7 +2492,7 @@ QString SearchServer::generateThumbnail(const QString &repoPath, const QString &
                                        int page, const QString &size)
 {
     // 1. Create thumbnail cache directory
-    QString cacheDir = "/tmp/paperman-thumbnails";
+    QString cacheDir = cacheDirPath("thumbnails");
     QDir().mkpath(cacheDir);
     
     // 2. Build full file path
@@ -2581,7 +2588,7 @@ QString SearchServer::convertToPdf(const QString &fullPath,
         return QString();
 
     // Build cache key from path + mtime
-    QString cacheDir = "/tmp/paperman-converted";
+    QString cacheDir = cacheDirPath("converted");
     QDir().mkpath(cacheDir);
 
     QString cacheKeyData = fullPath + "_"
@@ -2804,7 +2811,7 @@ QString SearchServer::convertPageWithFile(const QString &fullPath, int page,
                                           const QFileInfo &fileInfo)
 {
     // Build cache key from path + page + mtime
-    QString cacheDir = "/tmp/paperman-pages";
+    QString cacheDir = cacheDirPath("pages");
     QDir().mkpath(cacheDir);
 
     QString cacheKeyData = fullPath + "_page" + QString::number(page)
@@ -3092,8 +3099,8 @@ void SearchServer::onExtractionFinished(int exitCode,
 void SearchServer::cleanThumbnailCache()
 {
     QStringList cacheDirs;
-    cacheDirs << "/tmp/paperman-thumbnails" << "/tmp/paperman-pages"
-              << "/tmp/paperman-converted";
+    cacheDirs << cacheDirPath("thumbnails") << cacheDirPath("pages")
+              << cacheDirPath("converted");
 
     foreach (const QString &cacheDir, cacheDirs) {
         QDir dir(cacheDir);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1,6 +1,7 @@
 #include <QPainter>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
+#include <QStandardPaths>
 
 #include <cstring>
 
@@ -994,7 +995,7 @@ void TestFile::testRemoveRestorePages()
 
 void TestFile::testJpegAnnotations()
 {
-   if (!QFile::exists("/usr/bin/exiftool"))
+   if (QStandardPaths::findExecutable("exiftool").isEmpty())
       QSKIP("exiftool is not installed");
 
    QTemporaryDir tmp;

--- a/test/test_ops.cpp
+++ b/test/test_ops.cpp
@@ -1,6 +1,7 @@
 #include <QDate>
 #include <QPrinter>
 #include <QtTest/QtTest>
+#include <QDir>
 
 #include "../utils.h"
 #include "test.h"
@@ -615,7 +616,7 @@ void TestOps::testPrintToPdf()
 
    /* run the part of print() which follows the print dialogue, with
       the printer directed at a PDF file */
-   QString out = QString("%1/print_test.pdf").arg(P_tmpdir);
+   QString out = QDir::tempPath() + "/print_test.pdf";
    QFile::remove(out);
 
    Mainwidget *main = Mainwidget::singleton();
@@ -638,7 +639,7 @@ void TestOps::testPrintToPdf()
    // The PDF should exist and contain every page of both stacks
    QVERIFY(QFile::exists(out));
 
-   File *printed = File::createFile(QString(P_tmpdir) + "/",
+   File *printed = File::createFile(QDir::tempPath() + "/",
                                     QString("print_test.pdf"), nullptr,
                                     File::Type_pdf);
    QVERIFY(printed);

--- a/test/test_searchserver.cpp
+++ b/test/test_searchserver.cpp
@@ -2190,8 +2190,10 @@ void TestSearchServer::testRemoteOcr()
 {
     /* OCR of a remote stack runs on the server, which stores the text
        in the stack's ocr annotation and returns it. */
-    if (!QFile::exists("/usr/bin/tesseract"))
+    if (QStandardPaths::findExecutable("tesseract").isEmpty())
         QSKIP("tesseract is not installed");
+    if (QStandardPaths::findExecutable("exiftool").isEmpty())
+        QSKIP("exiftool is not installed");
 
     QTemporaryDir tmpDir;
     QVERIFY(tmpDir.isValid());

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -2,8 +2,10 @@
 
 #include "../config.h"
 
+#ifndef Q_OS_WIN
 #include <pwd.h>
 #include <unistd.h>
+#endif
 
 #include "../filemax.h"
 #include "../imageadjust.h"
@@ -463,9 +465,13 @@ void TestUtils::testUserName()
       (tests, cron, IDE launches). If it silently comes back empty the
       per-user .papertree cache filename loses its suffix and a stale,
       shared cache file is read instead */
+#ifdef Q_OS_WIN
+   QCOMPARE(utilUserName(), QString::fromLocal8Bit(qgetenv("USERNAME")));
+#else
    struct passwd *pw = getpwuid(getuid());
    QVERIFY(pw != nullptr);
    QCOMPARE(utilUserName(), QString(pw->pw_name));
+#endif
 }
 
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -66,6 +66,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QDir>
 #include <QTemporaryFile>
+#include <QThread>
 
 #include "epeglite.h"
 
@@ -1218,6 +1219,39 @@ QString utilUserName()
 }
 
 static bool test_mode;
+
+// how long to keep retrying a rename in total, in 50ms steps
+static const int RENAME_RETRIES = 20;
+
+bool utilRenameFile(const QString &from, const QString &to, QString *error)
+{
+   QFile file(from);
+
+   for (int i = 0; i < RENAME_RETRIES; i++) {
+      if (file.rename(to))
+         return true;
+      if (i == RENAME_RETRIES - 1 || !file.exists() || QFile::exists(to))
+         break;
+      QThread::msleep(50);
+   }
+   if (error)
+      *error = file.errorString();
+   return false;
+}
+
+bool utilReplaceFile(const QString &from, const QString &to, QString *error)
+{
+   QFile old(to);
+
+   for (int i = 0; i < RENAME_RETRIES; i++) {
+      if (!old.exists() || old.remove())
+         return utilRenameFile(from, to, error);
+      QThread::msleep(50);
+   }
+   if (error)
+      *error = QString("cannot remove %1: %2").arg(to, old.errorString());
+   return false;
+}
 
 void utilSetTestMode(bool testing)
 {

--- a/utils.cpp
+++ b/utils.cpp
@@ -1217,6 +1217,18 @@ QString utilUserName()
 #endif
 }
 
+static bool test_mode;
+
+void utilSetTestMode(bool testing)
+{
+   test_mode = testing;
+}
+
+bool utilTestMode()
+{
+   return test_mode;
+}
+
 void utilInit(const QString& group)
 {
 #ifdef Q_OS_WIN

--- a/utils.cpp
+++ b/utils.cpp
@@ -23,7 +23,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <cerrno>
 #include <cstring>
+#ifndef _WIN32
 #include <grp.h>
+#endif
 
 #include <QDate>
 #include <QDebug>
@@ -52,9 +54,15 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <sys/types.h>
 
 #include <limits.h>
-#include <pwd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <windows.h>
+#include <lmcons.h>
+#else
+#include <pwd.h>
+#endif
 
 #include "epeglite.h"
 
@@ -68,7 +76,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "utils.h"
 #include "zip.h"
 
+#ifndef Q_OS_WIN
 static int public_gid = -1;
+#endif
 
 bool getSettingsSizes (QString base, QList<int> &size)
    {
@@ -277,7 +287,7 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
          if (cinfo.output_components == 3 && bpp == 32)
             {
             byte *in;
-            u_int32_t *out;
+            uint32_t *out;
             int i;
 
             mem_check ();
@@ -285,7 +295,7 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
             i = cinfo.output_width;
             if (max_width != -1 && i > max_width)
                 i = max_width;
-            for (out = (u_int32_t *)dest; i != 0;
+            for (out = (uint32_t *)dest; i != 0;
                  i--, in += 3)
                *out++ = in [2] | (in [1] << 8) | (in [0] << 16);
             mem_check ();
@@ -416,7 +426,7 @@ void jpeg_encode (byte *image, cpoint *tile_size, byte *outbuff, int *size,
        if (bpp == 32)
           {
           int i;
-          u_int32_t *in;
+          uint32_t *in;
           byte *out;
 
           for (i = valid, in = (unsigned *)ptr, out = buff; i != 0;
@@ -472,7 +482,7 @@ void memtest (const char *name)
    int *test = new int [5];
 
    fprintf (stderr, "test %s: %p\n", name, test);
-   Q_ASSERT ((unsigned long)test < 0xb0000000);
+   Q_ASSERT ((uintptr_t)test < 0xb0000000);
    }
 
 
@@ -655,26 +665,15 @@ void util_incrementFilename (QString &name, bool useNum)
 err_info *util_getUsername (QString &userName)
    {
    userName = "whoami";
-#if defined(Q_WS_WIN)
-   // in Windows land...
-#if defined(UNICODE)
-   if ( qWinVersion() & Qt::WV_NT_based )
-      {
-      TCHAR winUserName[UNLEN + 1]; // UNLEN is defined in LMCONS.H
-      DWORD winUserNameSize = sizeof(winUserName);
-      GetUserName( winUserName, &winUserNameSize );
-      userName = qt_winQString( winUserName );
-      } 
-   else
-#endif
-      {
-      char winUserName[UNLEN + 1]; // UNLEN is defined in LMCONS.H
-      DWORD winUserNameSize = sizeof(winUserName);
-      GetUserNameA( winUserName, &winUserNameSize );
-      userName = QString::fromLocal8Bit( winUserName );
-      }
+#ifdef Q_OS_WIN
+   char winUserName[UNLEN + 1];
+   DWORD winUserNameSize = sizeof(winUserName);
+
+   if (!GetUserNameA (winUserName, &winUserNameSize))
+      return err_make (ERRFN, ERR_failed_to_read_username1,
+                       "GetUserName() failed");
+   userName = QString::fromLocal8Bit (winUserName);
 #else
-   // in the real world
    char name [200];
    struct passwd pwd, *user;
 
@@ -1142,6 +1141,10 @@ TreeItem *utilReadTree(QString fname, QString rootName)
 
 bool utilSetDirGroup(const QString& dirname)
 {
+#ifdef Q_OS_WIN
+    Q_UNUSED(dirname);
+    return true;
+#else
     if (public_gid == -1)
         return true;
     if (chmod(qPrintable(dirname), 0777) == -1) {
@@ -1157,10 +1160,15 @@ bool utilSetDirGroup(const QString& dirname)
         return false;
     }
     return true;
+#endif
 }
 
 bool utilSetGroup(const QString& fname)
 {
+#ifdef Q_OS_WIN
+    Q_UNUSED(fname);
+    return true;
+#else
     if (public_gid == -1)
         return true;
     if (chmod(qPrintable(fname), 0666) == -1) {
@@ -1176,10 +1184,18 @@ bool utilSetGroup(const QString& fname)
         return false;
     }
     return true;
+#endif
 }
 
 QString utilUserName()
 {
+#ifdef Q_OS_WIN
+   QString name;
+
+   if (!util_getUsername (name))
+      return name;
+   return "";
+#else
    char username[80];
 
    /* identify the user by uid: getlogin_r() needs a controlling
@@ -1195,10 +1211,16 @@ QString utilUserName()
       return username;
 
    return "";
+#endif
 }
 
 void utilInit(const QString& group)
 {
+#ifdef Q_OS_WIN
+   // there are no Unix groups to share scratch directories with
+   if (!group.isEmpty())
+      qDebug() << "Ignoring group" << group << "on Windows";
+#else
    struct group *grp;
 
    if (!group.isEmpty()) {
@@ -1209,6 +1231,7 @@ void utilInit(const QString& group)
       }
       public_gid = grp->gr_gid;
    }
+#endif
 }
 
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -64,6 +64,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <pwd.h>
 #endif
 
+#include <QDir>
+#include <QTemporaryFile>
+
 #include "epeglite.h"
 
 
@@ -528,14 +531,14 @@ QImage util_smooth_scale_image (QImage &image, QSize size)
 
 err_info *util_get_tmp (char *tmp)
    {
-   int fd;
+   QTemporaryFile file (QDir::tempPath () + "/maxviewXXXXXX");
 
-   sprintf (tmp, "%s/maxviewXXXXXX", P_tmpdir);
-   fd = mkstemp (tmp);
-   if (fd < 0)
+   if (!file.open ())
       return err_make (ERRFN, ERR_could_not_make_temporary_file);
-   close (fd);
-   unlink (tmp);
+   QByteArray name = QFile::encodeName (file.fileName ());
+   if (name.size () >= PATH_MAX)
+      return err_make (ERRFN, ERR_could_not_make_temporary_file);
+   strcpy (tmp, name.constData ());
    return NULL;
    }
 
@@ -559,7 +562,7 @@ err_info *util_buildZip (QString &zip, const QStringList &fnamelist)
    Zip::ErrorCode ec;
    Zip uz;
 
-   zip = util_getUnique (zip, P_tmpdir, ".zip");
+   zip = util_getUnique (zip, QDir::tempPath (), ".zip");
 //    zip = util_findNextFilename (zip, P_tmpdir, ".zip");
 //    zip = QString ("%1/%2.zip").arg (P_tmpdir).arg (zip);
    ec = uz.createArchive (zip);

--- a/utils.h
+++ b/utils.h
@@ -337,6 +337,12 @@ bool utilSetDirGroup(const QString& dirname);
  */
 QString utilUserName();
 
+/** record that the program is running its test suite: error reports go
+    to the console instead of a modal dialog, which would hang a headless
+    test run */
+void utilSetTestMode(bool testing);
+bool utilTestMode();
+
 /**
  * @brief Set up the utils file
  * @param group  Name of the public group to use for utilSetGroup()

--- a/utils.h
+++ b/utils.h
@@ -343,6 +343,27 @@ QString utilUserName();
 void utilSetTestMode(bool testing);
 bool utilTestMode();
 
+/** rename a file, retrying briefly if it fails
+
+    On Windows a file which has just been written is often still held
+    open for a moment by the search indexer or virus scanner, so a rename
+    can fail transiently; Windows also refuses to rename a file another
+    process has open
+
+    \param from   existing path
+    \param to     new path, which must not exist
+    \param error  returns the error string on failure
+    \returns true on success */
+bool utilRenameFile(const QString &from, const QString &to, QString *error);
+
+/** replace a file with another, retrying briefly as for utilRenameFile()
+
+    \param from   existing path
+    \param to     path to replace; any existing file is removed first
+    \param error  returns the error string on failure
+    \returns true on success */
+bool utilReplaceFile(const QString &from, const QString &to, QString *error);
+
 /**
  * @brief Set up the utils file
  * @param group  Name of the public group to use for utilSetGroup()

--- a/win32/sane/sane.h
+++ b/win32/sane/sane.h
@@ -1,0 +1,248 @@
+/* sane - Scanner Access Now Easy.
+   Copyright (C) 1997-1999 David Mosberger-Tang and Andreas Beck
+   This file is part of the SANE package.
+
+   This file is in the public domain.  You may use and modify it as
+   you see fit, as long as this copyright message is included and
+   that there is an indication as to what modifications have been
+   made (if any).
+
+   SANE is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   This file declares SANE application interface.  See the SANE
+   standard for a detailed explanation of the interface.  */
+#ifndef sane_h
+#define sane_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * SANE types and defines
+ */
+
+#define SANE_CURRENT_MAJOR	1
+#define SANE_CURRENT_MINOR	0
+
+#define SANE_VERSION_CODE(major, minor, build)	\
+  (  (((SANE_Word) (major) &   0xff) << 24)	\
+   | (((SANE_Word) (minor) &   0xff) << 16)	\
+   | (((SANE_Word) (build) & 0xffff) <<  0))
+
+#define SANE_VERSION_MAJOR(code)	((((SANE_Word)(code)) >> 24) &   0xff)
+#define SANE_VERSION_MINOR(code)	((((SANE_Word)(code)) >> 16) &   0xff)
+#define SANE_VERSION_BUILD(code)	((((SANE_Word)(code)) >>  0) & 0xffff)
+
+#define SANE_FALSE	0
+#define SANE_TRUE	1
+
+typedef unsigned char  SANE_Byte;
+typedef int  SANE_Word;
+typedef SANE_Word  SANE_Bool;
+typedef SANE_Word  SANE_Int;
+typedef char SANE_Char;
+typedef SANE_Char *SANE_String;
+typedef const SANE_Char *SANE_String_Const;
+typedef void *SANE_Handle;
+typedef SANE_Word SANE_Fixed;
+
+#define SANE_FIXED_SCALE_SHIFT	16
+#define SANE_FIX(v)	((SANE_Word) ((v) * (1 << SANE_FIXED_SCALE_SHIFT)))
+#define SANE_UNFIX(v)	((double)(v) / (1 << SANE_FIXED_SCALE_SHIFT))
+
+typedef enum
+  {
+    SANE_STATUS_GOOD = 0,	/* everything A-OK */
+    SANE_STATUS_UNSUPPORTED,	/* operation is not supported */
+    SANE_STATUS_CANCELLED,	/* operation was cancelled */
+    SANE_STATUS_DEVICE_BUSY,	/* device is busy; try again later */
+    SANE_STATUS_INVAL,		/* data is invalid (includes no dev at open) */
+    SANE_STATUS_EOF,		/* no more data available (end-of-file) */
+    SANE_STATUS_JAMMED,		/* document feeder jammed */
+    SANE_STATUS_NO_DOCS,	/* document feeder out of documents */
+    SANE_STATUS_COVER_OPEN,	/* scanner cover is open */
+    SANE_STATUS_IO_ERROR,	/* error during device I/O */
+    SANE_STATUS_NO_MEM,		/* out of memory */
+    SANE_STATUS_ACCESS_DENIED	/* access to resource has been denied */
+  }
+SANE_Status;
+
+/* following are for later sane version, older frontends won't support */
+#if 0
+#define SANE_STATUS_WARMING_UP 12 /* lamp not ready, please retry */
+#define SANE_STATUS_HW_LOCKED  13 /* scanner mechanism locked for transport */
+#endif
+
+typedef enum
+  {
+    SANE_TYPE_BOOL = 0,
+    SANE_TYPE_INT,
+    SANE_TYPE_FIXED,
+    SANE_TYPE_STRING,
+    SANE_TYPE_BUTTON,
+    SANE_TYPE_GROUP
+  }
+SANE_Value_Type;
+
+typedef enum
+  {
+    SANE_UNIT_NONE = 0,		/* the value is unit-less (e.g., # of scans) */
+    SANE_UNIT_PIXEL,		/* value is number of pixels */
+    SANE_UNIT_BIT,		/* value is number of bits */
+    SANE_UNIT_MM,		/* value is millimeters */
+    SANE_UNIT_DPI,		/* value is resolution in dots/inch */
+    SANE_UNIT_PERCENT,		/* value is a percentage */
+    SANE_UNIT_MICROSECOND	/* value is micro seconds */
+  }
+SANE_Unit;
+
+typedef struct
+  {
+    SANE_String_Const name;	/* unique device name */
+    SANE_String_Const vendor;	/* device vendor string */
+    SANE_String_Const model;	/* device model name */
+    SANE_String_Const type;	/* device type (e.g., "flatbed scanner") */
+  }
+SANE_Device;
+
+#define SANE_CAP_SOFT_SELECT		(1 << 0)
+#define SANE_CAP_HARD_SELECT		(1 << 1)
+#define SANE_CAP_SOFT_DETECT		(1 << 2)
+#define SANE_CAP_EMULATED		(1 << 3)
+#define SANE_CAP_AUTOMATIC		(1 << 4)
+#define SANE_CAP_INACTIVE		(1 << 5)
+#define SANE_CAP_ADVANCED		(1 << 6)
+
+#define SANE_OPTION_IS_ACTIVE(cap)	(((cap) & SANE_CAP_INACTIVE) == 0)
+#define SANE_OPTION_IS_SETTABLE(cap)	(((cap) & SANE_CAP_SOFT_SELECT) != 0)
+
+#define SANE_INFO_INEXACT		(1 << 0)
+#define SANE_INFO_RELOAD_OPTIONS	(1 << 1)
+#define SANE_INFO_RELOAD_PARAMS		(1 << 2)
+
+typedef enum
+  {
+    SANE_CONSTRAINT_NONE = 0,
+    SANE_CONSTRAINT_RANGE,
+    SANE_CONSTRAINT_WORD_LIST,
+    SANE_CONSTRAINT_STRING_LIST
+  }
+SANE_Constraint_Type;
+
+typedef struct
+  {
+    SANE_Word min;		/* minimum (element) value */
+    SANE_Word max;		/* maximum (element) value */
+    SANE_Word quant;		/* quantization value (0 if none) */
+  }
+SANE_Range;
+
+typedef struct
+  {
+    SANE_String_Const name;	/* name of this option (command-line name) */
+    SANE_String_Const title;	/* title of this option (single-line) */
+    SANE_String_Const desc;	/* description of this option (multi-line) */
+    SANE_Value_Type type;	/* how are values interpreted? */
+    SANE_Unit unit;		/* what is the (physical) unit? */
+    SANE_Int size;
+    SANE_Int cap;		/* capabilities */
+
+    SANE_Constraint_Type constraint_type;
+    union
+      {
+	const SANE_String_Const *string_list;	/* NULL-terminated list */
+	const SANE_Word *word_list;	/* first element is list-length */
+	const SANE_Range *range;
+      }
+    constraint;
+  }
+SANE_Option_Descriptor;
+
+typedef enum
+  {
+    SANE_ACTION_GET_VALUE = 0,
+    SANE_ACTION_SET_VALUE,
+    SANE_ACTION_SET_AUTO
+  }
+SANE_Action;
+
+typedef enum
+  {
+    SANE_FRAME_GRAY,	/* band covering human visual range */
+    SANE_FRAME_RGB,	/* pixel-interleaved red/green/blue bands */
+    SANE_FRAME_RED,	/* red band only */
+    SANE_FRAME_GREEN,	/* green band only */
+    SANE_FRAME_BLUE 	/* blue band only */
+  }
+SANE_Frame;
+
+/* push remaining types down to match existing backends */
+/* these are to be exposed in a later version of SANE */
+/* most front-ends will require updates to understand them */
+#if 0
+#define SANE_FRAME_TEXT  0x0A  /* backend specific textual data */
+#define SANE_FRAME_JPEG  0x0B  /* complete baseline JPEG file */
+#define SANE_FRAME_G31D  0x0C  /* CCITT Group 3 1-D Compressed (MH) */
+#define SANE_FRAME_G32D  0x0D  /* CCITT Group 3 2-D Compressed (MR) */
+#define SANE_FRAME_G42D  0x0E  /* CCITT Group 4 2-D Compressed (MMR) */
+
+#define SANE_FRAME_IR    0x0F  /* bare infrared channel */
+#define SANE_FRAME_RGBI  0x10  /* red+green+blue+infrared */
+#define SANE_FRAME_GRAYI 0x11  /* gray+infrared */
+#define SANE_FRAME_XML   0x12  /* undefined schema */
+#endif
+
+typedef struct
+  {
+    SANE_Frame format;
+    SANE_Bool last_frame;
+    SANE_Int bytes_per_line;
+    SANE_Int pixels_per_line;
+    SANE_Int lines;
+    SANE_Int depth;
+  }
+SANE_Parameters;
+
+struct SANE_Auth_Data;
+
+#define SANE_MAX_USERNAME_LEN	128
+#define SANE_MAX_PASSWORD_LEN	128
+
+typedef void (*SANE_Auth_Callback) (SANE_String_Const resource,
+				    SANE_Char *username,
+				    SANE_Char *password);
+
+extern SANE_Status sane_init (SANE_Int * version_code,
+			      SANE_Auth_Callback authorize);
+extern void sane_exit (void);
+extern SANE_Status sane_get_devices (const SANE_Device *** device_list,
+				     SANE_Bool local_only);
+extern SANE_Status sane_open (SANE_String_Const devicename,
+			      SANE_Handle * handle);
+extern void sane_close (SANE_Handle handle);
+extern const SANE_Option_Descriptor *
+  sane_get_option_descriptor (SANE_Handle handle, SANE_Int option);
+extern SANE_Status sane_control_option (SANE_Handle handle, SANE_Int option,
+					SANE_Action action, void *value,
+					SANE_Int * info);
+extern SANE_Status sane_get_parameters (SANE_Handle handle,
+					SANE_Parameters * params);
+extern SANE_Status sane_start (SANE_Handle handle);
+extern SANE_Status sane_read (SANE_Handle handle, SANE_Byte * data,
+			      SANE_Int max_length, SANE_Int * length);
+extern void sane_cancel (SANE_Handle handle);
+extern SANE_Status sane_set_io_mode (SANE_Handle handle,
+				     SANE_Bool non_blocking);
+extern SANE_Status sane_get_select_fd (SANE_Handle handle,
+				       SANE_Int * fd);
+extern SANE_String_Const sane_strstatus (SANE_Status status);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* sane_h */

--- a/win32/sane/saneopts.h
+++ b/win32/sane/saneopts.h
@@ -1,0 +1,469 @@
+/* sane - Scanner Access Now Easy.
+   Copyright (C) 1996, 1997 David Mosberger-Tang and Andreas Beck
+   This file is part of the SANE package.
+
+   SANE is free software; you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your
+   option) any later version.
+
+   SANE is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with sane; see the file COPYING.
+   If not, see <https://www.gnu.org/licenses/>.
+
+   As a special exception, the authors of SANE give permission for
+   additional uses of the libraries contained in this release of SANE.
+
+   The exception is that, if you link a SANE library with other files
+   to produce an executable, this does not by itself cause the
+   resulting executable to be covered by the GNU General Public
+   License.  Your use of that executable is in no way restricted on
+   account of linking the SANE library code into it.
+
+   This exception does not, however, invalidate any other reasons why
+   the executable file might be covered by the GNU General Public
+   License.
+
+   If you submit changes to SANE to the maintainers to be included in
+   a subsequent release, you agree by submitting the changes that
+   those changes may be distributed with this exception intact.
+
+   If you write modifications of your own for SANE, it is your choice
+   whether to permit this exception to apply to your modifications.
+   If you do not wish that, delete this exception notice.
+
+   This file declares common option names, titles, and descriptions.  A
+   backend is not limited to these options but for the sake of
+   consistency it's better to use options declared here when appropriate.
+*/
+
+/* This file defines several option NAMEs, TITLEs and DESCs
+   that are (or should be) used by several backends.
+
+   All well known options should be listed here. But this does
+   not mean that all options that are listed here are well known options.
+   To find out if an option is a well known option and how well known
+   options have to be defined please take a look at the sane standard!!!
+ */
+#ifndef saneopts_h
+#define saneopts_h
+
+#ifndef SANE_I18N
+#define SANE_I18N(text) text
+#endif
+
+/* This _must_ be the first option (index 0): */
+#define SANE_NAME_NUM_OPTIONS		""	/* never settable */
+
+/* The common option groups */
+#define SANE_NAME_STANDARD   		"standard"
+#define SANE_NAME_GEOMETRY   		"geometry"
+#define SANE_NAME_ENHANCEMENT		"enhancement"
+#define SANE_NAME_ADVANCED   		"advanced"
+#define SANE_NAME_SENSORS    		"sensors"
+
+#define SANE_NAME_PREVIEW		"preview"
+#define SANE_NAME_GRAY_PREVIEW		"preview-in-gray"
+#define SANE_NAME_BIT_DEPTH		"depth"
+#define SANE_NAME_SCAN_MODE		"mode"
+#define SANE_NAME_SCAN_SPEED		"speed"
+#define SANE_NAME_SCAN_SOURCE		"source"
+#define SANE_NAME_BACKTRACK		"backtrack"
+/* Most user-interfaces will let the user specify the scan area as the
+   top-left corner and the width/height of the scan area.  The reason
+   the backend interface uses the top-left/bottom-right corner is so
+   that the scan area values can be properly constraint independent of
+   any other option value.  */
+#define SANE_NAME_SCAN_TL_X		"tl-x"
+#define SANE_NAME_SCAN_TL_Y		"tl-y"
+#define SANE_NAME_SCAN_BR_X		"br-x"
+#define SANE_NAME_SCAN_BR_Y		"br-y"
+#define SANE_NAME_SCAN_RESOLUTION	"resolution"
+#define SANE_NAME_SCAN_X_RESOLUTION	"x-resolution"
+#define SANE_NAME_SCAN_Y_RESOLUTION	"y-resolution"
+#define SANE_NAME_PAGE_WIDTH  		"page-width"
+#define SANE_NAME_PAGE_HEIGHT 		"page-height"
+#define SANE_NAME_CUSTOM_GAMMA		"custom-gamma"
+#define SANE_NAME_GAMMA_VECTOR		"gamma-table"
+#define SANE_NAME_GAMMA_VECTOR_R	"red-gamma-table"
+#define SANE_NAME_GAMMA_VECTOR_G	"green-gamma-table"
+#define SANE_NAME_GAMMA_VECTOR_B	"blue-gamma-table"
+#define SANE_NAME_BRIGHTNESS		"brightness"
+#define SANE_NAME_CONTRAST		"contrast"
+#define SANE_NAME_GRAIN_SIZE		"grain"
+#define SANE_NAME_HALFTONE		"halftoning"
+#define SANE_NAME_BLACK_LEVEL           "black-level"
+#define SANE_NAME_WHITE_LEVEL           "white-level"
+#define SANE_NAME_WHITE_LEVEL_R         "white-level-r"
+#define SANE_NAME_WHITE_LEVEL_G         "white-level-g"
+#define SANE_NAME_WHITE_LEVEL_B         "white-level-b"
+#define SANE_NAME_SHADOW		"shadow"
+#define SANE_NAME_SHADOW_R		"shadow-r"
+#define SANE_NAME_SHADOW_G		"shadow-g"
+#define SANE_NAME_SHADOW_B		"shadow-b"
+#define SANE_NAME_HIGHLIGHT		"highlight"
+#define SANE_NAME_HIGHLIGHT_R		"highlight-r"
+#define SANE_NAME_HIGHLIGHT_G		"highlight-g"
+#define SANE_NAME_HIGHLIGHT_B		"highlight-b"
+#define SANE_NAME_HUE			"hue"
+#define SANE_NAME_SATURATION		"saturation"
+#define SANE_NAME_FILE			"filename"
+#define SANE_NAME_HALFTONE_DIMENSION	"halftone-size"
+#define SANE_NAME_HALFTONE_PATTERN	"halftone-pattern"
+#define SANE_NAME_RESOLUTION_BIND	"resolution-bind"
+#define SANE_NAME_NEGATIVE		"negative"
+#define SANE_NAME_QUALITY_CAL		"quality-cal"
+#define SANE_NAME_DOR			"double-res"
+#define SANE_NAME_RGB_BIND		"rgb-bind"
+#define SANE_NAME_THRESHOLD		"threshold"
+#define SANE_NAME_ANALOG_GAMMA		"analog-gamma"
+#define SANE_NAME_ANALOG_GAMMA_R	"analog-gamma-r"
+#define SANE_NAME_ANALOG_GAMMA_G	"analog-gamma-g"
+#define SANE_NAME_ANALOG_GAMMA_B	"analog-gamma-b"
+#define SANE_NAME_ANALOG_GAMMA_BIND	"analog-gamma-bind"
+#define SANE_NAME_WARMUP		"warmup"
+#define SANE_NAME_CAL_EXPOS_TIME	"cal-exposure-time"
+#define SANE_NAME_CAL_EXPOS_TIME_R	"cal-exposure-time-r"
+#define SANE_NAME_CAL_EXPOS_TIME_G	"cal-exposure-time-g"
+#define SANE_NAME_CAL_EXPOS_TIME_B	"cal-exposure-time-b"
+#define SANE_NAME_SCAN_EXPOS_TIME	"scan-exposure-time"
+#define SANE_NAME_SCAN_EXPOS_TIME_R	"scan-exposure-time-r"
+#define SANE_NAME_SCAN_EXPOS_TIME_G	"scan-exposure-time-g"
+#define SANE_NAME_SCAN_EXPOS_TIME_B	"scan-exposure-time-b"
+#define SANE_NAME_SELECT_EXPOSURE_TIME	"select-exposure-time"
+#define SANE_NAME_CAL_LAMP_DEN		"cal-lamp-density"
+#define SANE_NAME_SCAN_LAMP_DEN		"scan-lamp-density"
+#define SANE_NAME_SELECT_LAMP_DENSITY	"select-lamp-density"
+#define SANE_NAME_LAMP_OFF_AT_EXIT	"lamp-off-at-exit"
+#define SANE_NAME_FOCUS			"focus"
+#define SANE_NAME_AUTOFOCUS		"autofocus"
+
+/* well known options from 'SENSORS' group*/
+#define SANE_NAME_SCAN			"scan"
+#define SANE_NAME_EMAIL			"email"
+#define SANE_NAME_FAX			"fax"
+#define SANE_NAME_COPY			"copy"
+#define SANE_NAME_PDF			"pdf"
+#define SANE_NAME_CANCEL		"cancel"
+#define SANE_NAME_PAGE_LOADED		"page-loaded"
+#define SANE_NAME_COVER_OPEN		"cover-open"
+
+#define SANE_TITLE_NUM_OPTIONS		SANE_I18N("Number of options")
+
+#define SANE_TITLE_STANDARD   		SANE_I18N("Standard")
+#define SANE_TITLE_GEOMETRY   		SANE_I18N("Geometry")
+#define SANE_TITLE_ENHANCEMENT		SANE_I18N("Enhancement")
+#define SANE_TITLE_ADVANCED   		SANE_I18N("Advanced")
+#define SANE_TITLE_SENSORS    		SANE_I18N("Sensors")
+
+#define SANE_TITLE_PREVIEW		SANE_I18N("Preview")
+#define SANE_TITLE_GRAY_PREVIEW		SANE_I18N("Force monochrome preview")
+#define SANE_TITLE_BIT_DEPTH		SANE_I18N("Bit depth")
+#define SANE_TITLE_SCAN_MODE		SANE_I18N("Scan mode")
+#define SANE_TITLE_SCAN_SPEED		SANE_I18N("Scan speed")
+#define SANE_TITLE_SCAN_SOURCE		SANE_I18N("Scan source")
+#define SANE_TITLE_BACKTRACK		SANE_I18N("Force backtracking")
+#define SANE_TITLE_SCAN_TL_X		SANE_I18N("Top-left x")
+#define SANE_TITLE_SCAN_TL_Y		SANE_I18N("Top-left y")
+#define SANE_TITLE_SCAN_BR_X		SANE_I18N("Bottom-right x")
+#define SANE_TITLE_SCAN_BR_Y		SANE_I18N("Bottom-right y")
+#define SANE_TITLE_SCAN_RESOLUTION	SANE_I18N("Scan resolution")
+#define SANE_TITLE_SCAN_X_RESOLUTION	SANE_I18N("X-resolution")
+#define SANE_TITLE_SCAN_Y_RESOLUTION	SANE_I18N("Y-resolution")
+#define SANE_TITLE_PAGE_WIDTH  		SANE_I18N("Page width")
+#define SANE_TITLE_PAGE_HEIGHT 		SANE_I18N("Page height")
+#define SANE_TITLE_CUSTOM_GAMMA		SANE_I18N("Use custom gamma table")
+#define SANE_TITLE_GAMMA_VECTOR		SANE_I18N("Image intensity")
+#define SANE_TITLE_GAMMA_VECTOR_R	SANE_I18N("Red intensity")
+#define SANE_TITLE_GAMMA_VECTOR_G	SANE_I18N("Green intensity")
+#define SANE_TITLE_GAMMA_VECTOR_B	SANE_I18N("Blue intensity")
+#define SANE_TITLE_BRIGHTNESS		SANE_I18N("Brightness")
+#define SANE_TITLE_CONTRAST		SANE_I18N("Contrast")
+#define SANE_TITLE_GRAIN_SIZE		SANE_I18N("Grain size")
+#define SANE_TITLE_HALFTONE		SANE_I18N("Halftoning")
+#define SANE_TITLE_BLACK_LEVEL          SANE_I18N("Black level")
+#define SANE_TITLE_WHITE_LEVEL          SANE_I18N("White level")
+#define SANE_TITLE_WHITE_LEVEL_R        SANE_I18N("White level for red")
+#define SANE_TITLE_WHITE_LEVEL_G        SANE_I18N("White level for green")
+#define SANE_TITLE_WHITE_LEVEL_B        SANE_I18N("White level for blue")
+#define SANE_TITLE_SHADOW		SANE_I18N("Shadow")
+#define SANE_TITLE_SHADOW_R		SANE_I18N("Shadow for red")
+#define SANE_TITLE_SHADOW_G		SANE_I18N("Shadow for green")
+#define SANE_TITLE_SHADOW_B		SANE_I18N("Shadow for blue")
+#define SANE_TITLE_HIGHLIGHT		SANE_I18N("Highlight")
+#define SANE_TITLE_HIGHLIGHT_R		SANE_I18N("Highlight for red")
+#define SANE_TITLE_HIGHLIGHT_G		SANE_I18N("Highlight for green")
+#define SANE_TITLE_HIGHLIGHT_B		SANE_I18N("Highlight for blue")
+#define SANE_TITLE_HUE			SANE_I18N("Hue")
+#define SANE_TITLE_SATURATION		SANE_I18N("Saturation")
+#define SANE_TITLE_FILE			SANE_I18N("Filename")
+#define SANE_TITLE_HALFTONE_DIMENSION	SANE_I18N("Halftone pattern size")
+#define SANE_TITLE_HALFTONE_PATTERN	SANE_I18N("Halftone pattern")
+#define SANE_TITLE_RESOLUTION_BIND	SANE_I18N("Bind X and Y resolution")
+#define SANE_TITLE_NEGATIVE		SANE_I18N("Negative")
+#define SANE_TITLE_QUALITY_CAL		SANE_I18N("Quality calibration")
+#define SANE_TITLE_DOR			SANE_I18N("Double Optical Resolution")
+#define SANE_TITLE_RGB_BIND		SANE_I18N("Bind RGB")
+#define SANE_TITLE_THRESHOLD		SANE_I18N("Threshold")
+#define SANE_TITLE_ANALOG_GAMMA		SANE_I18N("Analog gamma correction")
+#define SANE_TITLE_ANALOG_GAMMA_R	SANE_I18N("Analog gamma red")
+#define SANE_TITLE_ANALOG_GAMMA_G	SANE_I18N("Analog gamma green")
+#define SANE_TITLE_ANALOG_GAMMA_B	SANE_I18N("Analog gamma blue")
+#define SANE_TITLE_ANALOG_GAMMA_BIND    SANE_I18N("Bind analog gamma")
+#define SANE_TITLE_WARMUP		SANE_I18N("Warmup lamp")
+#define SANE_TITLE_CAL_EXPOS_TIME	SANE_I18N("Cal. exposure-time")
+#define SANE_TITLE_CAL_EXPOS_TIME_R	SANE_I18N("Cal. exposure-time for red")
+#define SANE_TITLE_CAL_EXPOS_TIME_G	SANE_I18N("Cal. exposure-time for " \
+"green")
+#define SANE_TITLE_CAL_EXPOS_TIME_B	SANE_I18N("Cal. exposure-time for blue")
+#define SANE_TITLE_SCAN_EXPOS_TIME	SANE_I18N("Scan exposure-time")
+#define SANE_TITLE_SCAN_EXPOS_TIME_R	SANE_I18N("Scan exposure-time for red")
+#define SANE_TITLE_SCAN_EXPOS_TIME_G	SANE_I18N("Scan exposure-time for " \
+"green")
+#define SANE_TITLE_SCAN_EXPOS_TIME_B	SANE_I18N("Scan exposure-time for blue")
+#define SANE_TITLE_SELECT_EXPOSURE_TIME	SANE_I18N("Set exposure-time")
+#define SANE_TITLE_CAL_LAMP_DEN		SANE_I18N("Cal. lamp density")
+#define SANE_TITLE_SCAN_LAMP_DEN	SANE_I18N("Scan lamp density")
+#define SANE_TITLE_SELECT_LAMP_DENSITY	SANE_I18N("Set lamp density")
+#define SANE_TITLE_LAMP_OFF_AT_EXIT	SANE_I18N("Lamp off at exit")
+#define SANE_TITLE_FOCUS		SANE_I18N("Focus position")
+#define SANE_TITLE_AUTOFOCUS		SANE_I18N("Autofocus")
+
+/* well known options from 'SENSORS' group*/
+#define SANE_TITLE_SCAN			"Scan button"
+#define SANE_TITLE_EMAIL		"Email button"
+#define SANE_TITLE_FAX			"Fax button"
+#define SANE_TITLE_COPY			"Copy button"
+#define SANE_TITLE_PDF			"PDF button"
+#define SANE_TITLE_CANCEL		"Cancel button"
+#define SANE_TITLE_PAGE_LOADED		"Page loaded"
+#define SANE_TITLE_COVER_OPEN		"Cover open"
+
+/* Descriptive/help strings for above options: */
+#define SANE_DESC_NUM_OPTIONS \
+SANE_I18N("Read-only option that specifies how many options a specific " \
+"device supports.")
+
+#define SANE_DESC_STANDARD    SANE_I18N("Source, mode and resolution options")
+#define SANE_DESC_GEOMETRY    SANE_I18N("Scan area and media size options")
+#define SANE_DESC_ENHANCEMENT SANE_I18N("Image modification options")
+#define SANE_DESC_ADVANCED    SANE_I18N("Hardware specific options")
+#define SANE_DESC_SENSORS     SANE_I18N("Scanner sensors and buttons")
+
+#define SANE_DESC_PREVIEW \
+SANE_I18N("Request a preview-quality scan.")
+
+#define SANE_DESC_GRAY_PREVIEW \
+SANE_I18N("Request that all previews are done in monochrome mode.  On a " \
+"three-pass scanner this cuts down the number of passes to one and on a " \
+"one-pass scanner, it reduces the memory requirements and scan-time of the " \
+"preview.")
+
+#define SANE_DESC_BIT_DEPTH \
+SANE_I18N("Number of bits per sample, typical values are 1 for \"line-art\" " \
+"and 8 for multibit scans.")
+
+#define SANE_DESC_SCAN_MODE \
+SANE_I18N("Selects the scan mode (e.g., lineart, monochrome, or color).")
+
+#define SANE_DESC_SCAN_SPEED \
+SANE_I18N("Determines the speed at which the scan proceeds.")
+
+#define SANE_DESC_SCAN_SOURCE \
+SANE_I18N("Selects the scan source (such as a document-feeder).")
+
+#define SANE_DESC_BACKTRACK \
+SANE_I18N("Controls whether backtracking is forced.")
+
+#define SANE_DESC_SCAN_TL_X \
+SANE_I18N("Top-left x position of scan area.")
+
+#define SANE_DESC_SCAN_TL_Y \
+SANE_I18N("Top-left y position of scan area.")
+
+#define SANE_DESC_SCAN_BR_X \
+SANE_I18N("Bottom-right x position of scan area.")
+
+#define SANE_DESC_SCAN_BR_Y \
+SANE_I18N("Bottom-right y position of scan area.")
+
+#define SANE_DESC_SCAN_RESOLUTION \
+SANE_I18N("Sets the resolution of the scanned image.")
+
+#define SANE_DESC_SCAN_X_RESOLUTION \
+SANE_I18N("Sets the horizontal resolution of the scanned image.")
+
+#define SANE_DESC_SCAN_Y_RESOLUTION \
+SANE_I18N("Sets the vertical resolution of the scanned image.")
+
+#define SANE_DESC_PAGE_WIDTH \
+SANE_I18N("Specifies the width of the media.  Required for automatic " \
+"centering of sheet-fed scans.")
+
+#define SANE_DESC_PAGE_HEIGHT \
+SANE_I18N("Specifies the height of the media.")
+
+#define SANE_DESC_CUSTOM_GAMMA \
+SANE_I18N("Determines whether a builtin or a custom gamma-table should be " \
+"used.")
+
+#define SANE_DESC_GAMMA_VECTOR \
+SANE_I18N("Gamma-correction table.  In color mode this option equally " \
+"affects the red, green, and blue channels simultaneously (i.e., it is an " \
+"intensity gamma table).")
+
+#define SANE_DESC_GAMMA_VECTOR_R \
+SANE_I18N("Gamma-correction table for the red band.")
+
+#define SANE_DESC_GAMMA_VECTOR_G \
+SANE_I18N("Gamma-correction table for the green band.")
+
+#define SANE_DESC_GAMMA_VECTOR_B \
+SANE_I18N("Gamma-correction table for the blue band.")
+
+#define SANE_DESC_BRIGHTNESS \
+SANE_I18N("Controls the brightness of the acquired image.")
+
+#define SANE_DESC_CONTRAST \
+SANE_I18N("Controls the contrast of the acquired image.")
+
+#define SANE_DESC_GRAIN_SIZE \
+SANE_I18N("Selects the \"graininess\" of the acquired image.  Smaller values " \
+"result in sharper images.")
+
+#define SANE_DESC_HALFTONE \
+SANE_I18N("Selects whether the acquired image should be halftoned (dithered).")
+
+#define SANE_DESC_BLACK_LEVEL \
+SANE_I18N("Selects what radiance level should be considered \"black\".")
+
+#define SANE_DESC_WHITE_LEVEL \
+SANE_I18N("Selects what radiance level should be considered \"white\".")
+
+#define SANE_DESC_WHITE_LEVEL_R \
+SANE_I18N("Selects what red radiance level should be considered \"white\".")
+
+#define SANE_DESC_WHITE_LEVEL_G \
+SANE_I18N("Selects what green radiance level should be considered \"white\".")
+
+#define SANE_DESC_WHITE_LEVEL_B \
+SANE_I18N("Selects what blue radiance level should be considered \"white\".")
+
+#define SANE_DESC_SHADOW \
+SANE_I18N("Selects what radiance level should be considered \"black\".")
+#define SANE_DESC_SHADOW_R \
+SANE_I18N("Selects what red radiance level should be considered \"black\".")
+#define SANE_DESC_SHADOW_G \
+SANE_I18N("Selects what green radiance level should be considered \"black\".")
+#define SANE_DESC_SHADOW_B \
+SANE_I18N("Selects what blue radiance level should be considered \"black\".")
+
+#define SANE_DESC_HIGHLIGHT \
+SANE_I18N("Selects what radiance level should be considered \"white\".")
+#define SANE_DESC_HIGHLIGHT_R \
+SANE_I18N("Selects what red radiance level should be considered \"full red\".")
+#define SANE_DESC_HIGHLIGHT_G \
+SANE_I18N("Selects what green radiance level should be considered \"full " \
+"green\".")
+#define SANE_DESC_HIGHLIGHT_B \
+SANE_I18N("Selects what blue radiance level should be considered \"full " \
+"blue\".")
+
+#define SANE_DESC_HUE \
+SANE_I18N("Controls the \"hue\" (blue-level) of the acquired image.")
+
+#define SANE_DESC_SATURATION \
+SANE_I18N("The saturation level controls the amount of \"blooming\" that " \
+"occurs when acquiring an image with a camera. Larger values cause more " \
+"blooming.")
+
+#define SANE_DESC_FILE \
+SANE_I18N("The filename of the image to be loaded.")
+
+#define SANE_DESC_HALFTONE_DIMENSION \
+SANE_I18N("Sets the size of the halftoning (dithering) pattern used when " \
+"scanning halftoned images.")
+
+#define SANE_DESC_HALFTONE_PATTERN \
+SANE_I18N("Defines the halftoning (dithering) pattern for scanning " \
+"halftoned images.")
+
+#define SANE_DESC_RESOLUTION_BIND \
+SANE_I18N("Use same values for X and Y resolution")
+#define SANE_DESC_NEGATIVE \
+SANE_I18N("Swap black and white")
+#define SANE_DESC_QUALITY_CAL \
+SANE_I18N("Do a quality white-calibration")
+#define SANE_DESC_DOR \
+SANE_I18N("Use lens that doubles optical resolution")
+#define SANE_DESC_RGB_BIND \
+SANE_I18N("In RGB-mode use same values for each color")
+#define SANE_DESC_THRESHOLD \
+SANE_I18N("Select minimum-brightness to get a white point")
+#define SANE_DESC_ANALOG_GAMMA \
+SANE_I18N("Analog gamma-correction")
+#define SANE_DESC_ANALOG_GAMMA_R \
+SANE_I18N("Analog gamma-correction for red")
+#define SANE_DESC_ANALOG_GAMMA_G \
+SANE_I18N("Analog gamma-correction for green")
+#define SANE_DESC_ANALOG_GAMMA_B \
+SANE_I18N("Analog gamma-correction for blue")
+#define SANE_DESC_ANALOG_GAMMA_BIND \
+SANE_I18N("In RGB-mode use same values for each color")
+#define SANE_DESC_WARMUP \
+SANE_I18N("Warm up lamp before scanning")
+#define SANE_DESC_CAL_EXPOS_TIME \
+SANE_I18N("Define exposure-time for calibration")
+#define SANE_DESC_CAL_EXPOS_TIME_R \
+SANE_I18N("Define exposure-time for red calibration")
+#define SANE_DESC_CAL_EXPOS_TIME_G \
+SANE_I18N("Define exposure-time for green calibration")
+#define SANE_DESC_CAL_EXPOS_TIME_B \
+SANE_I18N("Define exposure-time for blue calibration")
+#define SANE_DESC_SCAN_EXPOS_TIME \
+SANE_I18N("Define exposure-time for scan")
+#define SANE_DESC_SCAN_EXPOS_TIME_R \
+SANE_I18N("Define exposure-time for red scan")
+#define SANE_DESC_SCAN_EXPOS_TIME_G \
+SANE_I18N("Define exposure-time for green scan")
+#define SANE_DESC_SCAN_EXPOS_TIME_B \
+SANE_I18N("Define exposure-time for blue scan")
+#define SANE_DESC_SELECT_EXPOSURE_TIME \
+SANE_I18N("Enable selection of exposure-time")
+#define SANE_DESC_CAL_LAMP_DEN \
+SANE_I18N("Define lamp density for calibration")
+#define SANE_DESC_SCAN_LAMP_DEN \
+SANE_I18N("Define lamp density for scan")
+#define SANE_DESC_SELECT_LAMP_DENSITY \
+SANE_I18N("Enable selection of lamp density")
+#define SANE_DESC_LAMP_OFF_AT_EXIT \
+SANE_I18N("Turn off lamp when program exits")
+#define SANE_DESC_FOCUS \
+SANE_I18N("Focus position for manual focus")
+#define SANE_DESC_AUTOFOCUS \
+SANE_I18N("Perform autofocus before scan")
+
+/* well known options from 'SENSORS' group*/
+#define SANE_DESC_SCAN		SANE_I18N("Scan button")
+#define SANE_DESC_EMAIL		SANE_I18N("Email button")
+#define SANE_DESC_FAX		SANE_I18N("Fax button")
+#define SANE_DESC_COPY		SANE_I18N("Copy button")
+#define SANE_DESC_PDF		SANE_I18N("PDF button")
+#define SANE_DESC_CANCEL	SANE_I18N("Cancel button")
+#define SANE_DESC_PAGE_LOADED	SANE_I18N("Page loaded")
+#define SANE_DESC_COVER_OPEN	SANE_I18N("Cover open")
+
+/* Typical values for stringlists (to keep the backends consistent) */
+#define SANE_VALUE_SCAN_MODE_COLOR		SANE_I18N("Color")
+#define SANE_VALUE_SCAN_MODE_COLOR_LINEART	SANE_I18N("Color Lineart")
+#define SANE_VALUE_SCAN_MODE_COLOR_HALFTONE     SANE_I18N("Color Halftone")
+#define SANE_VALUE_SCAN_MODE_GRAY		SANE_I18N("Gray")
+#define SANE_VALUE_SCAN_MODE_HALFTONE           SANE_I18N("Halftone")
+#define SANE_VALUE_SCAN_MODE_LINEART		SANE_I18N("Lineart")
+
+#endif /* saneopts_h */

--- a/win32/sanestub.cpp
+++ b/win32/sanestub.cpp
@@ -1,0 +1,114 @@
+/*
+ * Stand-in for libsane on platforms where it is not available (Windows)
+ *
+ * The scanner code is written against the SANE API throughout, so rather
+ * than guard every call site this provides the handful of entry points
+ * paperman uses. There are never any devices, so every real operation
+ * reports SANE_STATUS_UNSUPPORTED; the built-in simulated scanner in
+ * qscanner.cpp bypasses these functions and keeps working.
+ */
+
+#include <cstddef>
+
+#include <sane/sane.h>
+
+extern "C"
+{
+
+SANE_Status sane_init (SANE_Int *version_code, SANE_Auth_Callback)
+   {
+   if (version_code)
+      *version_code = SANE_VERSION_CODE (1, 0, 0);
+   return SANE_STATUS_GOOD;
+   }
+
+void sane_exit (void)
+   {
+   }
+
+SANE_Status sane_get_devices (const SANE_Device ***device_list, SANE_Bool)
+   {
+   static const SANE_Device *none = NULL;
+
+   *device_list = &none;
+   return SANE_STATUS_GOOD;
+   }
+
+SANE_Status sane_open (SANE_String_Const, SANE_Handle *handle)
+   {
+   *handle = NULL;
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+void sane_close (SANE_Handle)
+   {
+   }
+
+const SANE_Option_Descriptor *sane_get_option_descriptor (SANE_Handle,
+                                                          SANE_Int)
+   {
+   return NULL;
+   }
+
+SANE_Status sane_control_option (SANE_Handle, SANE_Int, SANE_Action, void *,
+                                 SANE_Int *info)
+   {
+   if (info)
+      *info = 0;
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+SANE_Status sane_get_parameters (SANE_Handle, SANE_Parameters *)
+   {
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+SANE_Status sane_start (SANE_Handle)
+   {
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+SANE_Status sane_read (SANE_Handle, SANE_Byte *, SANE_Int, SANE_Int *length)
+   {
+   if (length)
+      *length = 0;
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+void sane_cancel (SANE_Handle)
+   {
+   }
+
+SANE_Status sane_set_io_mode (SANE_Handle, SANE_Bool)
+   {
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+SANE_Status sane_get_select_fd (SANE_Handle, SANE_Int *fd)
+   {
+   if (fd)
+      *fd = -1;
+   return SANE_STATUS_UNSUPPORTED;
+   }
+
+SANE_String_Const sane_strstatus (SANE_Status status)
+   {
+   switch (status)
+      {
+      case SANE_STATUS_GOOD: return "Success";
+      case SANE_STATUS_UNSUPPORTED: return "Operation not supported";
+      case SANE_STATUS_CANCELLED: return "Operation was cancelled";
+      case SANE_STATUS_DEVICE_BUSY: return "Device busy";
+      case SANE_STATUS_INVAL: return "Invalid argument";
+      case SANE_STATUS_EOF: return "End of file reached";
+      case SANE_STATUS_JAMMED: return "Document feeder jammed";
+      case SANE_STATUS_NO_DOCS: return "Document feeder out of documents";
+      case SANE_STATUS_COVER_OPEN: return "Scanner cover is open";
+      case SANE_STATUS_IO_ERROR: return "Error during device I/O";
+      case SANE_STATUS_NO_MEM: return "Out of memory";
+      case SANE_STATUS_ACCESS_DENIED: return "Access to resource denied";
+      }
+   return "Unknown SANE status";
+   }
+
+}

--- a/win32/sys/poll.h
+++ b/win32/sys/poll.h
@@ -1,0 +1,33 @@
+/*
+ * Minimal poll() for Windows
+ *
+ * The scanner code polls the SANE select file descriptor while waiting for
+ * data. The Windows build has no libsane, so sane_get_select_fd() never
+ * succeeds and the poll loop is never entered; this only needs to compile.
+ */
+
+#ifndef WIN32_SYS_POLL_H
+#define WIN32_SYS_POLL_H
+
+#include <windows.h>
+
+#define POLLIN   0x0001
+#define POLLNVAL 0x0020
+
+struct pollfd
+   {
+   int fd;
+   short events;
+   short revents;
+   };
+
+static inline int poll (struct pollfd *fds, unsigned int nfds, int timeout)
+   {
+   for (unsigned int i = 0; i < nfds; i++)
+      fds [i].revents = POLLNVAL;
+   if (timeout > 0)
+      Sleep (timeout);
+   return (int)nfds;
+   }
+
+#endif


### PR DESCRIPTION
Ports paperman to build and pass its test suite on Windows with the MSYS2 MinGW64 toolchain (Qt 6, PoDoFo 1.x, poppler-qt6) and adds a GitHub Actions job to keep it that way.

- Bundle the SANE headers with a stub libsane and a poll() shim so the scanner code compiles; only the simulated scanner works on Windows for now
- Guard the POSIX-only calls (getpwuid, getgrnam, chown, dlsym, getrlimit, fmemopen, termios, setenv) and fix 64-bit pointer casts that assume a 64-bit long
- Use QDir::tempPath() instead of P_tmpdir and hardcoded /tmp
- Run tesseract via QProcess on the PNG directly, dropping the ImageMagick convert step
- Add a PoDoFo 1.x code path in pdfio.cpp next to the 0.9 one (MSYS2 ships 1.1.1, Ubuntu 0.9.8)
- Release open PDF handles before renames, retry renames that fail transiently, and fix a leaked PoDoFo document on reopen; Windows refuses to rename or replace open files
- Add a `windows` CI job (MSYS2, Qt6) that builds the app and server, generates fixtures and runs the C++ tests: 204 pass, 2 skip (exiftool is not packaged for MSYS2)

Also fixes a pre-existing CI gap: the Linux jobs built without `CONFIG+=test`, so `./paperman -t` only printed a hint and the C++ test suite never actually ran in CI. All jobs now build the tests, `-t` fails when they are not compiled in, and error reports go to the console under test instead of a modal dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuuJ6u4Q43PFHDsNmhRQcA