### PR TITLE
Keep the display up with a fast feeder, and judge each page's colour and orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ For example:
     27 Property taxes  pd 2020.max 2 1093872 78572475 16422b9a c900d2a7 61ce49d6
     27 Property taxes  pd 2020.max 3 1093872 96562c4e cebfc3b3 5c863b22 d80abde6
 
+### --scan [--repo DIR] [--dir SUBDIR] [--device NAME] [--pages N]
+
+Scans into a repository without showing the GUI, using the saved scanner
+settings. The stack goes into the top-level directory of the first
+configured repository unless `--repo` and `--dir` say otherwise, and the
+scanner is the last one used unless `--device` names another (the
+built-in simulated scanner is `simulscan`). `--pages` stops after that
+many sides; otherwise scanning continues until the feeder is empty.
+`--set NAME=VALUE` sets a scanner option by its SANE name before the scan
+(for example `mode=Color`, `resolution=200`, `source="ADF Duplex"` or
+`page-height=355.6`, with fixed-point values in their units) and can be
+repeated. Progress is printed on stdout and the exit code is 0 if at
+least one page was scanned. For example, to scan two pages in colour
+into the 'inbox' directory of the repository in ~/paper:
+
+    paperman --scan --repo ~/paper --dir inbox --pages 2 --set mode=Color
+
 ### -o <directory> | --ocr <directory>
 
 Recursively process all .max files in a directory, performing OCR (Optical Character

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ how far the feeder ran ahead. Options vary resolution, pre-pick, divided
 delivery and end-of-page detection. It always stops the feeder and
 closes the session, so it can be interrupted with Ctrl-C.
 
+`tools/sane-bench.py` does the same through SANE with scanimage, so it
+works over USB (fujitsu backend) as well as the network, timing each side
+as it completes; for a fujitsu device it adds `buffermode=On` and, in
+colour, `compression=JPEG`, which the fi-8950 needs to run at speed over
+USB.
+
 With `PAPERMAN_SNAP=<dir>` set (or `--snap <dir>`), paperman saves a
 snapshot of its window as it appears on screen once a second, as
 `snap-NNNN-<seconds>s.jpg` in that directory; `--clean-snaps` (or

--- a/README.md
+++ b/README.md
@@ -170,12 +170,30 @@ into the 'inbox' directory of the repository in ~/paper:
 
     paperman --scan --repo ~/paper --dir inbox --pages 2 --set mode=Color
 
+Before every scan paperman turns on the fast-transfer settings a backend
+offers: `buffermode=On`, so a scanner with memory scans ahead instead of
+stopping after each sheet, and in colour `compression=JPEG`, so a side
+arrives as under 1 MB rather than 25 MB. Both matter over USB (the
+patched fujitsu backend has them; the fi-8950 runs at a third of its
+speed without). A `None` chosen for compression in the scan dialog is
+respected, and `--set` still overrides either.
+
 With `PAPERMAN_SCAN_STATS=1` in the environment, paperman prints a line
 of statistics on stderr at the end of every scan, in the GUI as well as
 with `--scan`: sides scanned, time per side, CPU used by the display and
 scanning threads, and how far the display fell behind the scanner. This
 is the first thing to look at if scanning seems slow, since it says
 which side is the bottleneck.
+
+With `PAPERMAN_SNAP=<dir>` set (or `--snap <dir>`), paperman saves a
+snapshot of its window as it appears on screen once a second, as
+`snap-NNNN-<seconds>s.jpg` in that directory; `--clean-snaps` (or
+`PAPERMAN_SNAP_CLEAN=1`) removes the snapshots already there first. This shows what the display
+actually showed and when, to set against a log, which is useful when the
+display seems to lag behind what paperman reports. It grabs from
+paperman's own event loop, so it misses the moments paperman is busy, and
+it captures screen pixels, so it needs X11 (on Wayland the snapshots come
+out empty).
 
 ### -o <directory> | --ocr <directory>
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ scanning threads, and how far the display fell behind the scanner. This
 is the first thing to look at if scanning seems slow, since it says
 which side is the bottleneck.
 
+To measure the scanner itself, `tools/psip-bench.py` talks the fi-8950's
+network protocol directly, with neither the SANE backend nor paperman in
+the way: it scans a number of sides (default 50) as fast as the scanner
+will hand them over, prints the timing of every side with `-v`, and
+reports the rate, how long the scanner made it wait for each side, and
+how far the feeder ran ahead. Options vary resolution, pre-pick, divided
+delivery and end-of-page detection. It always stops the feeder and
+closes the session, so it can be interrupted with Ctrl-C.
+
 With `PAPERMAN_SNAP=<dir>` set (or `--snap <dir>`), paperman saves a
 snapshot of its window as it appears on screen once a second, as
 `snap-NNNN-<seconds>s.jpg` in that directory; `--clean-snaps` (or

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ into the 'inbox' directory of the repository in ~/paper:
 
     paperman --scan --repo ~/paper --dir inbox --pages 2 --set mode=Color
 
+For a benchmark or a test scan that should not end up in a real
+repository, point `--repo` at a throwaway directory: it is used for that
+run only and is not added to the configured repositories.
+
+    mkdir -p /tmp/bench && paperman --scan --repo /tmp/bench --pages 50
+
 Before every scan paperman turns on the fast-transfer settings a backend
 offers: `buffermode=On`, so a scanner with memory scans ahead instead of
 stopping after each sheet, and in colour `compression=JPEG`, so a side

--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ many sides; otherwise scanning continues until the feeder is empty.
 `--set NAME=VALUE` sets a scanner option by its SANE name before the scan
 (for example `mode=Color`, `resolution=200`, `source="ADF Duplex"` or
 `page-height=355.6`, with fixed-point values in their units) and can be
-repeated. Progress is printed on stdout and the exit code is 0 if at
-least one page was scanned. For example, to scan two pages in colour
-into the 'inbox' directory of the repository in ~/paper:
+repeated. `--auto-colour` stores pages that turn out to have no colour
+as greyscale, or as mono when they have no shading either, as the
+Auto colour box in the scan window does. Progress is printed on stdout
+and the exit code is 0 if at least one page was scanned. For example,
+to scan two pages in colour into the 'inbox' directory of the
+repository in ~/paper:
 
     paperman --scan --repo ~/paper --dir inbox --pages 2 --set mode=Color
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ into the 'inbox' directory of the repository in ~/paper:
 
     paperman --scan --repo ~/paper --dir inbox --pages 2 --set mode=Color
 
+With `PAPERMAN_SCAN_STATS=1` in the environment, paperman prints a line
+of statistics on stderr at the end of every scan, in the GUI as well as
+with `--scan`: sides scanned, time per side, CPU used by the display and
+scanning threads, and how far the display fell behind the scanner. This
+is the first thing to look at if scanning seems slow, since it says
+which side is the bottleneck.
+
 ### -o <directory> | --ocr <directory>
 
 Recursively process all .max files in a directory, performing OCR (Optical Character

--- a/desktopdelegate.cpp
+++ b/desktopdelegate.cpp
@@ -33,6 +33,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QTimer>
 
 #include "desktopdelegate.h"
+#include "utils.h"
 #include "desktopmodel.h"
 
 
@@ -409,19 +410,19 @@ void Desktopdelegate::paint (QPainter *painter, const QStyleOptionViewItem &opti
       {
       // otherwise we just draw an outline
       painter->fillRect (measure.pixmapRectHint, QBrush (Qt::DiagCrossPattern));
-         //style->standardPalette().color(QPalette::BrightText));
+         //utilStylePalette (style).color(QPalette::BrightText));
       }
 
    // if this is the target of a drag, draw a little 'pages' symbol over it
    if (measure.target) // || measure.source)
       {
       style->drawItemPixmap (painter, measure.pixmapRect, Qt::AlignHCenter, *pages);
-      painter->fillRect (measure.titleRect, style->standardPalette().color(QPalette::BrightText));
+      painter->fillRect (measure.titleRect, utilStylePalette (style).color(QPalette::BrightText));
       }
    if (option.state & QStyle::State_Selected)
-      painter->fillRect (measure.titleRect, style->standardPalette().color(QPalette::Highlight));
+      painter->fillRect (measure.titleRect, utilStylePalette (style).color(QPalette::Highlight));
    style->drawItemText (painter, measure.titleRect, Qt::AlignHCenter,
-         style->standardPalette (), false, measure.title,
+         utilStylePalette (style), false, measure.title,
          option.state & QStyle::State_Selected
              ? QPalette::HighlightedText : QPalette::WindowText);
    f.setBold (false);
@@ -434,7 +435,7 @@ void Desktopdelegate::paint (QPainter *painter, const QStyleOptionViewItem &opti
    if (measure.multiple)
       {
       style->drawItemText (painter, measure.pagenameRect, Qt::AlignHCenter,
-         style->standardPalette (), false, measure.pagename, QPalette::WindowText);
+         utilStylePalette (style), false, measure.pagename, QPalette::WindowText);
 //    printf ("%s\n", measure.title.latin1 ());
 
 #ifdef OUTLINE
@@ -444,14 +445,14 @@ void Desktopdelegate::paint (QPainter *painter, const QStyleOptionViewItem &opti
       // draw control area
       QRect rect = measure.pagenumRect;
 
-      painter->fillRect (rect, style->standardPalette().color(QPalette::Button));
+      painter->fillRect (rect, utilStylePalette (style).color(QPalette::Button));
       painter->drawPixmap (rect.x (), rect.y (), *pleft);
       painter->drawPixmap (rect.right () - pright->width (), rect.y (), *pright);
 
       rect.adjust (pleft->width (), 0, -pright->width (), 0);
 
       style->drawItemText (painter, rect, Qt::AlignHCenter,
-            style->standardPalette (), false, measure.pagestr, QPalette::WindowText);
+            utilStylePalette (style), false, measure.pagestr, QPalette::WindowText);
 #ifdef OUTLINE
       painter->setPen (Qt::blue);
       painter->drawRect (measure.pagenumRect);

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -941,6 +941,7 @@ void Desktopmodel::pageStarting (Paperscan &scan, const PPage *page)
    _need_scaled_image = false;
    _scaled_image_size = QSize ();
    _scaled_linenums.clear ();
+   _scaled_factors.clear ();
    emit beginningPage ();
    }
 
@@ -951,14 +952,16 @@ void Desktopmodel::pageProgress (Paperscan &scan, const PPage *page)
    const char *data = 0;
    int scaled_linenum;
    int size = 0;
+   QSize surface;
    bool ok;
 
    if (_scan_err)
       return;
 
    ok = scan.getData (page, data, size);
-   if (ok && getNewScaledImage (scan, page, data, size, image, scaled_linenum))
-      emit newScaledImage (image, scaled_linenum, page->pagenum ());
+   if (ok && getNewScaledImage (scan, page, data, size, image, scaled_linenum,
+                                surface))
+      emit newScaledImage (image, scaled_linenum, page->pagenum (), surface);
    }
 
 
@@ -968,24 +971,45 @@ void Desktopmodel::pageProgress (Paperscan &scan, const PPage *page)
 
 
 bool Desktopmodel::getNewScaledImage (Paperscan &scan, const PPage *page,
-      const char *data, int nbytes, QImage &image, int &scaled_linenum)
+      const char *data, int nbytes, QImage &image, int &scaled_linenum,
+      QSize &surface)
    {
    int width, height;
    int depth, stride;
 
-   if (_need_scaled_image && scan.getPageDetails (page, width, height, depth, stride) && stride)
+   if (_need_scaled_image && scan.getPageDetails (page, width, height, depth, stride)
+       && stride && width > 0 && height > 0)
       {
       int linenum, lines;
+      int pagenum = page->pagenum ();
+
+      /* scale the page to fit the box, keeping its shape, and place
+         each band with that same factor, so bands butt up against each
+         other whatever shape the page is. The surface is the page's
+         scaled shape, not the box */
+      double scale = qMin ((double)_scaled_image_size.width () / width,
+                           (double)_scaled_image_size.height () / height);
+
+      surface = QSize (qMax (1, qRound (width * scale)),
+                       qMax (1, qRound (height * scale)));
+
       /* progress is tracked per page, so front and back can advance
        * independently during a progressive duplex scan. Default 0 for a
-       * page we haven't seen yet. */
-      int prev_linenum = _scaled_linenums.value (page->pagenum (), 0);
+       * page we haven't seen yet. When the back end learns the page's
+       * true height part way through (fujitsu ald) the factor can change:
+       * carry the progress over in the new scale, as the surface is */
+      int prev_linenum = _scaled_linenums.value (pagenum, 0);
+      double prev_scale = _scaled_factors.value (pagenum, scale);
+
+      if (prev_scale != scale)
+         prev_linenum = qRound (prev_linenum * scale / prev_scale);
+      _scaled_factors.insert (pagenum, scale);
 
       // how many scan lines worth of data do we have?
       lines = nbytes / stride;
 
       // what scaled line number are we up to now?
-      linenum = lines * _scaled_image_size.height () / height;
+      linenum = (int)(lines * scale);
 
       /** we must have at least 2 lines to work with to be sure of getting a
           single line result */
@@ -1000,9 +1024,11 @@ bool Desktopmodel::getNewScaledImage (Paperscan &scan, const PPage *page,
 
       /* we now need to generate an image from scaled lines prev_linenum
          to linenum. First work out the input (unscaled) line numbers */
-      int from_linenum = scaled_from * height / _scaled_image_size.height ();
-      int to_linenum = linenum * height / _scaled_image_size.height ();
+      int from_linenum = (int)(scaled_from / scale);
+      int to_linenum = qMin (lines, (int)(linenum / scale));
 
+      if (to_linenum <= from_linenum)
+         return false;
 //       qDebug () << "getNewScaledImage bytes " << nbytes << " lines from" << from_linenum << to_linenum;
       Filepage::getImageFromLines (data + stride * from_linenum, width,
          to_linenum - from_linenum, depth, stride, image);
@@ -1013,12 +1039,12 @@ bool Desktopmodel::getNewScaledImage (Paperscan &scan, const PPage *page,
          image = image.convertToFormat (QImage::Format_RGB32);
 #endif
 
-      image = image.scaled (_scaled_image_size, Qt::KeepAspectRatio);
+      image = image.scaled (surface.width (), linenum - scaled_from);
       if (!image.height ())
          return false;
 //       qDebug () << "desktopmodel image" << image.width () << image.height ()<< image.format ();
       scaled_linenum = scaled_from;
-      _scaled_linenums.insert (page->pagenum (), linenum);
+      _scaled_linenums.insert (pagenum, linenum);
       return true;
       }
    return false;
@@ -1035,6 +1061,7 @@ void Desktopmodel::registerScaledImageSize (const QSize &size)
       // if the size has changed, start the image again
       _scaled_image_size = size;
       _scaled_linenums.clear ();
+   _scaled_factors.clear ();
       }
    }
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -924,7 +924,7 @@ err_info *Desktopmodel::addPageToScan (const Filepage *mp, const QString &covera
       return NULL;
    CALL (_scan_file->addPage (mp, false));
 //    qDebug () << "Desktopmodel::addPageToScan, page count" << _scan_file->pagecount;
-   emit newScannedPage (coverageStr, mp->markBlank ());
+   emit newScannedPage (coverageStr, mp->markBlank (), mp->_rotate);
    return NULL;
    }
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -53,6 +53,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "file.h"
 #include "paperstack.h"
 #include "utils.h"
+#include <QMutex>
 
 
 // time to delay between scanning each stack, should be 0 unless testing
@@ -1858,6 +1859,7 @@ QMimeData *Desktopmodel::mimeData (const QModelIndexList &list) const
 err_info *Desktopmodel::getImage (const QModelIndex &ind, int pnum, bool do_scale,
                QImage &imagep, QSize &Size, QSize &trueSize, int &bpp, bool blank) const
    {
+   QMutexLocker locker (&_imageMutex);
    _modelconv->assertIsSource (0, &ind, 0);
    File *f = getFile (ind);
 
@@ -1952,6 +1954,7 @@ QString Desktopmodel::imageTimestamp (const QModelIndex &ind, int pagenum)
 err_info *Desktopmodel::getImagePreviewSizes (const QModelIndex &ind, int pagenum,
       QSize &preview_size, QSize &image_size) const
    {
+   QMutexLocker locker (&_imageMutex);
    _modelconv->assertIsSource (0, &ind, 0);
    File *f = getFile (ind);
    QSize dsize;
@@ -1972,6 +1975,7 @@ err_info *Desktopmodel::getImagePreviewSizes (const QModelIndex &ind, int pagenu
 void Desktopmodel::getScaledImage (const QModelIndex &ind, int pagenum,
       QSize &size, QPixmap &pixmap, bool blank) const
    {
+   QMutexLocker locker (&_imageMutex);
    QSize preview_size, image_size;
    err_info *err;
 
@@ -2020,9 +2024,37 @@ void Desktopmodel::getScaledImage (const QModelIndex &ind, int pagenum,
    }
 
 
+bool Desktopmodel::imageNeedsDecode (const QModelIndex &ind, int pagenum,
+      const QSize &size) const
+   {
+   QMutexLocker locker (&_imageMutex);
+   QSize preview_size, image_size;
+
+   if (getImagePreviewSizes (ind, pagenum, preview_size, image_size))
+      return false;   // on error let the synchronous path deal with it
+   return size.width () > preview_size.width () + 20
+       || size.height () > preview_size.height () + 20;
+   }
+
+
+err_info *Desktopmodel::getScaledImageData (const QModelIndex &ind, int pagenum,
+      const QSize &size, bool blank, QImage &image) const
+   {
+   QMutexLocker locker (&_imageMutex);
+   QSize isize, tsize;
+   int bpp;
+
+   CALL (getImage (ind, pagenum, false, image, isize, tsize, bpp, blank));
+   if (image.width () != size.width () && image.height () != size.height ())
+      image = util_smooth_scale_image (image, size);
+   return NULL;
+   }
+
+
 err_info *Desktopmodel::getImagePreview (const QModelIndex &ind, int pagenum,
          QPixmap &pixmap, bool blank) const
    {
+   QMutexLocker locker (&_imageMutex);
    File *f = getFile (ind);
    err_info *err;
 

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -2044,6 +2044,11 @@ err_info *Desktopmodel::getScaledImageData (const QModelIndex &ind, int pagenum,
    QSize isize, tsize;
    int bpp;
 
+   /* the render thread may hold a model index that has gone stale, so
+      check it maps to a file rather than asserting deep in getImage */
+   if (!ind.isValid () || !IS_FILE (ind))
+      return err_make (ERRFN, ERR_file_not_loaded_yet1, "stale index");
+
    CALL (getImage (ind, pagenum, false, image, isize, tsize, bpp, blank));
    if (image.width () != size.width () && image.height () != size.height ())
       image = util_smooth_scale_image (image, size);

--- a/desktopmodel.cpp
+++ b/desktopmodel.cpp
@@ -2007,7 +2007,6 @@ void Desktopmodel::getScaledImage (const QModelIndex &ind, int pagenum,
       err = getImage (ind, pagenum, false, image, isize, tsize, bpp, blank);
       //qDebug () << "Desktopmodel::getScaledImage" << image.width () << image.height ()
       //        << image.bits () << image.size ();
-      mem_check ();
       if (err)
          ;
       // do we need to scale?

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1336,7 +1336,8 @@ signals:
 
       \param coverageStr      coverage string for user
       \param mark_blank       true if page should be marked blank */
-   void newScannedPage (const QString &coverageStr, bool mark_blank);
+   void newScannedPage (const QString &coverageStr, bool mark_blank,
+                        int rotate);
 
 public:
    /** clone a model

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -1019,8 +1019,11 @@ signals:
       \param image            the new part of the image
       \param scaled_linenum   destination start line number for this image
       \param pagenum          which page in the active scan this is (0 =
-                              front; 1 = back during progressive duplex) */
-   void newScaledImage (const QImage &image, int scaled_linenum, int pagenum);
+                              front; 1 = back during progressive duplex)
+      \param surface          size of the whole scaled page the image is
+                              part of */
+   void newScaledImage (const QImage &image, int scaled_linenum, int pagenum,
+                        const QSize &surface);
 
    /** request that the scan stack be commited, because we are about to
        operate on it */
@@ -1092,7 +1095,7 @@ private:
                                    int pagenum, File::e_transform op);
 
    bool getNewScaledImage (Paperscan &scan, const PPage *page, const char *data,
-         int nbytes, QImage &image, int &scaled_linenum);
+         int nbytes, QImage &image, int &scaled_linenum, QSize &surface);
 
    /** check if the list contains the scan stack - if so commit it
 
@@ -1550,6 +1553,7 @@ private:
       and back independently. Reset by pageStarting() / replaced by
       registerScaledImageSize() whenever the size changes. */
    QHash<int, int> _scaled_linenums;
+   QHash<int, double> _scaled_factors; //!< scale factor used per page
    QPixmap _unknown;
    QPixmap _no_access;
    QStringList _persistent_filenames;  //!< list of filename for each persistent model index (used when saving)

--- a/desktopmodel.h
+++ b/desktopmodel.h
@@ -26,6 +26,11 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QMouseEvent>
 #include <QKeyEvent>
 #include <QSet>
+#include <QMutex>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QRecursiveMutex>
+#endif
+#include <QImage>
 
 
 class QFontMetrics;
@@ -1254,6 +1259,26 @@ public:
       \returns error, or NULL if none */
    err_info *getImagePreview (const QModelIndex &ind, int pagenum,
          QPixmap &pixmap, bool blank = false) const;
+
+   /** True if showing a page at the given size needs a full decode
+       rather than the small stored preview (i.e. it is worth doing on
+       the render thread) */
+   bool imageNeedsDecode (const QModelIndex &ind, int pagenum,
+         const QSize &size) const;
+
+   /** Decode and scale a page to a QImage, for the background render
+       thread (which cannot make a QPixmap). Serialised with all other
+       file access. */
+   err_info *getScaledImageData (const QModelIndex &ind, int pagenum,
+         const QSize &size, bool blank, QImage &image) const;
+
+   /** Serialises access to the .max files, which are not thread-safe, so
+       the render thread and the GUI thread never decode at once */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+   mutable QRecursiveMutex _imageMutex;
+#else
+   mutable QMutex _imageMutex {QMutex::Recursive};
+#endif
 
    /** deletes a pixmap if non-null, and not one of our internal ones. Sets
        *pixmapp to 0

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -295,8 +295,8 @@ void Desktopwidget::createPage(void)
       _page, SLOT (slotBeginningPage ()));
 
    // and when we have a new preview image fragment for the page being scanned
-   connect (_contents, SIGNAL (newScaledImage (const QImage &, int, int)),
-      _page, SLOT (slotNewScaledImage (const QImage &, int, int)));
+   connect (_contents, SIGNAL (newScaledImage (const QImage &, int, int, const QSize &)),
+      _page, SLOT (slotNewScaledImage (const QImage &, int, int, const QSize &)));
 
    // and when we change a stack
    connect (_contents, SIGNAL (dataChanged (const QModelIndex &, const QModelIndex &)),

--- a/desktopwidget.cpp
+++ b/desktopwidget.cpp
@@ -287,8 +287,8 @@ void Desktopwidget::createPage(void)
    _page->init ();
 
    // alert the page widget whenever a new page is finished scanning
-   connect (_contents, SIGNAL (newScannedPage (const QString &, bool)),
-      _page, SLOT (slotNewScannedPage (const QString &, bool)));
+   connect (_contents, SIGNAL (newScannedPage (const QString &, bool, int)),
+      _page, SLOT (slotNewScannedPage (const QString &, bool, int)));
 
    // alert the page widget whenever we start to scan a new page
    connect (_contents, SIGNAL (beginningPage ()),

--- a/desktopwidget.h
+++ b/desktopwidget.h
@@ -140,6 +140,9 @@ public:
 
    /** returns a pointer to the model, which contains the items being displayed */
    Desktopmodel *getModel (void) { return _contents; }
+   
+   //! the page pane that shows the current stack and follows a scan
+   Pagewidget *getPagewidget (void) { return _page; }
 
    /** returns a pointer to the view,, which contains the view of the items */
    Desktopview *getView (void) { return _view; }

--- a/file.cpp
+++ b/file.cpp
@@ -1422,7 +1422,7 @@ Filepage::Filepage ()
    _timestamp = QDateTime::currentDateTime ();
 //    mp->stack = NULL;
 //    mp->chunk = NULL;
-   _width = _height = _depth = _stride = _size = 0;
+   _width = _height = _depth = _stride = _size = _rotate = 0;
    _jpeg = _mark_blank = false;
    _pagenum = -1;
    _stack = 0;

--- a/file.h
+++ b/file.h
@@ -698,6 +698,7 @@ public:
    int _height;  //!< height in pixels
    int _depth;   //!< depth in bpp
    int _stride;  //!< bytes per line
+   int _rotate;  //!< degrees the page was turned as it was stored: 0, 90, 270
    int _size;       //!< size of data
    QString _name; //!< the page name
    int _jpeg;           //!< true if page is already JPEG compressed

--- a/filemax.cpp
+++ b/filemax.cpp
@@ -466,6 +466,7 @@ Filemax::Filemax (const QString &dir, const QString &filename, Desk *desk)
    _debug = no_debug ();
 
    _fin = NULL;
+   _open_count = 0;
    max_clear_cache (_cache);
    max_clear_cache (_scache);
    _bermuda = _tunguska = _annot = _trail = _b0 = _b4 = 0;
@@ -742,6 +743,9 @@ err_info *Filemax::max_cache_data (cache_info &cache, int pos,
    cache.buff.resize (size + 4);
 
    // read the data
+   QMutexLocker locker (&_file_mutex);
+   if (!_fin)
+      return err_make (ERRFN, ERR_cannot_open_file1, _pathname.toLatin1().constData());
    fseek (_fin, pos, SEEK_SET);
    n = fread (cache.buff.data (), 1, size, _fin);
    if (n != size)
@@ -795,6 +799,8 @@ byte *Filemax::max_check_scache (int pos)
 
 err_info *Filemax::max_read_data (int pos, byte *buf, int size)
    {
+   //! see max_write_data(): the file must not close under the read
+   QMutexLocker locker (&_file_mutex);
    int count;
 
    // guard against a read while the file is closed, rather than crashing in
@@ -811,6 +817,11 @@ err_info *Filemax::max_read_data (int pos, byte *buf, int size)
 
 err_info *Filemax::max_write_data (int pos, byte *data, int size)
    {
+   /* Hold the file across the write. Another thread closing the file
+      between the check below and the write leaves this one seeking and
+      writing down a closed handle, which fails with a bad file
+      descriptor part way through saving a stack */
+   QMutexLocker locker (&_file_mutex);
    int count;
 
    // guard against a write while the file is closed (see max_read_data)
@@ -2729,6 +2740,8 @@ err_info *Filemax::getImageInfo (int pagenum, QSize &size,
       QSize &true_size, int &bpp, int &image_size, int &compressed_size,
       QDateTime &timestamp)
    {
+   QMutexLocker locker (&_file_mutex);
+
    chunk_info *chunk;
    page_info *page;
 
@@ -2776,8 +2789,27 @@ int Filemax::pagecount (void)
    return _pages.size ();
    }
 
+Filemax::Open::Open (Filemax *max) : _max (max), _err (max->ensure_open ())
+   {
+   }
+
+
+Filemax::Open::~Open ()
+   {
+   if (!_err)
+      _max->ensure_closed ();
+   }
+
+
+/* Open the file if it is not open, and count the request, so that the
+   matching ensure_closed() only closes it once every caller is done: the
+   render thread and the GUI thread each open and close around their own
+   reads of the same stack, and one thread's close used to pull the file
+   from under the other's read */
 err_info *Filemax::ensure_open()
 {
+   QMutexLocker locker (&_file_mutex);
+
    if (!_fin) {
       _fin = fopen (_pathname.toLatin1(), "r+b");
       if (!_fin) {
@@ -2787,7 +2819,7 @@ err_info *Filemax::ensure_open()
             return err_make (ERRFN, ERR_cannot_open_file1, _pathname.toLatin1().constData());
       }
    }
-
+   _open_count++;
    return nullptr;
 }
 
@@ -2803,7 +2835,11 @@ err_info *Filemax::max_open_file()
 
 void Filemax::ensure_closed()
 {
-   if (_fin) {
+   QMutexLocker locker (&_file_mutex);
+
+   if (_open_count > 0)
+      _open_count--;
+   if (_fin && !_open_count) {
       fclose(_fin);
       _fin = nullptr;
    }
@@ -4594,11 +4630,13 @@ err_info *Filemax::max_replace_page (page_info &page, Filemaxpage &mp)
       page keeps its existing chunk positions: insert_chunk() reuses
       each one where the new data fits and relocates it where not. The
       text chunk is untouched, so any OCR text survives */
-   CALL (ensure_open ());
+   Open open (this);
+
+   CALL (open.err ());
    page.chunkid = _chunkid_next;
    page.titlestr = mp.name ();
    CALL (max_setup_page (page, mp));
-   return flush ();   // this also closes the file
+   return flush ();
    }
 
 err_info *Filemaxpage::compress (void)
@@ -5278,9 +5316,10 @@ err_info *Filemax::flush_chunks (void)
 
          // write the chunk to disc
          assert (chunk.buf);
-         CALL(ensure_open());
+         Open open (this);
+
+         CALL (open.err ());
          CALL (max_write_data (chunk.start, chunk.buf, chunk.size));
-         ensure_closed();
          chunk.saved = true;
          }
       }
@@ -5311,7 +5350,9 @@ err_info *Filemax::flush (void)
    _xform_page = -1;
    _xform_image = QImage ();
 
-   CALL(ensure_open());
+   Open open (this);
+
+   CALL (open.err ());
    ensure_all_chunks ();
 
    // write back any changed page titles
@@ -5323,12 +5364,10 @@ err_info *Filemax::flush (void)
 
    // now flush header
    write_max_header ();
-   CALL(ensure_open());
    CALL (max_write_data (0, (byte *)_hdr.data (), _hdr.size ()));
    _hdr_updated = true;
 
    fflush (_fin);
-   ensure_closed();
 
    // update the file size
    QFileInfo fi (_pathname);
@@ -5567,6 +5606,7 @@ err_info *Filemax::reload (void)
       page_resize() insist on starting from empty lists */
    max_free ();
    _fin = NULL;
+   _open_count = 0;
    _chunks.clear ();
    _pages.clear ();
    _annot_loaded = false;
@@ -5942,7 +5982,9 @@ Filemaxpage::~Filemaxpage (void)
 
 err_info *Filemax::rebuildPagePreview (int pagenum)
    {
-   CALL (ensure_open ());
+   Open open (this);
+
+   CALL (open.err ());
    CALL (ensure_all_chunks ());
 
    chunk_info *chunk;
@@ -6074,6 +6116,8 @@ err_info *Filemax::rebuildPreviews ()
 err_info *Filemax::getImage (int pagenum, bool,
             QImage &image, QSize &Size, QSize &trueSize, int &bpp, bool blank)
    {
+   QMutexLocker locker (&_file_mutex);
+
    int num_bytes;
    int compressed_size;
    QDateTime timestamp;

--- a/filemax.h
+++ b/filemax.h
@@ -33,6 +33,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 
 #include <QDateTime>
+#include <QRecursiveMutex>
 #include <QImage>
 
 #include "file.h"
@@ -478,6 +479,27 @@ private:
    //! Ensure that the file is closed
    void ensure_closed();
 
+   /** Holds the file open for as long as it is in scope
+
+       Every ensure_open() must be matched by an ensure_closed() or the
+       file is never closed, and on Windows nothing can then delete or
+       rename it. The CALL() macro returns as soon as anything fails, so
+       a function that closes at its end only gives the count back on the
+       paths it thinks about; this gives it back on all of them */
+   class Open
+      {
+   public:
+      Open (Filemax *max);
+      ~Open ();
+
+      //! the error from opening the file, or NULL
+      err_info *err (void) const { return _err; }
+
+   private:
+      Filemax *_max;
+      err_info *_err;
+      };
+
    err_info *max_open_file();
 
    err_info *dodump (FILE *f, byte *ptr, int start, int count);
@@ -607,6 +629,10 @@ private:
 private:
 //    char *_fname;                                               /* file name */
    FILE *_fin;     // the open file
+   int _open_count;  // ensure_open() calls not yet matched by ensure_closed()
+   /** serialises use of _fin and the caches: the render thread reads pages
+       while the GUI thread reads or writes others of the same stack */
+   QRecursiveMutex _file_mutex;
 //   byte *data;                                              /* file data */
 
    int _version;         // version number

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -575,12 +575,11 @@ void Mainwidget::slotScanComplete (SANE_Status status, const QString &msg, const
    if (status)
       {
       if (utilHeadless ())
-         qWarning () << "Scan status:" << sane_strstatus (status);
+         qWarning () << "Scan status:" << sane_strstatus (status) << msg;
       else
          {
-         QSaneStatusMessage fred (status, this);
+         QSaneStatusMessage fred (status, this, msg);
 
-         printf ("status = %d\n", status);
          fred.exec ();
          }
       }

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -111,6 +111,9 @@ Mainwidget::Mainwidget (QWidget *parent, const char *name)
    _pscan = 0;
    _options = 0;
    _scanning = false;
+   _scan_ok = false;
+   _scan_pages = 0;
+   _console = false;
 //    _stack = 0;
 
    addWidget (_desktop);
@@ -183,14 +186,27 @@ void Mainwidget::saveSettings (void)
 bool Mainwidget::complain(err_info *err)
 {
    if (err)
-      {
-      if (utilTestMode())
-         qWarning() << "Error:" << err->errstr;
-      else
-         QMessageBox::warning (0, "Maxview", err->errstr);
-      }
+      warn ("Maxview", err->errstr);
 
    return err != nullptr;
+}
+
+
+void Mainwidget::warn (const QString &title, const QString &msg)
+{
+   if (utilHeadless ())
+      qWarning () << qPrintable (title) << ":" << qPrintable (msg);
+   else
+      QMessageBox::warning (0, title, msg);
+}
+
+
+void Mainwidget::inform (const QString &title, const QString &msg)
+{
+   if (utilHeadless ())
+      qInfo () << qPrintable (title) << ":" << qPrintable (msg);
+   else
+      QMessageBox::information (this, title, msg);
 }
 
 void Mainwidget::showPage (const QModelIndex &index, bool delay_smoothing)
@@ -283,6 +299,12 @@ bool Mainwidget::ensureScanner (void)
       ok = ssd.setupLast ();
       if (ok)
          _scanner = ssd.scanner ();
+      else if (utilHeadless ())
+         {
+         // there is no one to choose from a dialog
+         warn ("Scanner Problem", "No scanner selected: use --device");
+         return false;
+         }
       else
          {
          ssd.show ();
@@ -305,7 +327,7 @@ bool Mainwidget::ensureScanner (void)
          }
       else
          {
-         QMessageBox::warning (0, "Scanner Problem", "Scanner not selected");
+         warn ("Scanner Problem", "Scanner not selected");
          return false;
          }
       }
@@ -362,6 +384,7 @@ void Mainwidget::scanInto(QModelIndex target)
 
    if (!ensureScanner ())
       return;
+   applyScanOptions ();
 
    // check resolution, etc.
    status = _scanner->getParameters(&parameters);
@@ -385,8 +408,8 @@ void Mainwidget::scanInto(QModelIndex target)
          }
       if (status != SANE_STATUS_GOOD)
          {
-         QMessageBox::warning (0, "Scanner Problem",
-            "Could not get parameters - is the scanner connected?");
+         warn ("Scanner Problem",
+               "Could not get parameters - is the scanner connected?");
          return;
          }
       }
@@ -436,6 +459,9 @@ void Mainwidget::scanInto(QModelIndex target)
    _scan = &scan;
    _scanning = true;
    _scan_cancelling = false;
+   _scan_ok = false;
+   _scan_pages = 0;
+   _scan_summary.clear ();
    updatePscan ();
 
    while (_scanning)
@@ -453,6 +479,34 @@ void Mainwidget::scan(void)
 {
    scanInto(QModelIndex());
 }
+
+
+void Mainwidget::applyScanOptions (void)
+   {
+   QMap<QString, QString> rest;
+
+   for (auto it = _scan_options.constBegin (); it != _scan_options.constEnd ();
+        ++it)
+      {
+      int num = _scanner->findOption (qPrintable (it.key ()));
+
+      if (num < 0)
+         {
+         warn ("Scanner", QString ("No option '%1'").arg (it.key ()));
+         continue;
+         }
+      /* QScanner sets fixed-point options from their raw value, so
+         convert from the user's units here */
+      if (_scanner->getOptionType (num) == SANE_TYPE_FIXED)
+         {
+         SANE_Word word = SANE_FIX (it.value ().toDouble ());
+         _scanner->setOption (num, &word);
+         }
+      else
+         rest [it.key ()] = it.value ();
+      }
+   _scanner->setOptionsByName (rest);
+   }
 
 void Mainwidget::slotStackNew (const QString &stack_name)
    {
@@ -509,7 +563,7 @@ void Mainwidget::slotScanComplete (SANE_Status status, const QString &msg, const
          setupScanDialog ();
          if (_pscan)
             _pscan->reapplyCurrentPreset ();
-         QMessageBox::information (this, "Scanner reconnected",
+         inform ("Scanner reconnected",
             "The scanner connection was lost and has been re-established.\n"
             "Please try the scan again.");
          _scanning = false;
@@ -520,16 +574,23 @@ void Mainwidget::slotScanComplete (SANE_Status status, const QString &msg, const
    // don't report end of documents if we have managed to scan some
    if (status)
       {
-      QSaneStatusMessage fred (status, this);
+      if (utilHeadless ())
+         qWarning () << "Scan status:" << sane_strstatus (status);
+      else
+         {
+         QSaneStatusMessage fred (status, this);
 
-      printf ("status = %d\n", status);
-      fred.exec ();
+         printf ("status = %d\n", status);
+         fred.exec ();
+         }
       }
 
    progress (msg);
 
    if (err && err->errnum != ERR_scan_cancelled)
-      QMessageBox::warning (0, "Error", err->errstr);
+      warn ("Error", err->errstr);
+   _scan_ok = status == SANE_STATUS_GOOD && !err;
+   _scan_summary = msg;
    _scanning = false;
    }
 
@@ -544,6 +605,9 @@ void Mainwidget::slotStackNewPage (const Filepage *mp, const QString &coverageSt
    //    qDebug () << "slotStackNewPage";
       if (!infostr.isEmpty ())
          info (infostr);
+      _scan_pages++;
+      if (_console)
+         printf ("Page %d: %s\n", _scan_pages, qPrintable (coverageStr));
       err = _contents->addPageToScan (mp, coverageStr);
       _scan->pageAdded (mp);
       progressSize (_contents->getScanSize ());
@@ -585,6 +649,8 @@ void Mainwidget::slotStackCancel (void)
 void Mainwidget::progress (const QString &str)
    {
 //    qDebug () << "progress" << str;
+   if (_console && !str.isEmpty ())
+      printf ("%s\n", qPrintable (str));
    if (_pscan)
       _pscan->progress (str.toLatin1 ().constData());
    else

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -29,6 +29,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QDebug>
 #include <QDialogButtonBox>
+#include <QEventLoop>
 #include <QtGlobal>
 #include <QShortcut>
 #if QT_VERSION >= 0x050000
@@ -464,10 +465,15 @@ void Mainwidget::scanInto(QModelIndex target)
    _scan_summary.clear ();
    updatePscan ();
 
+   /* Wait for the scan to finish, processing events as they arrive. Block
+      in WaitForMoreEvents rather than spinning on a bare processEvents(),
+      which returns at once when the queue is empty and so pegs a whole CPU
+      core for the entire scan. _buttonTimer wakes us at least twice a
+      second, so _scanning is re-checked promptly even if a wake-up is
+      missed. The scanning thread has no event loop of its own, so nothing
+      needs delivering to it. */
    while (_scanning)
-      /* note this will not allow the scanning thread to get events, but
-         at the moment it doesn't have an event loop anyway */
-      qApp->processEvents ();
+      qApp->processEvents (QEventLoop::WaitForMoreEvents);
    /* scanComplete() is emitted from the thread just before it finishes,
       so it may still be running: destroying it now would abort */
    scan.wait ();

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -28,6 +28,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "config.h"
 
 #include <QDebug>
+#include <time.h>
 #include <QDialogButtonBox>
 #include <QEventLoop>
 #include <QtGlobal>
@@ -463,6 +464,10 @@ void Mainwidget::scanInto(QModelIndex target)
    _scan_ok = false;
    _scan_pages = 0;
    _scan_summary.clear ();
+   _scan_stats.wall.start ();
+   _scan_stats.gui_cpu = threadCpuSeconds ();
+   _scan_stats.progress = 0;
+   _scan_stats.max_behind = 0;
    updatePscan ();
 
    /* Wait for the scan to finish, processing events as they arrive. Block
@@ -477,6 +482,20 @@ void Mainwidget::scanInto(QModelIndex target)
    /* scanComplete() is emitted from the thread just before it finishes,
       so it may still be running: destroying it now would abort */
    scan.wait ();
+   if (getenv ("PAPERMAN_SCAN_STATS"))
+      {
+      double wall = _scan_stats.wall.elapsed () / 1000.0;
+      double gui = threadCpuSeconds () - _scan_stats.gui_cpu;
+
+      qWarning ("scan stats: %d sides in %.1fs (%.0f ms/side); display "
+                "thread CPU %.2fs (%.0f%%), scanning thread CPU %.2fs "
+                "(%.0f%%); display was behind the scanner by up to %d "
+                "sides; %d progress messages",
+                _scan_pages, wall, _scan_pages ? wall * 1000 / _scan_pages : 0,
+                gui, wall ? gui * 100 / wall : 0, scan.cpuSeconds (),
+                wall ? scan.cpuSeconds () * 100 / wall : 0,
+                _scan_stats.max_behind, _scan_stats.progress);
+      }
    _scan = 0;
 //    qDebug () << "scan complete";
    _watchButtons = true;
@@ -528,6 +547,17 @@ void Mainwidget::slotStackNew (const QString &stack_name)
       if (err)
          _scan->cancelScan (err);
       }
+   }
+
+
+/* CPU time used so far by the calling thread, in seconds */
+double Mainwidget::threadCpuSeconds (void)
+   {
+   struct timespec ts;
+
+   if (clock_gettime (CLOCK_THREAD_CPUTIME_ID, &ts))
+      return 0;
+   return ts.tv_sec + ts.tv_nsec / 1e9;
    }
 
 
@@ -614,6 +644,8 @@ void Mainwidget::slotStackNewPage (const Filepage *mp, const QString &coverageSt
       if (!infostr.isEmpty ())
          info (infostr);
       _scan_pages++;
+      _scan_stats.max_behind = qMax (_scan_stats.max_behind,
+                                     _scan->sidesDone () - _scan_pages);
       if (_console)
          printf ("Page %d: %s\n", _scan_pages, qPrintable (coverageStr));
       err = _contents->addPageToScan (mp, coverageStr);
@@ -688,6 +720,7 @@ void Mainwidget::slotStackPageProgress (const PPage *page)
    /* let the scanning thread send another message for this page: any data
       arriving from here on is not covered by this one */
    _scan->progressHandled (page);
+   _scan_stats.progress++;
    if (!_scan_cancelling)
       {
       const char *data;

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -27,6 +27,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include "config.h"
 
+#include <QTimer>
 #include <QDebug>
 #include <time.h>
 #include <QDialogButtonBox>
@@ -115,6 +116,11 @@ Mainwidget::Mainwidget (QWidget *parent, const char *name)
    _scanning = false;
    _scan_ok = false;
    _scan_pages = 0;
+   _scan_first_page = -1;
+   _scan_rate_timer = new QTimer (this);
+   _scan_rate_timer->setInterval (1000);
+   connect (_scan_rate_timer, &QTimer::timeout, this,
+            [this] () { updateScanRate (); });
    _console = false;
 //    _stack = 0;
 
@@ -471,6 +477,10 @@ void Mainwidget::scanInto(QModelIndex target)
    _scan_stats.gui_cpu = threadCpuSeconds ();
    _scan_stats.progress = 0;
    _scan_stats.max_behind = 0;
+   _scan_page_times.clear ();
+   _scan_first_page = -1;
+   updateScanRate ();
+   _scan_rate_timer->start ();
    updatePscan ();
 
    /* Wait for the scan to finish, processing events as they arrive. Block
@@ -502,6 +512,8 @@ void Mainwidget::scanInto(QModelIndex target)
                 _scan_stats.progress);
       }
    _scan = 0;
+   /* leave the last rate showing, as a record of the scan */
+   _scan_rate_timer->stop ();
 //    qDebug () << "scan complete";
    _watchButtons = true;
    updatePscan ();
@@ -649,6 +661,11 @@ void Mainwidget::slotStackNewPage (const Filepage *mp, const QString &coverageSt
       if (!infostr.isEmpty ())
          info (infostr);
       _scan_pages++;
+      qint64 t = _scan_stats.wall.elapsed ();
+      if (_scan_page_times.isEmpty () && _scan_first_page < 0)
+         _scan_first_page = t;
+      _scan_page_times.append (t);
+      updateScanRate ();
       _scan_stats.max_behind = qMax (_scan_stats.max_behind,
                                      _scan->sidesDone () - _scan_pages);
       if (_console)
@@ -743,6 +760,32 @@ void Mainwidget::slotDoubleFeedDetected (void)
    // Show a message to the user that double-feed was detected
    // This is emitted from the scanning thread, so use queued connection behavior
    info (tr("Double feed detected - please clear the scanner"));
+   }
+
+
+void Mainwidget::updateScanRate (void)
+   {
+   const qint64 WINDOW_MS = 10000;
+   qint64 now = _scan_stats.wall.isValid () ? _scan_stats.wall.elapsed () : 0;
+
+   /* the window runs back ten seconds, or to the first page while the
+      scan is younger than that: counting from the start of the scan would
+      spread the pages over the scanner's warm-up as well and read low for
+      the first ten seconds. The page at the very start of a short window
+      is the window's origin, not part of the count */
+   qint64 window = qMin (now - _scan_first_page, WINDOW_MS);
+   int count = 0;
+   foreach (qint64 t, _scan_page_times)
+      if (t > now - window)
+         count++;
+   while (!_scan_page_times.isEmpty ()
+          && now - _scan_page_times.first () > WINDOW_MS)
+      _scan_page_times.removeFirst ();
+
+   /* below a second the figure would just be noise */
+   double rate = window >= 1000 ? count * 1000.0 / window : 0;
+   if (_pscan)
+      _pscan->progressRate (tr ("%1 pages/s").arg (rate, 0, 'f', 1));
    }
 
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -685,6 +685,9 @@ void Mainwidget::info (const QString &str)
 
 void Mainwidget::slotStackPageProgress (const PPage *page)
    {
+   /* let the scanning thread send another message for this page: any data
+      arriving from here on is not covered by this one */
+   _scan->progressHandled (page);
    if (!_scan_cancelling)
       {
       const char *data;

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -468,6 +468,9 @@ void Mainwidget::scanInto(QModelIndex target)
       /* note this will not allow the scanning thread to get events, but
          at the moment it doesn't have an event loop anyway */
       qApp->processEvents ();
+   /* scanComplete() is emitted from the thread just before it finishes,
+      so it may still be running: destroying it now would abort */
+   scan.wait ();
    _scan = 0;
 //    qDebug () << "scan complete";
    _watchButtons = true;

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -411,8 +411,8 @@ void Mainwidget::scanInto(QModelIndex target)
             _scanDialog = 0;
             if (_pscan)
                _pscan->setScanDialog (_scanDialog);
+            setupScanDialog ();
             }
-         setupScanDialog ();
          if (_pscan)
             _pscan->reapplyCurrentPreset ();
          status = _scanner->getParameters(&parameters);
@@ -615,8 +615,8 @@ void Mainwidget::slotScanComplete (SANE_Status status, const QString &msg, const
             _scanDialog = 0;
             if (_pscan)
                _pscan->setScanDialog (_scanDialog);
+            setupScanDialog ();
             }
-         setupScanDialog ();
          if (_pscan)
             _pscan->reapplyCurrentPreset ();
          inform ("Scanner reconnected",
@@ -851,8 +851,12 @@ void Mainwidget::setupScanDialog (void)
                   _scanDialog, SLOT (slotDoPendingChanges()));
    connect (_scanDialog, SIGNAL (warning (QString&)), this, SLOT (slotWarning (QString &)));
    _preview = _scanDialog->getPreview ();
-   _pscan->setPreviewWidget (_preview);
-   _pscan->setScanDialog (_scanDialog);
+   /* there is no scan window without a GUI, as in --scan mode */
+   if (_pscan)
+      {
+      _pscan->setPreviewWidget (_preview);
+      _pscan->setScanDialog (_scanDialog);
+      }
    updateScanDialog ();
    }
 

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -500,6 +500,9 @@ void Mainwidget::scanInto(QModelIndex target)
       double wall = _scan_stats.wall.elapsed () / 1000.0;
       double gui = threadCpuSeconds () - _scan_stats.gui_cpu;
 
+      qint64 t_start, t_read, t_data, t_confirm;
+
+      scan.phases (t_start, t_read, t_data, t_confirm);
       qWarning ("scan stats: %d sides in %.1fs (%.0f ms/side); display "
                 "thread CPU %.2fs (%.0f%%), scanning thread CPU %.2fs "
                 "(%.0f%%); display was behind the scanner by up to %d "
@@ -510,6 +513,12 @@ void Mainwidget::scanInto(QModelIndex target)
                 wall ? scan.cpuSeconds () * 100 / wall : 0,
                 _scan_stats.max_behind, scan.maxWaiting (),
                 _scan_stats.progress);
+      int n = _scan_pages ? _scan_pages : 1;
+      qWarning ("scan phases per side: start (fetch and decode) %lld ms, "
+                "read %lld ms, coverage %lld ms, confirm (turn and store) "
+                "%lld ms",
+                (long long) (t_start / n), (long long) (t_read / n),
+                (long long) (t_data / n), (long long) (t_confirm / n));
       }
    _scan = 0;
    /* leave the last rate showing, as a record of the scan */

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -608,33 +608,19 @@ void Mainwidget::slotScanComplete (SANE_Status status, const QString &msg, const
 
 //    qDebug () << "slotScanComplete" << status << msg << err;
 
-   // If the scanner went to sleep and woke up, the SANE handle is in a
-   // broken state. Reconnect it and reapply the active preset so the user
-   // can simply retry.
-   if (status == SANE_STATUS_IO_ERROR && _scanner)
-      {
-      if (_scanner->reconnect ())
-         {
-         // QScanDialog's QSaneOption widgets are bound to the old SANE
-         // handle; rebuild against the new handle before reapplying the
-         // preset, otherwise option writes go nowhere.
-         if (_scanDialog)
-            {
-            delete _scanDialog;
-            _scanDialog = 0;
-            if (_pscan)
-               _pscan->setScanDialog (_scanDialog);
-            setupScanDialog ();
-            }
-         if (_pscan)
-            _pscan->reapplyCurrentPreset ();
-         inform ("Scanner reconnected",
-            "The scanner connection was lost and has been re-established.\n"
-            "Please try the scan again.");
-         _scanning = false;
-         return;
-         }
-      }
+   /* A scan that ends in an I/O error leaves the SANE handle in a broken
+      state, and reconnecting recovers it. Do not do that here: this runs
+      on the GUI thread, inside the event loop scanInto() is spinning, and
+      a reconnect closes and reopens the device. When the scanner is not
+      answering, as a misfeed can leave it, every one of those calls waits
+      out the USB timeout of 30 seconds, and the interface is frozen for
+      the whole minute or more. That is exactly when the user is pressing
+      Stop, so Stop appears to do nothing.
+
+      Leave the handle alone and report what happened. The next scan finds
+      the stale handle when it asks for the scan parameters and reconnects
+      there, which is where a wait belongs: the user has just asked for
+      something and expects it to take a moment. */
 
    // don't report end of documents if we have managed to scan some
    if (status)

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -386,7 +386,10 @@ void Mainwidget::scanInto(QModelIndex target)
 
    if (!ensureScanner ())
       return;
+   /* the mode must be set first, since JPEG is only offered in colour;
+      anything --set names is left as set */
    applyScanOptions ();
+   _scanner->useFastTransfer (_scan_options.keys ());
 
    // check resolution, etc.
    status = _scanner->getParameters(&parameters);

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -538,7 +538,7 @@ void Mainwidget::applyScanOptions (void)
       else
          rest [it.key ()] = it.value ();
       }
-   _scanner->setOptionsByName (rest);
+   _scanner->setOptionsByName (rest, true);   // --set may set anything
    }
 
 void Mainwidget::slotStackNew (const QString &stack_name)

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -490,11 +490,13 @@ void Mainwidget::scanInto(QModelIndex target)
       qWarning ("scan stats: %d sides in %.1fs (%.0f ms/side); display "
                 "thread CPU %.2fs (%.0f%%), scanning thread CPU %.2fs "
                 "(%.0f%%); display was behind the scanner by up to %d "
-                "sides; %d progress messages",
+                "sides; scanner had up to %d images waiting; %d progress "
+                "messages",
                 _scan_pages, wall, _scan_pages ? wall * 1000 / _scan_pages : 0,
                 gui, wall ? gui * 100 / wall : 0, scan.cpuSeconds (),
                 wall ? scan.cpuSeconds () * 100 / wall : 0,
-                _scan_stats.max_behind, _scan_stats.progress);
+                _scan_stats.max_behind, scan.maxWaiting (),
+                _scan_stats.progress);
       }
    _scan = 0;
 //    qDebug () << "scan complete";

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -79,6 +79,36 @@ public:
    Mainwidget (QWidget *parent, const char *name = 0);
    ~Mainwidget();
    Desktopwidget *getDesktop (void) { return _desktop; }
+
+   /** report scan progress and results on stdout, for the command line */
+   void setConsole (bool console) { _console = console; }
+
+   /** scanner options to apply before each scan, by SANE option name:
+       fixed-point values are given in their units (mm, dpi) */
+   void setScanOptions (const QMap<QString, QString> &options)
+      { _scan_options = options; }
+
+   /** \returns true if the last scan completed without error */
+   bool scanOk (void) { return _scan_ok; }
+
+   /** \returns the number of pages received in the last scan */
+   int scanPages (void) { return _scan_pages; }
+
+   /** \returns the result message from the last scan */
+   QString scanSummary (void) { return _scan_summary; }
+
+   /** \returns the directory the last scan went into */
+   QString scanPath (void) { return _scan_path; }
+
+   /** report a problem: a warning dialog, or a console message when
+       running headless */
+   void warn (const QString &title, const QString &msg);
+
+   /** apply the options from setScanOptions() to the open scanner */
+   void applyScanOptions (void);
+
+   /** as for warn(), but for information */
+   void inform (const QString &title, const QString &msg);
    Pagewidget *getPage (void) { return _page; }
    Mainwindow *getMainwindow() { return _mainwindow; }
 
@@ -426,6 +456,11 @@ private:
    //! information about a scanning job in progress
    bool _scanning;         //!< true if scanning
    bool _scan_cancelling;  //!< true if cancelling the scan
+   bool _scan_ok;          //!< true if the last scan completed without error
+   int _scan_pages;        //!< pages received in the current scan
+   QString _scan_summary;  //!< result message from the last scan
+   bool _console;          //!< report scan progress on stdout
+   QMap<QString, QString> _scan_options;  //!< options to apply before scanning
 //   Paperstack *_stack;     //!< paper stack to scan into
    Paperscan *_scan;       //!< the current scan in progress
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -49,6 +49,7 @@ struct err_info;
 struct print_info;
 
 #include <QElapsedTimer>
+#include <QList>
 #include <QModelIndex>
 #include <QStackedWidget>
 
@@ -120,6 +121,11 @@ public:
 
    /** sets the displayed size of the scanned file so far */
    void progressSize (int size);
+
+   /** show the rate the scanner is delivering pages at: those finished in
+       the last ten seconds, or since the scan started if that is sooner,
+       so the figure settles quickly and follows a stall within seconds */
+   void updateScanRate (void);
 
    /** set the current information text */
    void info (const QString &str);
@@ -462,6 +468,9 @@ private:
    bool _scan_cancelling;  //!< true if cancelling the scan
    bool _scan_ok;          //!< true if the last scan completed without error
    int _scan_pages;        //!< pages received in the current scan
+   QList<qint64> _scan_page_times;  //!< when recent pages arrived, ms into the scan
+   qint64 _scan_first_page;  //!< when the first page arrived, ms into the scan, or -1
+   QTimer *_scan_rate_timer;  //!< refreshes the page rate while scanning
    struct {
       QElapsedTimer wall;  //!< since the scan started
       double gui_cpu;      //!< GUI-thread CPU seconds when the scan started

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -48,6 +48,7 @@ typedef struct file_info file_info;
 struct err_info;
 struct print_info;
 
+#include <QElapsedTimer>
 #include <QModelIndex>
 #include <QStackedWidget>
 
@@ -172,6 +173,9 @@ public:
 
    // Returns true if currently scanning
    bool isScanning();
+
+   //! CPU time used so far by the calling thread, in seconds
+   static double threadCpuSeconds (void);
 
    void setMainwindow(Mainwindow *mainwindow);
 
@@ -458,6 +462,12 @@ private:
    bool _scan_cancelling;  //!< true if cancelling the scan
    bool _scan_ok;          //!< true if the last scan completed without error
    int _scan_pages;        //!< pages received in the current scan
+   struct {
+      QElapsedTimer wall;  //!< since the scan started
+      double gui_cpu;      //!< GUI-thread CPU seconds when the scan started
+      int progress;        //!< progress messages received
+      int max_behind;      //!< most sides the display was behind the scan
+      } _scan_stats;       //!< for PAPERMAN_SCAN_STATS
    QString _scan_summary;  //!< result message from the last scan
    bool _console;          //!< report scan progress on stdout
    QMap<QString, QString> _scan_options;  //!< options to apply before scanning

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -22,6 +22,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 
 #include <QtGui>
+#include <QDir>
 #include <QMessageBox>
 #include <QSettings>
 #include <qvariant.h>
@@ -53,6 +54,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "desktopmodel.h"
 #include "desktopundo.h"
 #include "desktopwidget.h"
+#include "dirmodel.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
 #include "pagewidget.h"
@@ -162,6 +164,100 @@ void Mainwindow::shutdown()
    if (xmlConfig)
       delete xmlConfig;
 }
+
+int Mainwindow::runScan(const QString& repo, const QString& subdir,
+                        const QString& device, int pages,
+                        const QStringList& settings)
+{
+   Mainwindow me;
+   Desktopwidget *desktop = me.getDesktop();
+   Mainwidget *main = me._main;
+   Dirmodel *dirs = desktop->getDirmodel();
+
+   utilSetHeadless(true);
+   main->setConsole(true);
+
+   QMap<QString, QString> options;
+   foreach (const QString &setting, settings) {
+      int eq = setting.indexOf('=');
+      if (eq <= 0) {
+         fprintf(stderr, "Expected NAME=VALUE for --set, not '%s'\n",
+                 qPrintable(setting));
+         return 1;
+      }
+      options[setting.left(eq)] = setting.mid(eq + 1);
+   }
+   main->setScanOptions(options);
+
+   // the configured repositories, then the one asked for if it is new
+   QList<err_info> err_list = desktop->addRepositories(QStringList());
+   foreach (const err_info &err, err_list)
+      fprintf(stderr, "Warning: %s\n", err.errstr);
+
+   QString repoPath;
+   if (!repo.isEmpty()) {
+      repoPath = QDir(repo).canonicalPath();
+      if (repoPath.isEmpty()) {
+         fprintf(stderr, "Repository '%s' not found\n", qPrintable(repo));
+         return 1;
+      }
+      if (!dirs->index(repoPath + "/", 0).isValid()) {
+         err_info *err = desktop->addDir(repoPath);
+         if (err) {
+            fprintf(stderr, "Cannot use repository '%s': %s\n",
+                    qPrintable(repo), err->errstr);
+            return 1;
+         }
+      }
+   } else {
+      if (!dirs->rowCount(QModelIndex())) {
+         fprintf(stderr, "No repository is configured: use --repo\n");
+         return 1;
+      }
+      repoPath = dirs->data(dirs->index(0, 0, QModelIndex()),
+                            Dirmodel::FilePathRole).toString();
+      if (repoPath.endsWith("/"))
+         repoPath.chop(1);
+   }
+
+   QString path = repoPath;
+   if (!subdir.isEmpty())
+      path += "/" + subdir;
+   if (!QDir(path).exists()) {
+      fprintf(stderr, "Directory '%s' does not exist\n", qPrintable(path));
+      return 1;
+   }
+   QModelIndex target = desktop->getDirIndex(path + "/");
+   if (!target.isValid()) {
+      fprintf(stderr, "Directory '%s' is not within a repository\n",
+              qPrintable(path));
+      return 1;
+   }
+
+   /* the scanner and page limit are taken from the saved scanner
+      settings; override them for this run only */
+   if (!xmlConfig)
+      new QXmlConfig();
+   QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
+   int old_single = xmlConfig->intValue("SCAN_SINGLE");
+   if (!device.isEmpty())
+      xmlConfig->setStringValue("LAST_DEVICE", device);
+   if (pages)
+      xmlConfig->setIntValue("SCAN_SINGLE", pages);
+
+   printf("Scanning into %s\n", qPrintable(path));
+   main->scanInto(target);
+
+   xmlConfig->setStringValue("LAST_DEVICE", old_device);
+   xmlConfig->setIntValue("SCAN_SINGLE", old_single);
+
+   if (!main->scanOk() || !main->scanPages()) {
+      fprintf(stderr, "Scan failed: %s\n", qPrintable(main->scanSummary()));
+      return 1;
+   }
+   return 0;
+}
+
 
 void Mainwindow::runGui(QApplication& app, QStringList args,
                         const QString& serverUrl)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -221,7 +221,8 @@ void Mainwindow::shutdown()
 
 int Mainwindow::runScan(const QString& repo, const QString& subdir,
                         const QString& device, int pages,
-                        const QStringList& settings, bool autoColour)
+                        const QStringList& settings, bool autoColour,
+                        int sideways)
 {
    Mainwindow me;
    Desktopwidget *desktop = me.getDesktop();
@@ -295,12 +296,15 @@ int Mainwindow::runScan(const QString& repo, const QString& subdir,
    QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
    int old_single = xmlConfig->intValue("SCAN_SINGLE");
    bool old_auto_colour = xmlConfig->boolValue("SCAN_AUTO_COLOUR");
+   int old_sideways = xmlConfig->intValue("SCAN_SIDEWAYS");
    if (!device.isEmpty())
       xmlConfig->setStringValue("LAST_DEVICE", device);
    if (pages)
       xmlConfig->setIntValue("SCAN_SINGLE", pages);
    if (autoColour)
       xmlConfig->setBoolValue("SCAN_AUTO_COLOUR", true);
+   if (sideways)
+      xmlConfig->setIntValue("SCAN_SIDEWAYS", sideways);
 
    printf("Scanning into %s\n", qPrintable(path));
    main->scanInto(target);
@@ -308,6 +312,7 @@ int Mainwindow::runScan(const QString& repo, const QString& subdir,
    xmlConfig->setStringValue("LAST_DEVICE", old_device);
    xmlConfig->setIntValue("SCAN_SINGLE", old_single);
    xmlConfig->setBoolValue("SCAN_AUTO_COLOUR", old_auto_colour);
+   xmlConfig->setIntValue("SCAN_SIDEWAYS", old_sideways);
 
    if (!main->scanOk() || !main->scanPages()) {
       fprintf(stderr, "Scan failed: %s\n", qPrintable(main->scanSummary()));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -221,7 +221,7 @@ void Mainwindow::shutdown()
 
 int Mainwindow::runScan(const QString& repo, const QString& subdir,
                         const QString& device, int pages,
-                        const QStringList& settings)
+                        const QStringList& settings, bool autoColour)
 {
    Mainwindow me;
    Desktopwidget *desktop = me.getDesktop();
@@ -294,16 +294,20 @@ int Mainwindow::runScan(const QString& repo, const QString& subdir,
       new QXmlConfig();
    QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
    int old_single = xmlConfig->intValue("SCAN_SINGLE");
+   bool old_auto_colour = xmlConfig->boolValue("SCAN_AUTO_COLOUR");
    if (!device.isEmpty())
       xmlConfig->setStringValue("LAST_DEVICE", device);
    if (pages)
       xmlConfig->setIntValue("SCAN_SINGLE", pages);
+   if (autoColour)
+      xmlConfig->setBoolValue("SCAN_AUTO_COLOUR", true);
 
    printf("Scanning into %s\n", qPrintable(path));
    main->scanInto(target);
 
    xmlConfig->setStringValue("LAST_DEVICE", old_device);
    xmlConfig->setIntValue("SCAN_SINGLE", old_single);
+   xmlConfig->setBoolValue("SCAN_AUTO_COLOUR", old_auto_colour);
 
    if (!main->scanOk() || !main->scanPages()) {
       fprintf(stderr, "Scan failed: %s\n", qPrintable(main->scanSummary()));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -110,6 +110,14 @@ Mainwindow::Mainwindow(QWidget* parent, const char* name, Qt::WindowFlags fl)
  */
 Mainwindow::~Mainwindow()
 {
+   /* The page view decodes thumbnails on a background thread, reading
+      from the desktop model through a bare pointer. Qt destroys child
+      widgets in its own order, so that model can go while the thread is
+      still in a decode, which crashes. This destructor body runs before
+      any of the children, so it is the one place the thread can be
+      stopped while everything it touches is still there */
+   if (_main && _main->getPage ())
+      _main->getPage ()->stopRendering ();
     // no need to delete child widgets, Qt does it all for us
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -24,6 +24,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QtGui>
 #include <QDir>
 #include <QMessageBox>
+#include <QScreen>
 #include <QSettings>
 #include <qvariant.h>
 
@@ -102,6 +103,51 @@ Mainwindow::Mainwindow(QWidget* parent, const char* name, Qt::WindowFlags fl)
 
    addAction(actionPscan);
    addAction(actionScango);
+
+   /* with PAPERMAN_SNAP=<dir>, save what is on screen once a second (or
+      every PAPERMAN_SNAP_MS milliseconds), to see what the display
+      actually showed when, against a log */
+   _snapTimer = 0;
+   _snapCount = 0;
+   _snapDir = QString::fromLocal8Bit(qgetenv("PAPERMAN_SNAP"));
+   if (!_snapDir.isEmpty() && QDir().mkpath(_snapDir)) {
+      /* --clean-snaps: start with an empty directory, so the files are
+         only this run's. Only our own files are touched */
+      if (!qgetenv("PAPERMAN_SNAP_CLEAN").isEmpty()) {
+         QDir dir(_snapDir);
+         foreach (const QString &old,
+                  dir.entryList(QStringList() << "snap-*.jpg", QDir::Files))
+            dir.remove(old);
+      }
+      _snapTimer = new QTimer(this);
+      connect(_snapTimer, SIGNAL(timeout()), this, SLOT(snapWindow()));
+      _snapClock.start();
+      int interval = qgetenv("PAPERMAN_SNAP_MS").toInt();
+      _snapTimer->start(interval > 0 ? interval : 1000);
+   }
+}
+
+
+void Mainwindow::snapWindow()
+{
+   if (!isVisible())
+      return;
+
+   /* grab the screen's pixels rather than render the widgets, so the
+      snapshot shows what the user sees even when the display has not
+      caught up with the widgets' state */
+   QScreen *scr = screen();
+   if (!scr)
+      return;
+   QPixmap pm = scr->grabWindow(winId());
+   if (pm.isNull())
+      return;
+   /* name by elapsed milliseconds, so frames line up with a timestamped
+      log at better than a second */
+   QString name = QString("%1/snap-%2-%3ms.jpg").arg(_snapDir)
+      .arg(++_snapCount, 4, 10, QChar('0'))
+      .arg(_snapClock.elapsed(), 6, 10, QChar('0'));
+   pm.save(name, "jpg", 85);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -67,6 +67,19 @@ public:
    static void runGui(QApplication& app, QStringList args,
                       const QString& serverUrl = QString());
 
+   /** Scan from the command line, without showing the GUI
+
+      \param repo     repository to scan into (empty for the first one
+                      configured)
+      \param subdir   directory within the repository (empty for its top)
+      \param device   scanner to use (empty for the last one used)
+      \param pages    maximum number of sides to scan (0 for no limit)
+      \param settings scanner options to set, as name=value
+      \returns exit code: 0 on success */
+   static int runScan(const QString& repo, const QString& subdir,
+                      const QString& device, int pages,
+                      const QStringList& settings = QStringList());
+
 public slots:
     virtual void on_actionPrint_triggered(bool);
     virtual void on_actionExit_triggered(bool);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -80,7 +80,8 @@ public:
       \returns exit code: 0 on success */
    static int runScan(const QString& repo, const QString& subdir,
                       const QString& device, int pages,
-                      const QStringList& settings = QStringList());
+                      const QStringList& settings = QStringList(),
+                      bool autoColour = false);
 
 public slots:
     virtual void on_actionPrint_triggered(bool);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -77,11 +77,14 @@ public:
       \param device   scanner to use (empty for the last one used)
       \param pages    maximum number of sides to scan (0 for no limit)
       \param settings scanner options to set, as name=value
+      \param autoColour  true to store pages without colour as grey or mono
+      \param sideways    how the sheets are fed (Paperstack::t_sideways),
+                         0 for upright
       \returns exit code: 0 on success */
    static int runScan(const QString& repo, const QString& subdir,
                       const QString& device, int pages,
                       const QStringList& settings = QStringList(),
-                      bool autoColour = false);
+                      bool autoColour = false, int sideways = 0);
 
 public slots:
     virtual void on_actionPrint_triggered(bool);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,6 +21,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
  Public License can be found in the /usr/share/common-licenses/GPL file.
 */
 
+#include <QElapsedTimer>
+#include <QTimer>
 #include "ui_mainwindow.h"
 #include "op.h"
 
@@ -112,6 +114,10 @@ public slots:
 
     void on_actionDirFilter_triggered(bool state);
 
+    /** save a snapshot of the window as shown on screen, for diagnosing
+        display problems (see PAPERMAN_SNAP) */
+    void snapWindow ();
+
 protected slots:
     virtual void languageChange();
     void closeEvent(QCloseEvent *event);
@@ -129,4 +135,9 @@ private:
     //! true if we have already shown the welcome message
     bool _welcome_shown;
     Desktopwidget *_desktop;
+
+    QTimer *_snapTimer;      //!< snapshot timer, or NULL (PAPERMAN_SNAP)
+    QString _snapDir;        //!< where the snapshots go
+    QElapsedTimer _snapClock; //!< time since the first snapshot
+    int _snapCount;          //!< snapshots taken so far
 };

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -534,6 +534,12 @@ static void usage (void)
    printf ("   --rebuild-previews FILE|DIR  regenerate missing greyscale previews\n");
    printf ("   --adjust TYPE FILE  apply image adjustment (e.g. whiten) to a stack\n");
    printf ("   --quality N         JPEG quality 1-100 for PDF output (default 75)\n");
+   printf ("   --scan              scan into a repository without the GUI, with:\n");
+   printf ("     --repo DIR          repository (default: the first configured)\n");
+   printf ("     --dir SUBDIR        directory within the repository (default: top)\n");
+   printf ("     --device NAME       scanner (default: the last one used)\n");
+   printf ("     --pages N           stop after N sides (default: until empty)\n");
+   printf ("     --set NAME=VALUE    set a scanner option, e.g. mode=Color\n");
 /*
    printf ("\n");
    printf ("If none of -p, -m, -j are specified, maxview opens in desktop "
@@ -598,6 +604,12 @@ int main (int argc, char *argv[])
      {"adjust", 1, 0, 260},
      {"quality", 1, 0, 261},
      {"server", 1, 0, 262},
+     {"scan", 0, 0, 263},
+     {"repo", 1, 0, 264},
+     {"dir", 1, 0, 265},
+     {"device", 1, 0, 266},
+     {"pages", 1, 0, 267},
+     {"set", 1, 0, 268},
      {0, 0, 0, 0}
    };
    int op_type = -1, c;
@@ -610,6 +622,9 @@ int main (int argc, char *argv[])
    int quality = 75;                      // JPEG quality (1-100)
    QString adjust_name;
    QString serverUrl;                     // --server URL
+   QString scanRepo, scanDir, scanDevice; // --scan options
+   QStringList scanSettings;
+   int scanPages = 0;
 
 #ifndef Q_OS_WIN
    struct rlimit limit;
@@ -693,6 +708,30 @@ int main (int argc, char *argv[])
                }
             break;
 
+         case 263 :    // --scan
+            op_type = 263;
+            break;
+
+         case 264 :    // --repo
+            scanRepo = optarg;
+            break;
+
+         case 265 :    // --dir
+            scanDir = optarg;
+            break;
+
+         case 266 :    // --device
+            scanDevice = optarg;
+            break;
+
+         case 267 :    // --pages
+            scanPages = atoi (optarg);
+            break;
+
+         case 268 :    // --set NAME=VALUE
+            scanSettings << optarg;
+            break;
+
          case 262 :    // --server URL
             serverUrl = QString(optarg);
             break;
@@ -713,7 +752,7 @@ int main (int argc, char *argv[])
 
    if (!dir && op_type != 't' && op_type != 'p' && op_type != 'm' &&
        op_type != 'j' && op_type != 'o' && op_type != 'q' &&
-       op_type != 259 && op_type != 260)
+       op_type != 259 && op_type != 260 && op_type != 263)
       need_gui = true;
 
 #ifdef Q_WS_X11
@@ -723,6 +762,13 @@ int main (int argc, char *argv[])
 #endif
    if (op_type == 't')
       useGUI = true;
+
+   // the command-line scan uses the desktop machinery without a display
+   if (op_type == 263)
+      {
+      useGUI = true;
+      qputenv("QT_QPA_PLATFORM", "offscreen");
+      }
 
    // OCR batch mode, search, and rebuild-previews don't need GUI
    if (op_type == 'o' || op_type == 'q' || op_type == 259 ||
@@ -823,7 +869,7 @@ int main (int argc, char *argv[])
          /* keep the results visible if a test hangs and is killed, and
             report errors to the console rather than in a dialog */
          setvbuf (stdout, NULL, _IONBF, 0);
-         utilSetTestMode (true);
+         utilSetHeadless (true);
 
          /* on Windows Qt sends test results and log messages to the
             debugger unless told to use stderr */
@@ -943,6 +989,10 @@ int main (int argc, char *argv[])
          break;
          }
 #endif
+      case 263 :
+         return Mainwindow::runScan (scanRepo, scanDir, scanDevice,
+                                     scanPages, scanSettings);
+
       case 259 :
          {
          QFileInfo info(fname);

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -544,6 +544,8 @@ static void usage (void)
    printf ("     --pages N           stop after N sides (default: until empty)\n");
    printf ("     --set NAME=VALUE    set a scanner option, e.g. mode=Color\n");
    printf ("     --auto-colour       store pages without colour as grey or mono\n");
+   printf ("     --sideways SIDE     sheets are fed sideways with the top of the\n");
+   printf ("                         page at the left or right: turn them upright\n");
    printf ("   --snap DIR          save a snapshot of the window every second\n");
    printf ("                       (or every PAPERMAN_SNAP_MS milliseconds)\n");
    printf ("                       into DIR (the same as PAPERMAN_SNAP=DIR)\n");
@@ -690,6 +692,7 @@ int main (int argc, char *argv[])
      {"pages", 1, 0, 267},
      {"set", 1, 0, 268},
      {"auto-colour", 0, 0, 271},
+     {"sideways", 1, 0, 272},
      {"snap", 1, 0, 269},
      {"clean-snaps", 0, 0, 270},
      {0, 0, 0, 0}
@@ -708,6 +711,7 @@ int main (int argc, char *argv[])
    QStringList scanSettings;
    int scanPages = 0;
    bool scanAutoColour = false;           // --auto-colour
+   int scanSideways = 0;                  // --sideways, Paperstack::t_sideways
 
 #ifndef Q_OS_WIN
    struct rlimit limit;
@@ -826,6 +830,18 @@ int main (int argc, char *argv[])
 
          case 271 :    // --auto-colour
             scanAutoColour = true;
+            break;
+
+         case 272 :    // --sideways left|right
+            if (!strcmp (optarg, "left"))
+               scanSideways = 1;
+            else if (!strcmp (optarg, "right"))
+               scanSideways = 2;
+            else
+               {
+               fprintf (stderr, "--sideways needs left or right\n");
+               return 1;
+               }
             break;
 
          case 262 :    // --server URL
@@ -1090,7 +1106,8 @@ int main (int argc, char *argv[])
 #endif
       case 263 :
          return Mainwindow::runScan (scanRepo, scanDir, scanDevice,
-                                     scanPages, scanSettings, scanAutoColour);
+                                     scanPages, scanSettings, scanAutoColour,
+                                     scanSideways);
 
       case 259 :
          {

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -540,6 +540,7 @@ static void usage (void)
    printf ("     --device NAME       scanner (default: the last one used)\n");
    printf ("     --pages N           stop after N sides (default: until empty)\n");
    printf ("     --set NAME=VALUE    set a scanner option, e.g. mode=Color\n");
+   printf ("     --auto-colour       store pages without colour as grey or mono\n");
    printf ("   --snap DIR          save a snapshot of the window every second\n");
    printf ("                       (or every PAPERMAN_SNAP_MS milliseconds)\n");
    printf ("                       into DIR (the same as PAPERMAN_SNAP=DIR)\n");
@@ -614,6 +615,7 @@ int main (int argc, char *argv[])
      {"device", 1, 0, 266},
      {"pages", 1, 0, 267},
      {"set", 1, 0, 268},
+     {"auto-colour", 0, 0, 271},
      {"snap", 1, 0, 269},
      {"clean-snaps", 0, 0, 270},
      {0, 0, 0, 0}
@@ -631,6 +633,7 @@ int main (int argc, char *argv[])
    QString scanRepo, scanDir, scanDevice; // --scan options
    QStringList scanSettings;
    int scanPages = 0;
+   bool scanAutoColour = false;           // --auto-colour
 
 #ifndef Q_OS_WIN
    struct rlimit limit;
@@ -744,6 +747,10 @@ int main (int argc, char *argv[])
 
          case 268 :    // --set NAME=VALUE
             scanSettings << optarg;
+            break;
+
+         case 271 :    // --auto-colour
+            scanAutoColour = true;
             break;
 
          case 262 :    // --server URL
@@ -1005,7 +1012,7 @@ int main (int argc, char *argv[])
 #endif
       case 263 :
          return Mainwindow::runScan (scanRepo, scanDir, scanDevice,
-                                     scanPages, scanSettings);
+                                     scanPages, scanSettings, scanAutoColour);
 
       case 259 :
          {

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -540,6 +540,10 @@ static void usage (void)
    printf ("     --device NAME       scanner (default: the last one used)\n");
    printf ("     --pages N           stop after N sides (default: until empty)\n");
    printf ("     --set NAME=VALUE    set a scanner option, e.g. mode=Color\n");
+   printf ("   --snap DIR          save a snapshot of the window every second\n");
+   printf ("                       (or every PAPERMAN_SNAP_MS milliseconds)\n");
+   printf ("                       into DIR (the same as PAPERMAN_SNAP=DIR)\n");
+   printf ("   --clean-snaps       first remove the snapshots already in DIR\n");
 /*
    printf ("\n");
    printf ("If none of -p, -m, -j are specified, maxview opens in desktop "
@@ -610,6 +614,8 @@ int main (int argc, char *argv[])
      {"device", 1, 0, 266},
      {"pages", 1, 0, 267},
      {"set", 1, 0, 268},
+     {"snap", 1, 0, 269},
+     {"clean-snaps", 0, 0, 270},
      {0, 0, 0, 0}
    };
    int op_type = -1, c;
@@ -710,6 +716,14 @@ int main (int argc, char *argv[])
 
          case 263 :    // --scan
             op_type = 263;
+            break;
+
+         case 269 :    // --snap DIR: the same as PAPERMAN_SNAP=DIR
+            qputenv ("PAPERMAN_SNAP", optarg);
+            break;
+
+         case 270 :    // --clean-snaps: remove old snapshots first
+            qputenv ("PAPERMAN_SNAP_CLEAN", "1");
             break;
 
          case 264 :    // --repo

--- a/maxview.cpp
+++ b/maxview.cpp
@@ -36,6 +36,7 @@ C           copy        scan and print to default printer, save to 'photocopy' f
 #include <QDir>
 #include <QDirIterator>
 #include <QFile>
+#include <QDateTime>
 #include <QFileInfo>
 #include <QStandardPaths>
 #include <QImage>
@@ -513,6 +514,8 @@ static void usage (void)
    printf ("   -p|--pdf        convert given file to .pdf\n");
    printf ("   -m|--max        convert given file to .max\n");
    printf ("   -j|--jpeg       convert given file to .jpg\n");
+   printf ("   -l|--list       list the pages in a stack with their size,\n");
+   printf ("                   depth and compressed size\n");
 /*
    printf ("   -v|--verbose    be verbose\n");
 */
@@ -551,6 +554,76 @@ static void usage (void)
           "mode, displaying\nthumbails of the given directory\n");
 */
    }
+
+/** List the pages of a stack, one per line, with the totals at the end
+
+   \param fname   the stack to list
+   \returns exit code: 0 on success */
+static int listPages (const QString &fname)
+   {
+   QFileInfo fi (fname);
+
+   if (!fi.exists ())
+      {
+      fprintf (stderr, "File not found: %s\n", qPrintable (fname));
+      return 1;
+      }
+
+   QString dir = fi.absolutePath () + '/';
+   File::e_type type = File::typeFromName (fi.fileName ());
+   File *file = File::createFile (dir, fi.fileName (), nullptr, type);
+
+   if (!file)
+      {
+      fprintf (stderr, "Unsupported file type: %s\n", qPrintable (fname));
+      return 1;
+      }
+
+   err_info *err = file->load ();
+
+   if (err)
+      {
+      fprintf (stderr, "Error loading %s: %s\n", qPrintable (fname),
+               err->errstr);
+      delete file;
+      return 1;
+      }
+
+   int count = file->pagecount ();
+   int depths [3] = {0, 0, 0};   // mono, grey, colour
+   qint64 total = 0;
+
+   printf ("%4s  %-24s %5s x %-5s  %-6s %9s  %s\n", "page", "name", "width",
+           "height", "depth", "bytes", "time");
+   for (int i = 0; i < count; i++)
+      {
+      QSize size, true_size;
+      int bpp, image_size, compressed;
+      QDateTime dt;
+      QString title;
+
+      err = file->getImageInfo (i, size, true_size, bpp, image_size,
+                                compressed, dt);
+      if (err)
+         {
+         printf ("%4d  error: %s\n", i + 1, err->errstr);
+         continue;
+         }
+      if (file->getPageTitle (i, title))
+         title = "?";
+      depths [bpp == 1 ? 0 : bpp == 8 ? 1 : 2]++;
+      total += compressed;
+      printf ("%4d  %-24s %5d x %-5d  %-6s %9d  %s\n", i + 1,
+              qPrintable (title), size.width (), size.height (),
+              bpp == 1 ? "mono" : bpp == 8 ? "grey" : "colour", compressed,
+              qPrintable (dt.toString ("yyyy-MM-dd hh:mm:ss")));
+      }
+   printf ("%d pages: %d mono, %d grey, %d colour, %lld bytes\n", count,
+           depths [0], depths [1], depths [2], (long long)total);
+   delete file;
+   return 0;
+   }
+
 
 int main (int argc, char *argv[])
    {
@@ -598,6 +671,7 @@ int main (int argc, char *argv[])
      {"relocate", 0, 0, 'r'},
 */
      {"sum", 1, 0, 's'},
+     {"list", 1, 0, 'l'},
      {"test", 0, 0, 't'},
      /*
      {"verbose", 0, 0, 'v'},
@@ -648,7 +722,7 @@ int main (int argc, char *argv[])
    }
 #endif
 
-   while (c = getopt_long (argc, argv, "hj:m:o:p:q:s:t",
+   while (c = getopt_long (argc, argv, "hj:l:m:o:p:q:s:t",
                            long_options, NULL), c != -1)
       switch (c)
          {
@@ -658,6 +732,7 @@ int main (int argc, char *argv[])
             op_type = c;
             break;
          case 'j' :
+         case 'l' :
          case 'm' :
          case 'p' :
             fname = optarg;
@@ -772,7 +847,7 @@ int main (int argc, char *argv[])
          }
 
    if (!dir && op_type != 't' && op_type != 'p' && op_type != 'm' &&
-       op_type != 'j' && op_type != 'o' && op_type != 'q' &&
+       op_type != 'j' && op_type != 'l' && op_type != 'o' && op_type != 'q' &&
        op_type != 259 && op_type != 260 && op_type != 263)
       need_gui = true;
 
@@ -792,8 +867,8 @@ int main (int argc, char *argv[])
       }
 
    // OCR batch mode, search, and rebuild-previews don't need GUI
-   if (op_type == 'o' || op_type == 'q' || op_type == 259 ||
-       op_type == 260)
+   if (op_type == 'o' || op_type == 'q' || op_type == 'l' ||
+       op_type == 259 || op_type == 260)
       {
       useGUI = false;
       // Force offscreen platform for console mode
@@ -910,6 +985,9 @@ int main (int argc, char *argv[])
 #endif
          break;
          }
+      case 'l' :
+         return listPages (fname);
+
       case 'j' :
       case 'p' :
          {

--- a/mem.cpp
+++ b/mem.cpp
@@ -29,19 +29,6 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "mem.h"
 
 
-void mem_check (void)
-{
-    void *ptr;
-    int i;
-
-    for (i = 0; i < 50; i++)
-    {
-        ptr = malloc (rand () % 100000);
-        free (ptr);
-    }
-}
-
-
 err_info *mem_alloc (void **ptr, int size, const char *func_name)
    {
    *ptr = NULL;

--- a/mem.h
+++ b/mem.h
@@ -36,5 +36,3 @@ struct err_info *mem_str (void **ptr, const char *str, const char *func_name);
 
 /** reallocate memory for string: free (*ptr); *ptr = strdup (str) */
 err_info *mem_restr (void **ptr, const char *str, const char *func_name);
-
-void mem_check (void);

--- a/pagedelegate.cpp
+++ b/pagedelegate.cpp
@@ -156,11 +156,17 @@ void Pagedelegate::measureItem (const QStyleOptionViewItem &option, const QModel
       leftmost = measure.coverageRect.left ();
       }
 
-   measure.size = _pagesize;
-   measure.size.setHeight (_pagesize.height () + lines * fmb.height ());
-
    QPixmap pm = pi->pixmap (measure.dodgy);
    measure.pixmap = pm;
+   /* size the cell to the page's own shape, so a landscape page does not
+      sit in a portrait-tall box. The pixmap (the scan image while
+      scanning, the scaled page once loaded) carries the real aspect;
+      before it is ready fall back to the full box and re-measure when it
+      arrives (see Pageview's relayout on dataChanged) */
+   int pageHeight = pm.height () > 0 ? pm.height () : _pagesize.height ();
+
+   measure.size = _pagesize;
+   measure.size.setHeight (pageHeight + lines * fmb.height ());
    measure.pixmapRect = QRect ((_pagesize.width () - pm.width ()) / 2, 0,
          pm.width (), pm.height ());
 
@@ -171,11 +177,11 @@ void Pagedelegate::measureItem (const QStyleOptionViewItem &option, const QModel
    measure.pagenameRect = QRect (measure.pagenumRect.width () + 5, 0,
       leftmost - 5, fmb.height ());
 
-   measure.pagenumRect.translate (0, _pagesize.height () + 3);
-   measure.pagenameRect.translate (0, _pagesize.height () + 3);
-   measure.coverageRect.translate (0, _pagesize.height () + 3);
-   measure.blankRect.translate (0, _pagesize.height ());
-   measure.removeRect.translate (0, _pagesize.height ());
+   measure.pagenumRect.translate (0, pageHeight + 3);
+   measure.pagenameRect.translate (0, pageHeight + 3);
+   measure.coverageRect.translate (0, pageHeight + 3);
+   measure.blankRect.translate (0, pageHeight);
+   measure.removeRect.translate (0, pageHeight);
 
    if (offset)
       {

--- a/pagedelegate.cpp
+++ b/pagedelegate.cpp
@@ -73,6 +73,11 @@ If there is no room, the name gets dropped
 
 
 
+/** the gap between the bottom of a page and its label, and the gap the
+    cell keeps clear under the label */
+#define LABEL_TOP 3
+#define LABEL_GAP 8
+
 Pagedelegate::Pagedelegate (QObject *parent)
       : QAbstractItemDelegate (parent)
    {
@@ -166,8 +171,12 @@ void Pagedelegate::measureItem (const QStyleOptionViewItem &option, const QModel
       arrives (see Pageview's relayout on dataChanged) */
    int pageHeight = pm.height () > 0 ? pm.height () : _pagesize.height ();
 
+   /* the label sits LABEL_TOP below the page, and the cell keeps
+      LABEL_GAP clear under it so the label does not run into the row
+      beneath */
    measure.size = _pagesize;
-   measure.size.setHeight (pageHeight + lines * fmb.height ());
+   measure.size.setHeight (pageHeight + LABEL_TOP + lines * fmb.height ()
+         + LABEL_GAP);
    measure.pixmapRect = QRect ((_pagesize.width () - pm.width ()) / 2, 0,
          pm.width (), pm.height ());
 
@@ -178,9 +187,9 @@ void Pagedelegate::measureItem (const QStyleOptionViewItem &option, const QModel
    measure.pagenameRect = QRect (measure.pagenumRect.width () + 5, 0,
       leftmost - 5, fmb.height ());
 
-   measure.pagenumRect.translate (0, pageHeight + 3);
-   measure.pagenameRect.translate (0, pageHeight + 3);
-   measure.coverageRect.translate (0, pageHeight + 3);
+   measure.pagenumRect.translate (0, pageHeight + LABEL_TOP);
+   measure.pagenameRect.translate (0, pageHeight + LABEL_TOP);
+   measure.coverageRect.translate (0, pageHeight + LABEL_TOP);
    measure.blankRect.translate (0, pageHeight);
    measure.removeRect.translate (0, pageHeight);
 

--- a/pagedelegate.cpp
+++ b/pagedelegate.cpp
@@ -29,6 +29,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include "pagedelegate.h"
 #include "pagemodel.h"
+#include "utils.h"
 
 
 /*
@@ -225,20 +226,20 @@ void Pagedelegate::paint (QPainter *painter, const QStyleOptionViewItem &option,
       painter->fillRect (measure.rect, QBrush (Qt::DiagCrossPattern));
 
    style->drawItemText (painter, measure.pagenumRect, Qt::AlignLeft,
-         style->standardPalette (), false, QString ("%1").arg (measure.pagenum));
+         utilStylePalette (style), false, QString ("%1").arg (measure.pagenum));
    f.setBold (false);
    painter->setFont (f);
 
    if (option.state & QStyle::State_Selected)
-      painter->fillRect (measure.pagenameRect, style->standardPalette().color(QPalette::Highlight));
+      painter->fillRect (measure.pagenameRect, utilStylePalette (style).color(QPalette::Highlight));
    style->drawItemText (painter, measure.pagenameRect, Qt::AlignLeft,
-         style->standardPalette (), false, measure.pagename,
+         utilStylePalette (style), false, measure.pagename,
          option.state & QStyle::State_Selected
              ? QPalette::HighlightedText : QPalette::WindowText);
 
    if (_display & Display_coverage)
       style->drawItemText (painter, measure.coverageRect, Qt::AlignLeft,
-         style->standardPalette (), false, measure.coverageStr,
+         utilStylePalette (style), false, measure.coverageStr,
          QPalette::WindowText);
 
    if (measure.blank)

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -558,9 +558,19 @@ void Pagemodel::beginningScan (void)
 
 void Pagemodel::endingScan (void)
    {
+   bool pending = false;
+
 //    qDebug () << "endingScan";
    _own_scan = false;
    _lost_scan = false;
+
+   /* the pages just scanned are showing their live previews: now that
+      the render thread may read the file again, have it generate the
+      proper thumbnails in the background */
+   for (int i = 0; i < _count; i++)
+      pending |= _pages [i].finishProvisional ();
+   if (pending)
+      scheduleRescale ();
    }
 
 
@@ -797,6 +807,7 @@ Pageinfo::Pageinfo (void)
    _model = 0;
    _size = QSize ();
    _rescale = false;
+   _provisional = false;
    }
 
 
@@ -843,6 +854,7 @@ void Pageinfo::haltRescale ()
 void Pageinfo::invalidate ()
    {
    _valid = false;
+   _provisional = false;
    _coverage = "";
    _blank = _remove = _scanning = false;
    }
@@ -851,8 +863,25 @@ void Pageinfo::invalidate ()
 void Pageinfo::scanDone (QString coverage, bool mark_blank)
    {
    setCoverage (coverage);
-   _rescale = true;  // force a regenerate of the pixmap
-//    _valid = false;
+
+   /* The preview built up while the page was scanning is a good enough
+      thumbnail for now. Regenerating it here would decode the whole page
+      on the GUI thread, once per page and one page per event-loop turn,
+      since the render thread must stay off the file while the scan
+      writes it: that is what lets the display fall behind a fast feeder.
+      Keep the preview and regenerate it once the scan is over. A page
+      that never got a preview has to be generated now */
+   if (_pixmap.isNull ())
+      _rescale = true;
+   else
+      {
+      _provisional = true;
+      /* the page was painted before its first preview arrived, with no
+         pixmap, which asked for a rescale: the preview answers that now,
+         so drop the request, or the page is decoded in full once the
+         update timer fires */
+      _rescale = false;
+      }
    _coverage = coverage;
    _remove = _blank = mark_blank;
    _scanning = false;
@@ -887,6 +916,16 @@ QPixmap Pageinfo::pixmap (bool &dodgy)
    }
 
 
+bool Pageinfo::finishProvisional (void)
+   {
+   if (!_provisional)
+      return false;
+   _provisional = false;
+   _rescale = true;
+   return true;
+   }
+
+
 bool Pageinfo::updatePixmap (void)
    {
    // any need for rescale?
@@ -909,6 +948,12 @@ bool Pageinfo::updatePixmap (void)
 void Pageinfo::updateScanImage (const QImage &image)
    {
    _pixmap = QPixmap::fromImage (image);
+   /* the preview surface is the page box, so the pixmap is for the
+      current page size: without saying so, every paint would find it the
+      wrong size and ask for a rescale from the file, which decodes the
+      page on the GUI thread while the scan is still writing the stack and
+      replaces the preview with a full-height box */
+   _size = image.size ();
    }
 
 

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -652,6 +652,7 @@ void Pagemodel::beginningPage (void)
    Pageinfo &page = _pages [pagenum];
    page.setScanning (true, pagenum);
    page._scan_image = QImage ();
+   page._scan_painted = 0;
    endInsertRows ();
 //    emit dataChanged (index (pagenum, 0, QModelIndex ()),
 //       index (pagenum, 0, QModelIndex ()));
@@ -710,6 +711,8 @@ void Pagemodel::newScaledImage (const QImage &image, int scaled_linenum,
       p.drawImage (QPoint (0, scaled_linenum), src);
       p.end ();
 
+      page._scan_painted = qMax (page._scan_painted,
+                                 scaled_linenum + src.height ());
       page.updateScanImage (surface);
 
       // tell the view that part of an item has changed
@@ -808,6 +811,7 @@ Pageinfo::Pageinfo (void)
    _size = QSize ();
    _rescale = false;
    _provisional = false;
+   _scan_painted = 0;
    }
 
 
@@ -875,6 +879,12 @@ void Pageinfo::scanDone (QString coverage, bool mark_blank)
       _rescale = true;
    else
       {
+      /* the preview surface is the full page box; a shorter page (a
+         landscape sheet) fills only the top of it. Cut it to what was
+         painted, so the cell has the page's own shape, as the thumbnail
+         made from the file later will */
+      if (_scan_painted > 0 && _scan_painted < _pixmap.height ())
+         _pixmap = _pixmap.copy (0, 0, _pixmap.width (), _scan_painted);
       _provisional = true;
       /* the page was painted before its first preview arrived, with no
          pixmap, which asked for a rescale: the preview answers that now,

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -660,7 +660,7 @@ void Pagemodel::beginningPage (void)
 
 
 void Pagemodel::newScaledImage (const QImage &image, int scaled_linenum,
-                                int pagenum)
+                                int pagenum, const QSize &size)
    {
    if (!_stackindex.isValid ())
       return;
@@ -688,18 +688,36 @@ void Pagemodel::newScaledImage (const QImage &image, int scaled_linenum,
    QPainter p;
    QImage &surface = page._scan_image;
 
-   if (surface.isNull ())
+   if (surface.isNull () || surface.size () != size)
       {
-      surface = QImage (_pagesize.width (), _pagesize.height (),
-                        QImage::Format_RGB32);
-      surface.fill (Qt::white);
-      ok = p.begin (&surface);
+      /* the surface is the scaled page: hatched where nothing has
+         arrived yet. If there is one already of another size, the page's
+         height has been learnt since and the scale with it, so carry
+         what was painted across at the new scale */
+      QImage fresh (size, QImage::Format_RGB32);
+
+      fresh.fill (Qt::white);
+      ok = p.begin (&fresh);
       if (ok)
-         p.fillRect (QRect (QPoint (0, 0), surface.size ()),
+         {
+         p.fillRect (QRect (QPoint (0, 0), fresh.size ()),
                      QBrush (Qt::DiagCrossPattern));
+         if (!surface.isNull () && page._scan_painted > 0)
+            {
+            double factor = (double)size.width () / surface.width ();
+            QImage done = surface.copy (0, 0, surface.width (),
+                                        page._scan_painted);
+
+            done = done.scaled (size.width (),
+                                qMax (1, qRound (done.height () * factor)));
+            p.drawImage (QPoint (0, 0), done);
+            page._scan_painted = done.height ();
+            }
+         p.end ();
+         }
+      surface = fresh;
       }
-   else
-      ok = p.begin (&surface);
+   ok = p.begin (&surface);
 
    QImage src = image;
    if (src.format () != QImage::Format_RGB32
@@ -713,7 +731,7 @@ void Pagemodel::newScaledImage (const QImage &image, int scaled_linenum,
 
       page._scan_painted = qMax (page._scan_painted,
                                  scaled_linenum + src.height ());
-      page.updateScanImage (surface);
+      page.updateScanImage (surface, _pagesize);
 
       // tell the view that part of an item has changed
       QModelIndex ind = index (pagenum, 0, QModelIndex ());
@@ -955,15 +973,15 @@ bool Pageinfo::updatePixmap (void)
    }
 
 
-void Pageinfo::updateScanImage (const QImage &image)
+void Pageinfo::updateScanImage (const QImage &image, const QSize &size)
    {
    _pixmap = QPixmap::fromImage (image);
-   /* the preview surface is the page box, so the pixmap is for the
-      current page size: without saying so, every paint would find it the
-      wrong size and ask for a rescale from the file, which decodes the
-      page on the GUI thread while the scan is still writing the stack and
-      replaces the preview with a full-height box */
-   _size = image.size ();
+   /* the preview is scaled for the current page size: without saying so,
+      every paint would find it the wrong size and ask for a rescale from
+      the file, which decodes the page on the GUI thread while the scan is
+      still writing the stack and replaces the preview with a full-height
+      box */
+   _size = size;
    }
 
 

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -35,6 +35,91 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 Q_DECLARE_METATYPE(QPixmap *)
 
 
+void PageRenderer::render (int itemnum, const QPersistentModelIndex &stack,
+                          int pagenum, const QSize &size, bool blank,
+                          quint64 gen)
+   {
+   QMutexLocker locker (&_mutex);
+
+   _itemnum = itemnum;
+   _stack = stack;
+   _pagenum = pagenum;
+   _size = size;
+   _blank = blank;
+   _gen = gen;
+   _have = true;
+   if (!isRunning ())
+      start ();
+   _cond.wakeAll ();
+   }
+
+
+void PageRenderer::flush (void)
+   {
+   QMutexLocker locker (&_mutex);
+
+   /* drop a not-yet-started request and wait for any in-progress one */
+   _have = false;
+   while (_busy)
+      _cond.wait (&_mutex);
+   }
+
+
+void PageRenderer::shutdown (void)
+   {
+      {
+      QMutexLocker locker (&_mutex);
+      _stop = true;
+      _cond.wakeAll ();
+      }
+   wait ();
+   }
+
+
+void PageRenderer::run (void)
+   {
+   for (;;)
+      {
+      int itemnum, pagenum;
+      QPersistentModelIndex stack;
+      QSize size;
+      bool blank;
+      quint64 gen;
+
+         {
+         QMutexLocker locker (&_mutex);
+
+         while (!_have && !_stop)
+            _cond.wait (&_mutex);
+         if (_stop)
+            return;
+         itemnum = _itemnum;
+         stack = _stack;
+         pagenum = _pagenum;
+         size = _size;
+         blank = _blank;
+         gen = _gen;
+         _have = false;
+         _busy = true;
+         }
+
+      QImage image;
+
+      if (_contents && stack.isValid ())
+         _contents->getScaledImageData (stack, pagenum, size, blank, image);
+
+      {
+      QMutexLocker locker (&_mutex);
+
+      _busy = false;
+      _cond.wakeAll ();        // let flush() proceed
+      }
+
+      emit rendered (itemnum, image, gen);
+      }
+   }
+
+
 Pagemodel::Pagemodel (QObject *parent)
       : QAbstractItemModel (parent)
    {
@@ -52,11 +137,23 @@ Pagemodel::Pagemodel (QObject *parent)
    _updateTimer = new QTimer (this);
    _updateTimer->setSingleShot(true);
    connect (_updateTimer, SIGNAL (timeout()), this, SLOT (nextUpdate ()));
+
+   _generation = 0;
+   _renderer = new PageRenderer (this);
+   connect (_renderer, SIGNAL (rendered (int, QImage, quint64)),
+            this, SLOT (slotRendered (int, QImage, quint64)));
    }
 
 
 Pagemodel::~Pagemodel ()
    {
+   delete _renderer;   // stops and joins the render thread
+   }
+
+
+void Pagemodel::stopRendering (void)
+   {
+   _renderer->shutdown ();
    }
 
 
@@ -78,6 +175,9 @@ void Pagemodel::clear (void)
 void Pagemodel::reset (const Desktopmodel *model, const QModelIndex &index,
       int start, int count)
    {
+   _renderer->flush ();
+   _generation++;
+   _renderer->setContents (model);
     QAbstractItemModel::beginResetModel ();
    _contents = model;
    _stackindex = index;
@@ -311,6 +411,11 @@ QMimeData *Pagemodel::mimeData (const QModelIndexList &list) const
 
 void Pagemodel::setPagesize (QSize size)
    {
+   if (_pagesize != size)
+      {
+      _renderer->flush ();
+      _generation++;
+      }
    _pagesize = size;
    }
 
@@ -320,6 +425,8 @@ void Pagemodel::setScale (int scale_down)
    if (_scale_down != scale_down)
       {
       _scale_down = scale_down;
+      _renderer->flush ();
+      _generation++;
 
       // stop scaling all pages, since no point in any previous rescaling continuing
       for (int i = 0; i < _count; i++)
@@ -382,15 +489,32 @@ void Pagemodel::nextUpdate (void)
    // keep going until we find a page that needs updating, or get back to where we started
    for (; _update_upto < _count;)
       {
-      pi = &_pages [_update_upto];
+      int row = _update_upto;
+      pi = &_pages [row];
       if (++_update_upto == _count)
          _update_upto = 0;
-      if (pi->updatePixmap ())
+      if (pi->wantsRescale ())
          {
-         QModelIndex ind = index (pi->itemnum (), 0, QModelIndex ());
-         emit dataChanged (ind, ind);
-         _updateTimer->start (0);
-         break;
+         int pagenum = _start + row;
+
+         /* a big page is slow to decode, so hand it to the render thread
+            and carry on when it comes back; the scan image and small
+            previews are cheap, so do those here */
+         if (_stackindex.isValid () && !pi->scanning () && _contents
+             && _contents->imageNeedsDecode (_stackindex, pagenum, _pagesize))
+            {
+            pi->markRendering ();
+            _renderer->render (row, _stackindex, pagenum, _pagesize,
+                               pi->isBlank (), _generation);
+            return;
+            }
+         if (pi->updatePixmap ())
+            {
+            QModelIndex ind = index (row, 0, QModelIndex ());
+            emit dataChanged (ind, ind);
+            _updateTimer->start (0);
+            break;
+            }
          }
       if (_update_upto == start)
          {
@@ -400,6 +524,22 @@ void Pagemodel::nextUpdate (void)
          break;
          }
       }
+   }
+
+
+void Pagemodel::slotRendered (int itemnum, QImage image, quint64 gen)
+   {
+   /* drop results from before the last reset/scale change, and empty
+      images from a failed decode */
+   if (gen == _generation && itemnum >= 0 && itemnum < _count
+       && !image.isNull ())
+      {
+      _pages [itemnum].setPixmap (QPixmap::fromImage (image));
+      QModelIndex ind = index (itemnum, 0, QModelIndex ());
+      emit dataChanged (ind, ind);
+      }
+   if (_rescaling)
+      _updateTimer->start (0);   // on to the next page
    }
 
 

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -590,7 +590,7 @@ void Pagemodel::disownScanning (void)
 
 
 int Pagemodel::slotNewScannedPage (const QString &coverageStr,
-      bool mark_blank)
+      bool mark_blank, int rotate)
    {
    Pageinfo *page;
    int pagenum = -1;
@@ -616,7 +616,7 @@ int Pagemodel::slotNewScannedPage (const QString &coverageStr,
       page = new Pageinfo;
 
    // should invalidate pixmap so it is created fresh
-   page->scanDone (coverageStr, mark_blank);
+   page->scanDone (coverageStr, mark_blank, rotate);
 
    _scan_pages << *page;
 //       qDebug () << "Pagemodel::slotNewScannedPage, OWNED count now" << _scan_pages.size ();
@@ -882,7 +882,7 @@ void Pageinfo::invalidate ()
    }
 
 
-void Pageinfo::scanDone (QString coverage, bool mark_blank)
+void Pageinfo::scanDone (QString coverage, bool mark_blank, int rotate)
    {
    setCoverage (coverage);
 
@@ -903,6 +903,9 @@ void Pageinfo::scanDone (QString coverage, bool mark_blank)
          made from the file later will */
       if (_scan_painted > 0 && _scan_painted < _pixmap.height ())
          _pixmap = _pixmap.copy (0, 0, _pixmap.width (), _scan_painted);
+      // a page fed sideways was turned as it was stored: match it
+      if (rotate)
+         _pixmap = _pixmap.transformed (QTransform ().rotate (rotate));
       _provisional = true;
       /* the page was painted before its first preview arrived, with no
          pixmap, which asked for a rescale: the preview answers that now,

--- a/pagemodel.cpp
+++ b/pagemodel.cpp
@@ -500,7 +500,8 @@ void Pagemodel::nextUpdate (void)
          /* a big page is slow to decode, so hand it to the render thread
             and carry on when it comes back; the scan image and small
             previews are cheap, so do those here */
-         if (_stackindex.isValid () && !pi->scanning () && _contents
+         if (_stackindex.isValid () && !pi->scanning () && !_own_scan
+             && _contents
              && _contents->imageNeedsDecode (_stackindex, pagenum, _pagesize))
             {
             pi->markRendering ();
@@ -548,6 +549,7 @@ void Pagemodel::slotRendered (int itemnum, QImage image, quint64 gen)
 void Pagemodel::beginningScan (void)
    {
    // we 'own' the scanning now, so will display previews as pages are scanning
+   _renderer->flush ();     // no render thread reads while the scan writes
    _own_scan = true;
    _lost_scan = false;
    _scan_pages.clear ();

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -43,12 +43,65 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QPixmap>
 #include <QSize>
 #include <QVector>
+#include <QThread>
+#include <QMutex>
+#include <QWaitCondition>
+#include <QPersistentModelIndex>
 
 
 class QPixmap;
 class QTimer;
 
 class Desktopmodel;
+/** Decodes page images on a single background thread so the GUI thread
+    is not blocked while a large page is decoded and scaled. The .max
+    files are not thread-safe, so one worker (not a pool) is used and
+    Desktopmodel serialises file access. QPixmap cannot be made off the
+    GUI thread, so the worker produces a QImage and the model converts
+    it. */
+class PageRenderer : public QThread
+   {
+   Q_OBJECT
+public:
+   PageRenderer (QObject *parent = 0) : QThread (parent) {}
+   ~PageRenderer () { shutdown (); }
+
+   //! the stack model to decode from (set when the displayed stack changes)
+   void setContents (const Desktopmodel *contents) { _contents = contents; }
+
+   /** ask for a page to be rendered; replaces any request not yet started
+       (the newest wins) */
+   void render (int itemnum, const QPersistentModelIndex &stack, int pagenum,
+                const QSize &size, bool blank, quint64 gen);
+
+   //! wait for any in-progress render to finish (before the model changes)
+   void flush (void);
+
+   //! stop the thread and wait for it to exit
+   void shutdown (void);
+
+signals:
+   void rendered (int itemnum, QImage image, quint64 gen);
+
+protected:
+   void run (void) override;
+
+private:
+   const Desktopmodel *_contents = 0;
+   QMutex _mutex;
+   QWaitCondition _cond;
+   bool _stop = false;
+   bool _have = false;      //!< a request is waiting
+   bool _busy = false;      //!< a render is in progress
+   int _itemnum = 0;
+   int _pagenum = 0;
+   QPersistentModelIndex _stack;
+   QSize _size;
+   bool _blank = false;
+   quint64 _gen = 0;
+   };
+
+
 class Pagemodel;
 
 
@@ -92,6 +145,15 @@ public:
 
       \returns true if an update was necessary, false if not */
    bool updatePixmap (void);
+
+   //! true if this page is waiting for its pixmap to be regenerated
+   bool wantsRescale (void) const { return _rescale; }
+
+   //! mark that a background render has been dispatched for this page
+   void markRendering (void) { _rescale = false; }
+
+   //! store a pixmap produced by the background render thread
+   void setPixmap (const QPixmap &pm) { _pixmap = pm; _rescale = false; }
 
    /** returns the string with information on page coverage
 
@@ -171,6 +233,14 @@ public:
    void clear (void);
 
    /** reset the model to point to the given stack */
+   /** Stop the background render thread for good
+
+       It decodes from the Desktopmodel, which it holds only as a
+       pointer, so it has to be stopped before that model is destroyed.
+       Qt destroys children in its own order, so waiting for this
+       model's own destructor is too late */
+   void stopRendering (void);
+
    void reset (const Desktopmodel *model, const QModelIndex &index,
       int start, int count);
 
@@ -366,6 +436,9 @@ protected:
 protected slots:
    void nextUpdate (void);    //!< do the next rescale update
 
+   //! receive a page image from the background render thread
+   void slotRendered (int itemnum, QImage image, quint64 gen);
+
 private:
    const Desktopmodel *_contents;    //!< stack model
    QPersistentModelIndex _stackindex;  //!< index of stack in _model that we are displaying
@@ -381,6 +454,9 @@ private:
    QTimer *_updateTimer;   //!< timer for background scaling operations
    int _update_upto;       //!< where we are up to with updating
    bool _rescaling;        //!< true if we are rescaling in the background
+   PageRenderer *_renderer;   //!< background image decoder
+   quint64 _generation;       //!< bumped when the page set changes, to
+                              //!< drop render results that are now stale
    /* (per-page _scan_image lives in Pageinfo now to support progressive
     * duplex; see Pageinfo for details) */
    bool _own_scan;         //!< true if we own the scanning operation

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -217,6 +217,7 @@ private:
 //   int _scale_down;          //!< scale factor at which the pixmap was done (e.g. 24 means 1/24)
    QSize _size;            //!< image size
    bool _rescale;          //!< true if this page's pixmap needs to be rescaled
+   int _scan_painted;      //!< rows of the scan preview painted so far
    bool _provisional;      //!< the pixmap is the live scan preview, to be
                            //!< regenerated from the file once the scan ends
    QString _coverage;      //!< information about page coverage

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -153,7 +153,14 @@ public:
    void markRendering (void) { _rescale = false; }
 
    //! store a pixmap produced by the background render thread
-   void setPixmap (const QPixmap &pm) { _pixmap = pm; _rescale = false; }
+   void setPixmap (const QPixmap &pm)
+      { _pixmap = pm; _rescale = false; _provisional = false; }
+
+   /** If this page is still showing the preview built up while it was
+       scanned, ask for the proper thumbnail to be generated instead
+
+      \returns true if a rescale was requested */
+   bool finishProvisional (void);
 
    /** returns the string with information on page coverage
 
@@ -210,6 +217,8 @@ private:
 //   int _scale_down;          //!< scale factor at which the pixmap was done (e.g. 24 means 1/24)
    QSize _size;            //!< image size
    bool _rescale;          //!< true if this page's pixmap needs to be rescaled
+   bool _provisional;      //!< the pixmap is the live scan preview, to be
+                           //!< regenerated from the file once the scan ends
    QString _coverage;      //!< information about page coverage
    bool _blank;            //!< true if page is blank
    bool _remove;           //!< marked for removal

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -200,8 +200,9 @@ public:
 
    /** update the scan image (called while scan is in progress
 
-      \param image      scan image */
-   void updateScanImage (const QImage &image);
+      \param image      scan image
+      \param size       the page size the image was scaled for */
+   void updateScanImage (const QImage &image, const QSize &size);
 
 private:
    bool _valid;            //!< true if this page has been set up
@@ -361,8 +362,12 @@ public:
 
       \param image            scaled image to display
       \param scaled_linenum  destination start line for this fragment
-      \param pagenum         page index in our _pages list to update */
-   void newScaledImage (const QImage &image, int scaled_linenum, int pagenum);
+      \param pagenum         page index in our _pages list to update
+      \param surface         size of the whole scaled page: the preview
+                             surface is made this size, or brought to it
+                             if the page's height has since been learnt */
+   void newScaledImage (const QImage &image, int scaled_linenum, int pagenum,
+                        const QSize &surface);
 
    /** tell the model to disassociate itself with the scanning, since the
        user has clicked on another stack. This will halt previews */

--- a/pagemodel.h
+++ b/pagemodel.h
@@ -132,8 +132,11 @@ public:
        when we change the stack that is being used */
    void invalidate (void);
 
-   /** complete a scan on a page */
-   void scanDone (QString coverage, bool mark_blank);
+   /** complete a scan on a page
+
+      \param rotate   degrees the page was turned as it was stored, so the
+                      preview can be turned to match */
+   void scanDone (QString coverage, bool mark_blank, int rotate = 0);
 
    /** Stop any rescale that is pending. This happens when we change the
        scale of all the pages at once - any preview rescale is therefore
@@ -382,7 +385,8 @@ public slots:
       \param coverageStr   coverage string
       \param mark_blank    true if page should be marked blank
       \returns the row of the page that was just completed, or -1 */
-   int slotNewScannedPage (const QString &coverageStr, bool mark_blank);
+   int slotNewScannedPage (const QString &coverageStr, bool mark_blank,
+                           int rotate);
 
 signals:
    /* indicate that part of a page has changed

--- a/pageview.cpp
+++ b/pageview.cpp
@@ -44,7 +44,9 @@ Pageview::Pageview (QWidget *parent)
    setMovement (Free);
    setResizeMode (Adjust);
    setLayoutMode (SinglePass);
-   setUniformItemSizes (true);
+   /* pages may differ in shape (auto-size crops each to its own size),
+      so size each cell to its page rather than to the first one */
+   setUniformItemSizes (false);
    setSelectionRectVisible (true);
    setHorizontalScrollMode (QAbstractItemView::ScrollPerPixel);
    setVerticalScrollMode (QAbstractItemView::ScrollPerPixel);
@@ -54,6 +56,28 @@ Pageview::Pageview (QWidget *parent)
 
    _autoscroll = true;  // the user has not scrolled yet
    _ignore_scroll = false;
+
+   _relayoutTimer.setSingleShot (true);
+   connect (&_relayoutTimer, SIGNAL (timeout ()), this, SLOT (slotRelayout ()));
+   }
+
+
+void Pageview::setModel (QAbstractItemModel *model)
+   {
+   QListView::setModel (model);
+   if (model)
+      /* a page's pixmap is not ready when it is first laid out, so its
+         cell starts at the fallback height; re-measure once pixmaps
+         arrive. The timer coalesces the burst of updates into one pass */
+      connect (model, &QAbstractItemModel::dataChanged, this,
+               [this] (const QModelIndex &, const QModelIndex &,
+                       const QVector<int> &) { _relayoutTimer.start (150); });
+   }
+
+
+void Pageview::slotRelayout ()
+   {
+   scheduleDelayedItemsLayout ();
    }
 
 

--- a/pageview.cpp
+++ b/pageview.cpp
@@ -36,6 +36,7 @@ Pageview::Pageview (QWidget *parent)
       : QListView (parent)
    {
    setViewMode (IconMode);
+   setSpacing (4);   // a little gap so page previews do not run together
 
    setWrapping (true);
    setFlow (LeftToRight);

--- a/pageview.cpp
+++ b/pageview.cpp
@@ -45,9 +45,12 @@ Pageview::Pageview (QWidget *parent)
    setMovement (Free);
    setResizeMode (Adjust);
    setLayoutMode (SinglePass);
-   /* pages may differ in shape (auto-size crops each to its own size),
-      so size each cell to its page rather than to the first one */
-   setUniformItemSizes (false);
+   /* uniform item sizes keep icon-view layout O(1) per change; without
+      this, adding hundreds of pages during a scan is O(n^2) and the UI
+      falls a long way behind. The cells still get the right shape because
+      the delegate sizes them to the page and a relayout re-measures once
+      the first pixmap is ready (see slotRelayout). */
+   setUniformItemSizes (true);
    setSelectionRectVisible (true);
    setHorizontalScrollMode (QAbstractItemView::ScrollPerPixel);
    setVerticalScrollMode (QAbstractItemView::ScrollPerPixel);
@@ -78,6 +81,20 @@ void Pageview::setModel (QAbstractItemModel *model)
 
 void Pageview::slotRelayout ()
    {
+   /* uniform item sizes cache the size measured from the first item, and
+      that first measurement happens before its pixmap is ready, so it is
+      the tall fallback. Once pixmaps have arrived, set the grid cell from
+      the first item's real size hint: this fixes the cell height (no gap
+      under a landscape page) and keeps layout O(1). */
+   if (model () && model ()->rowCount () > 0)
+      {
+      QSize hint = itemDelegate ()->sizeHint (getViewOptions (),
+                                              model ()->index (0, 0));
+      /* with a grid the view's spacing no longer applies, so include it
+         in the cell, or the pages sit edge to edge */
+      if (hint.isValid ())
+         setGridSize (hint + QSize (spacing (), spacing ()));
+      }
    scheduleDelayedItemsLayout ();
    }
 

--- a/pageview.cpp
+++ b/pageview.cpp
@@ -24,6 +24,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <QDebug>
 #include <QScrollBar>
+#include <QTimer>
+#include <QKeyEvent>
 #include <QWheelEvent>
 
 #include "desktopmodel.h"
@@ -58,8 +60,15 @@ Pageview::Pageview (QWidget *parent)
    setEditTriggers (QAbstractItemView::EditKeyPressed);
    setStyleSheet ("QListView { background: palette(mid); }");
 
+   _follow = false;
    _autoscroll = true;  // the user has not scrolled yet
    _ignore_scroll = false;
+   /* actionTriggered() comes only from the user (scrollbar, wheel), never
+      from setValue(), so it tells user scrolls from ones a relayout makes */
+   connect (verticalScrollBar (), SIGNAL (actionTriggered (int)),
+            this, SLOT (slotUserScrolled ()));
+   connect (verticalScrollBar (), SIGNAL (rangeChanged (int, int)),
+            this, SLOT (slotRangeChanged (int, int)));
 
    _relayoutTimer.setSingleShot (true);
    connect (&_relayoutTimer, SIGNAL (timeout ()), this, SLOT (slotRelayout ()));
@@ -96,6 +105,21 @@ void Pageview::slotRelayout ()
          setGridSize (hint + QSize (spacing (), spacing ()));
       }
    scheduleDelayedItemsLayout ();
+   }
+
+
+void Pageview::slotRangeChanged (int min, int max)
+   {
+   Q_UNUSED (min);
+   /* the end has moved (rows added, cells re-measured, the view resized):
+      while following it, stay on it. scrollToRow() alone is not enough,
+      as the layout it scrolled to can still change afterwards */
+   if (followingEnd ())
+      {
+      _ignore_scroll = true;
+      verticalScrollBar ()->setValue (max);
+      _ignore_scroll = false;
+      }
    }
 
 
@@ -189,8 +213,12 @@ void Pageview::scrollToRow (int row, bool ifAtEnd)
    {
    if (row < 0)
       return;
-   if (!ifAtEnd || _autoscroll)
+   if (!ifAtEnd || followingEnd ())
       {
+      /* a relayout may be pending from the rows just added: do it first,
+         or the scroll is worked out from the old geometry and stops short
+         of the end */
+      executeDelayedItemsLayout ();
       _ignore_scroll = true;
       scrollTo (model ()->index (row, 0, QModelIndex ()), PositionAtBottom);
       _ignore_scroll = false;
@@ -200,17 +228,36 @@ void Pageview::scrollToRow (int row, bool ifAtEnd)
 
 void Pageview::scrollContentsBy (int dx, int dy)
    {
-   /* if we caused the scroll, then don't worry. Otherwise the user is trying
-      to adjust the scrollbars, so if they are not at the bottom, we turn off
-      autoscroll */
-   if (!_ignore_scroll)
-      {
+   /* Whether to keep following the end is decided by the user's scrolls
+      alone (slotUserScrolled, keyPressEvent). It used to be decided here,
+      by any scroll not of our own making: but a relayout as pages are
+      added moves the contents too, and the moment that happened with the
+      bar not quite at the end, following stopped for good and the view
+      sat on the first screenful while the scan went on below it */
+   QListView::scrollContentsBy (dx, dy);
+   }
+
+
+void Pageview::slotUserScrolled ()
+   {
+   /* the slider moves after the signal, so look once that is done */
+   QTimer::singleShot (0, this, [this] () {
       QScrollBar *vs = verticalScrollBar ();
 
       _autoscroll = vs->value () == vs->maximum ();
-//       qDebug () << "autoscroll" << _autoscroll;
-      }
-   QListView::scrollContentsBy (dx, dy);
+      });
+   }
+
+
+void Pageview::keyPressEvent (QKeyEvent *event)
+   {
+   QListView::keyPressEvent (event);
+
+   /* moving around with the keys scrolls the view without the scrollbar
+      knowing it was the user: treat it the same way */
+   QScrollBar *vs = verticalScrollBar ();
+
+   _autoscroll = vs->value () == vs->maximum ();
    }
 
 

--- a/pageview.h
+++ b/pageview.h
@@ -34,6 +34,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 */
 
 #include <QListView>
+#include <QTimer>
 
 class Pageview : public QListView
    {
@@ -106,7 +107,15 @@ signals:
 
    void showInfo (const QModelIndex &index);
 
+public:
+   void setModel (QAbstractItemModel *model) override;
+
+private slots:
+   /** re-lay-out after page pixmaps load, so cells fit their pages */
+   void slotRelayout ();
+
 private:
+   QTimer _relayoutTimer;  //!< coalesces re-layouts after pixmap updates
    int _scale_down;     //!< scale factor to use (1/n)
    bool _autoscroll;    //!< true if the user has not manually adjusted the scrollbar
    bool _ignore_scroll; //!< true to ignore any scrolls (they are machine-generated)

--- a/pageview.h
+++ b/pageview.h
@@ -90,11 +90,19 @@ public:
                         away from the end */
    void scrollToRow (int row, bool ifAtEnd = false);
 
+   /** Follow the end of the view as rows are added and the layout
+       changes, as when a scan is being shown. The user scrolling away
+       from the end suspends it until they scroll back to the end */
+   void setFollowEnd (bool follow)
+      { _follow = follow; _autoscroll = true; }
+   bool followingEnd (void) const { return _follow && _autoscroll; }
+
 public slots:
    void slotPagePartChanged (const QModelIndex &index, const QImage &image, int scaled_linenum);
 
 protected:
    void scrollContentsBy (int dx, int dy);
+   void keyPressEvent (QKeyEvent *event) override;
 
    //! update the view size based on the items within it
    void updateGeometries (void);
@@ -114,10 +122,19 @@ private slots:
    /** re-lay-out after page pixmaps load, so cells fit their pages */
    void slotRelayout ();
 
+   /** the user has moved the scrollbar (by any means): decide whether to
+       keep following the end of the view */
+   void slotUserScrolled ();
+
+   /** the scrollable range has changed (rows added, cells re-measured,
+       view resized): if following the end, stay there */
+   void slotRangeChanged (int min, int max);
+
 private:
    QTimer _relayoutTimer;  //!< coalesces re-layouts after pixmap updates
    int _scale_down;     //!< scale factor to use (1/n)
-   bool _autoscroll;    //!< true if the user has not manually adjusted the scrollbar
+   bool _follow;        //!< true to follow the end of the view (a scan is shown)
+   bool _autoscroll;    //!< true if the user has not scrolled away from the end
    bool _ignore_scroll; //!< true to ignore any scrolls (they are machine-generated)
    };
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -720,9 +720,11 @@ void Pagewidget::setPagesize (QSize size)
    _pagemodel->setPagesize (size);
    _pagedelegate->setPagesize (size);
 
+   /* keep a fixed column WIDTH so the columns line up, but let each row
+      take the height of its own page rather than the full portrait box */
    const QStyleOptionViewItem option = _pageview->getViewOptions ();
-   size += _pagedelegate->getSpacing (option);
-   _pageview->setGridSize (size);
+   QSize cell = size + _pagedelegate->getSpacing (option);
+   _pageview->setGridSize (QSize ());  // let sizeHint drive the layout
    }
 
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -901,6 +901,13 @@ void Pagewidget::revertMode (void)
    }
 
 
+void Pagewidget::stopRendering (void)
+   {
+   if (_pagemodel)
+      _pagemodel->stopRendering ();
+   }
+
+
 void Pagewidget::scanComplete (void)
    {
    _scanning = false;

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -720,11 +720,9 @@ void Pagewidget::setPagesize (QSize size)
    _pagemodel->setPagesize (size);
    _pagedelegate->setPagesize (size);
 
-   /* keep a fixed column WIDTH so the columns line up, but let each row
-      take the height of its own page rather than the full portrait box */
-   const QStyleOptionViewItem option = _pageview->getViewOptions ();
-   QSize cell = size + _pagedelegate->getSpacing (option);
-   _pageview->setGridSize (QSize ());  // let sizeHint drive the layout
+   /* clear the grid so each row takes the height of its own page rather
+      than the full portrait box; the delegate's size hint drives layout */
+   _pageview->setGridSize (QSize ());
    }
 
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -653,6 +653,7 @@ void Pagewidget::showPages (const QAbstractItemModel *model, const QModelIndex &
          }
 
       reset = true;
+      _pageview->setFollowEnd (false);
 
       /* if we were scanning into a stack, but have selected a different
          stack, disown the scanning stack */
@@ -866,6 +867,7 @@ void Pagewidget::beginningScan (const QModelIndex &ind)
    _prescan_mode = mode;
    showPages (ind.model (), ind, 0, -1, -1);
    _scanning = true;
+   _pageview->setFollowEnd (true);   // follow the pages as they arrive
    _pagemodel->beginningScan ();
    }
 
@@ -911,6 +913,9 @@ void Pagewidget::stopRendering (void)
 void Pagewidget::scanComplete (void)
    {
    _scanning = false;
+   /* keep following the end: the thumbnails are still being regenerated,
+      which can re-measure the cells and move it. Showing another stack,
+      or the user scrolling away, ends it */
    _pagemodel->endingScan ();
    revertMode ();
    }

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -957,11 +957,11 @@ void Pagewidget::slotBeginningPage (void)
 
 
 void Pagewidget::slotNewScaledImage (const QImage &image, int scaled_linenum,
-                                     int pagenum)
+                                     int pagenum, const QSize &surface)
    {
    // tell the model that we have a new image
    if (_scanning)
-      _pagemodel->newScaledImage (image, scaled_linenum, pagenum);
+      _pagemodel->newScaledImage (image, scaled_linenum, pagenum, surface);
    }
 
 

--- a/pagewidget.cpp
+++ b/pagewidget.cpp
@@ -921,7 +921,8 @@ void Pagewidget::scanComplete (void)
    }
 
 
-void Pagewidget::slotNewScannedPage (const QString &coverageStr, bool blank)
+void Pagewidget::slotNewScannedPage (const QString &coverageStr, bool blank,
+                                     int rotate)
    {
    if (_scanning)
       {
@@ -933,7 +934,7 @@ void Pagewidget::slotNewScannedPage (const QString &coverageStr, bool blank)
          }
       }
 
-   int pagenum = _pagemodel->slotNewScannedPage (coverageStr, blank);
+   int pagenum = _pagemodel->slotNewScannedPage (coverageStr, blank, rotate);
 
    /* Follow the scan by the pages that actually have data: scroll to
       the page that just finished.  This keeps the most recently

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -158,6 +158,10 @@ public:
    /** init the widget - must be called immediately after creation */
    void init (void);
 
+   /** stop the background render thread, before the stack model it
+       decodes from is destroyed */
+   void stopRendering (void);
+
    /** convert a mode to a tool button */
    QToolButton *modeToTool (e_mode mode);
 

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -331,9 +331,10 @@ protected slots:
 
       \param image           image fragment
       \param scaled_linenum  destination start line for this fragment
-      \param pagenum         which page this fragment belongs to */
+      \param pagenum         which page this fragment belongs to
+      \param surface         size of the whole scaled page */
    void slotNewScaledImage (const QImage &image, int scaled_linenum,
-                            int pagenum);
+                            int pagenum, const QSize &surface);
 
    /** called when we are beginning to scan a new page. We display it and
        monitor progress with calls we receive to slotNewScaledImage() */

--- a/pagewidget.h
+++ b/pagewidget.h
@@ -262,7 +262,8 @@ public slots:
 
        \param coverageStr  page coverage string
        \param blank        true if page is marked blank */
-   void slotNewScannedPage (const QString &coverageStr, bool blank);
+   void slotNewScannedPage (const QString &coverageStr, bool blank,
+                            int rotate);
 
    /******************************************************************/
    /** handle an item being clicked

--- a/paperman-client.pro
+++ b/paperman-client.pro
@@ -9,10 +9,12 @@ CONFIG -= app_bundle
 DEFINES += QT_NO_WIDGETS
 
 HEADERS += backend.h \
+    backendstats.h \
     remotebackend.h
 
 SOURCES += paperman-client.cpp \
     backend.cpp \
+    backendstats.cpp \
     remotebackend.cpp
 
 unix {

--- a/paperman.pro
+++ b/paperman.pro
@@ -27,7 +27,13 @@ OCRLIBPATH = /usr/local/lib/nuance-omnipage-csdk-15.5
 
 CONFIG += qt warn_on
 CONFIG -= release
-!debug:!coverage: QMAKE_CXXFLAGS += -O2
+# 'CONFIG -= release' above leaves a debug build, which is what we want
+# for the symbols, but it also made the '!debug' below never hold, so
+# nothing was ever optimised: every per-pixel pass over a scanned page,
+# the coverage and colour counting worst of all, ran several times
+# slower than it needed to. Optimise unless we are measuring coverage,
+# which needs the unoptimised line numbering
+!coverage: QMAKE_CXXFLAGS += -O2
 
 #QMAKE_LFLAGS += -static
 

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -827,6 +827,11 @@ void Paperscan::scan ()
          if (status != SANE_STATUS_GOOD || isCancelled ())
             break;
 
+         /* the parameters are only final once the scan has started: a
+            back end may adjust the size to what the scanner delivers */
+         if (_scanner->getParameters (&parameters) == SANE_STATUS_GOOD)
+            bpp = parameters.bytes_per_line * 8 / parameters.pixels_per_line;
+
          image_bpp = parameters.format == SANE_FRAME_RGB ? 24
                                                          : parameters.depth;
          is_jpeg = false;
@@ -993,6 +998,8 @@ void Paperscan::scan ()
          if (status != SANE_STATUS_GOOD || isCancelled ())
             break;
          total = 0;
+         if (_scanner->getParameters (&parameters) == SANE_STATUS_GOOD)
+            bpp = parameters.bytes_per_line * 8 / parameters.pixels_per_line;
          image_bpp = parameters.format == SANE_FRAME_RGB ? 24
                     : parameters.depth;
          is_jpeg = false;

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -873,6 +873,19 @@ void Paperscan::scan ()
             {
             SANE_Int flen = 0, blen = 0;
             status = _scanner->readDup (buf, buf_back, size, &flen, &blen);
+            if (status == SANE_STATUS_UNSUPPORTED && !total_f && !total_b)
+               {
+               /* the back end has no sane_read_dup(): the sheet is already
+                  started, so read it a side at a time instead. The next
+                  sheet takes the per-side loop, since hasReadDup() is now
+                  false */
+               status = readSide (buf, size, false, total_f);
+               if (status == SANE_STATUS_EOF)
+                  status = _scanner->start ();
+               if (status == SANE_STATUS_GOOD)
+                  status = readSide (buf_back, size, true, total_b);
+               break;
+               }
             if (status != SANE_STATUS_GOOD)
                break;
             qint64 t_now = QDateTime::currentMSecsSinceEpoch ();
@@ -1184,6 +1197,31 @@ void Paperscan::setup (QScanner *scanner, QString stack_name, QString page_name)
 
 
 /* this is our main thread */
+SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
+                                 long &total)
+   {
+   SANE_Status status = SANE_STATUS_GOOD;
+   SANE_Int len;
+
+   while (status == SANE_STATUS_GOOD && !isCancelled ())
+      {
+      status = _scanner->read (buf, size, &len);
+      if (status != SANE_STATUS_GOOD)
+         break;
+      _mutex.lock ();
+      if (back)
+         _stack->addImageBytesBack (buf, len);
+      else
+         _stack->addImageBytes (buf, len);
+      _mutex.unlock ();
+      total += len;
+      emit stackPageProgress (back ? _stack->curPageBack ()
+                                   : _stack->curPage ());
+      }
+   return status;
+   }
+
+
 void Paperscan::run (void)
    {
 //    qDebug () << "run";

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -759,10 +759,11 @@ void Paperscan::scan ()
       return;
 
    // check resolution, etc.
+   _op = "sane_get_parameters";
    status = _scanner->getParameters (&parameters);
    if (status != SANE_STATUS_GOOD)
       {
-      _progress_str = "";
+      _progress_str = failStr (status, 0);
       emit scanComplete (status, _progress_str, 0);
       return;
       }
@@ -817,10 +818,12 @@ void Paperscan::scan ()
                if (_scanner->checkDoubleFeed ())
                   emit doubleFeedDetected ();
                }
+            _op = "sane_start";
             status = _scanner->start ();
             if (status == SANE_STATUS_INVAL && !busy_count)
                {
                _scanner->cancel ();
+               _op = "sane_start";
                status = _scanner->start ();
                }
             }
@@ -872,6 +875,7 @@ void Paperscan::scan ()
          while (status == SANE_STATUS_GOOD && !isCancelled ())
             {
             SANE_Int flen = 0, blen = 0;
+            _op = "sane_read_dup";
             status = _scanner->readDup (buf, buf_back, size, &flen, &blen);
             if (status == SANE_STATUS_UNSUPPORTED && !total_f && !total_b)
                {
@@ -881,6 +885,7 @@ void Paperscan::scan ()
                   false */
                status = readSide (buf, size, false, total_f);
                if (status == SANE_STATUS_EOF)
+                  _op = "sane_start";
                   status = _scanner->start ();
                if (status == SANE_STATUS_GOOD)
                   status = readSide (buf_back, size, true, total_b);
@@ -999,11 +1004,13 @@ void Paperscan::scan ()
                if (_scanner->checkDoubleFeed ())
                   emit doubleFeedDetected ();
                }
+            _op = "sane_start";
             status = _scanner->start ();
             if (status == SANE_STATUS_INVAL && !busy_count)
                {
                // did we forget to cancel last time?
                _scanner->cancel ();
+               _op = "sane_start";
                status = _scanner->start ();
                }
 //            printf ("status = %d\n", status);
@@ -1033,6 +1040,7 @@ void Paperscan::scan ()
          for (i = 0; status == SANE_STATUS_GOOD && !isCancelled (); i++)
             {
             todo = size;
+            _op = "sane_read";
             status = _scanner->read (buf, todo, &len);
 //             printf ("status = %d, len = %d, total = %d\n", status, len, total + len);
             if (status != 0)
@@ -1156,6 +1164,9 @@ void Paperscan::scan ()
    if (status == SANE_STATUS_NO_DOCS && numsides > 0)
       status = SANE_STATUS_GOOD;
 
+   if (status != SANE_STATUS_GOOD && !isCancelled ())
+      str += "\n" + failStr (status, total_sides + 1);
+
    if (isCancelled ())
       err = &_cancel_err;
 
@@ -1197,6 +1208,17 @@ void Paperscan::setup (QScanner *scanner, QString stack_name, QString page_name)
 
 
 /* this is our main thread */
+QString Paperscan::failStr (SANE_Status status, int page)
+   {
+   QString str = tr ("%1() on device '%2' returned '%3'").arg (_op)
+      .arg (_scanner->name ()).arg (sane_strstatus (status));
+
+   if (page)
+      str += tr (" while scanning page %1").arg (page);
+   return str;
+   }
+
+
 SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
                                  long &total)
    {
@@ -1205,6 +1227,7 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
 
    while (status == SANE_STATUS_GOOD && !isCancelled ())
       {
+      _op = "sane_read";
       status = _scanner->read (buf, size, &len);
       if (status != SANE_STATUS_GOOD)
          break;

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -708,6 +708,11 @@ Paperscan::Paperscan (QObject *parent)
    _stack = 0;
    _scanner = 0;
    _cancel = false;
+   /* set up here, not in scan(): endScan() may be called as soon as the
+      thread is started, before scan() would have run */
+   _end = false;
+   _draining = false;
+   _progress_clock.start ();
    }
 
 
@@ -783,8 +788,6 @@ void Paperscan::scan ()
    _progress_str = "Starting...";
    emit progress (_progress_str);
 
-   _end = false;
-   _draining = false;
 
    stack_limit = xmlConfig->intValue ("SCAN_STACK_COUNT");
    err = NULL;
@@ -864,17 +867,6 @@ void Paperscan::scan ()
           * for the back. */
          unsigned char *buf_back = (unsigned char *) malloc (size);
          long total_f = 0, total_b = 0;
-         /* readDup() returns 4 KB chunks at scanner pace (~5 ms each)
-          * for two sides, which is faster than the GUI can absorb a
-          * progress event end-to-end (image.scaled, QPainter,
-          * QPixmap::fromImage, viewport repaint). Without throttling
-          * the queued events back up and the preview keeps painting
-          * for seconds after the scanner has finished. Cap emissions
-          * at ~20 fps per side; data still accumulates each
-          * iteration so the next emit shows a larger combined
-          * strip. */
-         const qint64 emit_interval_ms = 50;
-         qint64 t_last_emit_f = 0, t_last_emit_b = 0;
          if (!buf_back)
             status = SANE_STATUS_NO_MEM;
          while (status == SANE_STATUS_GOOD && !isCancelled ())
@@ -900,18 +892,13 @@ void Paperscan::scan ()
                }
             if (status != SANE_STATUS_GOOD)
                break;
-            qint64 t_now = QDateTime::currentMSecsSinceEpoch ();
             if (flen)
                {
                _mutex.lock ();
                _stack->addImageBytes (buf, flen);
                _mutex.unlock ();
                total_f += flen;
-               if (t_now - t_last_emit_f >= emit_interval_ms)
-                  {
-                  emit stackPageProgress (_stack->curPage ());
-                  t_last_emit_f = t_now;
-                  }
+               notifyProgress (_stack->curPage ());
                }
             if (blen)
                {
@@ -919,17 +906,13 @@ void Paperscan::scan ()
                _stack->addImageBytesBack (buf_back, blen);
                _mutex.unlock ();
                total_b += blen;
-               if (t_now - t_last_emit_b >= emit_interval_ms)
-                  {
-                  emit stackPageProgress (_stack->curPageBack ());
-                  t_last_emit_b = t_now;
-                  }
+               notifyProgress (_stack->curPageBack ());
                }
             }
-         /* drain any final state the throttled loop did not yet
-          * report so the preview shows the complete page. */
-         emit stackPageProgress (_stack->curPage ());
-         emit stackPageProgress (_stack->curPageBack ());
+         /* drain any final state notifyProgress() held back, so the
+          * preview shows the complete page */
+         notifyProgress (_stack->curPage (), true);
+         notifyProgress (_stack->curPageBack (), true);
          free (buf_back);
 
          if (status == SANE_STATUS_JAMMED && _scanner->checkDoubleFeed ())
@@ -1059,7 +1042,7 @@ void Paperscan::scan ()
             total += len;
             steps++;
 //             qDebug () << "thread up to " << total;
-            emit stackPageProgress (_stack->curPage ());
+            notifyProgress (_stack->curPage ());
             }
 
          // Check if error was due to double-feed
@@ -1069,6 +1052,7 @@ void Paperscan::scan ()
          // end of file is ok - indicates we have an image
          if (status == SANE_STATUS_EOF && total && !isCancelled ())
             {
+            notifyProgress (_stack->curPage (), true);
             QString cov = _stack->coverageStr ();
 
             if (side == 0 && numsides > 1)
@@ -1251,8 +1235,7 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
          _stack->addImageBytes (buf, len);
       _mutex.unlock ();
       total += len;
-      emit stackPageProgress (back ? _stack->curPageBack ()
-                                   : _stack->curPage ());
+      notifyProgress (back ? _stack->curPageBack () : _stack->curPage ());
       }
    return status;
    }
@@ -1276,6 +1259,41 @@ void Paperscan::cancelScan (err_info *err)
 //    qDebug () << "cancelScan";
    _cancel = true;
    _cancel_err = *err;
+   }
+
+
+/* The main thread does not need every chunk: the message carries no data
+   and the receiver looks at the page's current state when it gets to it,
+   so one outstanding message covers everything that arrives before then.
+   Sending one per chunk regardless swamps the display with repaints, a
+   hundred a page, and lets it fall ever further behind a fast feeder */
+void Paperscan::notifyProgress (const PPage *page, bool final)
+   {
+   const int PROGRESS_INTERVAL = 40;   // ms, so 25 updates a second at most
+
+   if (!page)
+      return;
+
+   int pagenum = page->pagenum ();
+   QMutexLocker locker (&_mutex);
+   qint64 now = _progress_clock.elapsed ();
+
+   if (_progress_pending.contains (pagenum)
+       || (!final && now - _progress_time.value (pagenum, -PROGRESS_INTERVAL)
+           < PROGRESS_INTERVAL))
+      return;
+   _progress_pending.insert (pagenum);
+   _progress_time.insert (pagenum, now);
+   locker.unlock ();
+   emit stackPageProgress (page);
+   }
+
+
+void Paperscan::progressHandled (const PPage *page)
+   {
+   QMutexLocker locker (&_mutex);
+
+   _progress_pending.remove (page->pagenum ());
    }
 
 

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -306,6 +306,14 @@ QString Paperstack::coverageStrBack ()
 PPage::PPage (int pagenum, int width, int height, int depth, int stride,
       bool jpeg, int blank_threshold)
    {
+   /* a back end that finds the foot of the sheet as it scans (the fujitsu
+      backend with ald) cannot say the height when the page starts and
+      reports -1. Size the buffers for a letter-shaped page for now; the
+      real height comes from the JPEG header, or for raw data from how
+      much arrives before the end of the page */
+   _height_known = height > 0;
+   if (!_height_known)
+      height = width * 13 / 10;
    _width = width;
    _height = height;
    _depth = depth;
@@ -494,6 +502,8 @@ void PPage::continueJpeg ()
       case State_read_header:
          if (jpeg_read_header (&_cinfo, true) == JPEG_SUSPENDED)
             break;
+         if (!_height_known)
+            setHeight (_cinfo.image_height);
          _state = State_start;
          Q_FALLTHROUGH();
 
@@ -608,8 +618,47 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
    }
 
 
+void PPage::setHeight (int height)
+   {
+   int i;
+
+   _height = height;
+   _height_known = true;
+   int size = _stride * height;
+   if (_jpeg)
+      {
+      /* the decompressor's row pointers go into _decomp, which may move
+         when it grows, so rebuild them */
+      if (size > _decomp.capacity ())
+         {
+         _decomp.reserve (size);
+         memset (_decomp.data (), '\0', size);
+         }
+      if (_jpeg_created)
+         {
+         delete[] _buffer;
+         _buffer = new JSAMPROW [height];
+         for (i = 0; i < height; i++)
+            _buffer [i] = (JSAMPLE *)(_decomp.data () + _stride * i);
+         }
+      size /= 2;
+      }
+   _size = qMax (size, _data.size ());
+   _data.reserve (_size);
+   _pixelTarget = _width * height;
+   if (_blankThreshold)
+      _pixelTarget /= _blankThreshold;
+   }
+
+
 bool PPage::addBytes (const unsigned char *buf, int size)
    {
+   /* raw data of a height not yet known: keep room for whatever comes */
+   if (!_height_known && !_jpeg && _data.size () + size > _size)
+      {
+      _size = qMax (_size * 2, _data.size () + size);
+      _data.reserve (_size);
+      }
    if (_data.size () + size <= _size)
       {
       _data.append (QByteArray ((const char *)buf, size));
@@ -635,6 +684,14 @@ err_info *PPage::confirm (QString &pageName, bool mark_blank, Filepage *mp)
       pageName.truncate (pageName.length () - 1);
    _name = pageName;
    _mark_blank = mark_blank;
+   /* raw data of a height the back end did not know: it is however many
+      lines arrived */
+   if (!_height_known)
+      {
+      _height = _stride ? _data.size () / _stride : 0;
+      _size = _height * _stride;
+      _height_known = true;
+      }
 //   printf ("confirmed %s\n", _name.latin1 ());
 //   printf ("page complete: %dx%dx%d @%d, size %d/%d, short %d\n", _width, _height,
 //      _depth, _stride, _upto, _size, _size - _upto);

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -45,6 +45,42 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include "qscanner.h"
 #include "qxmlconfig.h"
 
+/* A pixel counts towards coverage when it is dark enough that the
+   lineart conversion would make it black, so a page reports a similar
+   coverage whether scanned in colour, grey or mono. This matches the
+   default lineart threshold (mid-grey). */
+#define COVERAGE_THRESHOLD 128
+
+/* A pixel is coloured when the spread between its strongest and weakest
+   of red, green and blue is at least a fifth of the strongest, so a dark
+   colour counts as much as a bright one, and it is not so dark that the
+   spread is just noise. A page counts as colour when at least
+   COLOUR_FRACTION of its pixels are: scanned text and line art give under
+   0.5% by this measure, from colour fringes at edges and the JPEG the
+   scanner sends, and anything with a coloured mark on it several percent */
+#define SATURATION_DIVISOR 5
+#define SATURATION_MIN_BRIGHT 40
+#define COLOUR_FRACTION 0.01
+
+/* Without colour, a page is grey rather than mono when enough of it lies
+   in the mid-tones inside filled regions: pixels with ink (darker than
+   INK_THRESHOLD, so print showing through from the back of the sheet
+   does not count) whose whole (2 * INTERIOR_RADIUS + 1)-square
+   neighbourhood has ink too, and which are themselves no darker than
+   MID_THRESHOLD. Text is thin strokes, so almost none of its pixels lie
+   inside a region, and a bold heading is solid black rather than
+   mid-toned, while a photograph qualifies across its area: 7% of a book
+   page for an illustration, 3% for a small one, against under 0.2% for
+   text. The scanner leaves a shadow of the paper edge along the top and
+   bottom of the page, a mid-grey band that would count, so the first and
+   last EDGE_ROWS rows are left out */
+#define INK_THRESHOLD 200
+#define MID_THRESHOLD 64
+#define INTERIOR_RADIUS 2
+#define INTERIOR_ROWS (2 * INTERIOR_RADIUS + 1)
+#define EDGE_ROWS 32
+#define GREY_FRACTION 0.01
+
 
 
 Paperstack::Paperstack (QString stackName, QString pageName, bool jpeg)
@@ -58,6 +94,7 @@ Paperstack::Paperstack (QString stackName, QString pageName, bool jpeg)
 //    _file = 0;
    _blankPolicy = record;
    _blankThreshold = 500;
+   _autoColour = false;
    _jpeg = jpeg;
    _scanning = true;
    _cleared = 0;
@@ -198,6 +235,12 @@ err_info *Paperstack::confirmImageBack (Filepage *&mp, QMutex &mutex)
    }
 
 
+void Paperstack::setAutoColour (bool on)
+   {
+   _autoColour = on;
+   }
+
+
 void Paperstack::setBlankPolicy (t_blankPolicy policy, int blank_threshold)
    {
    _blankPolicy = policy;
@@ -228,7 +271,8 @@ int Paperstack::pageCount (void)
 int Paperstack::addImage (int width, int height, int depth, int stride, bool front, bool jpeg)
    {
    assert (!_page);
-   _page = new PPage (_pages.size (), width, height, depth, stride, _jpeg, _blankThreshold);
+   _page = new PPage (_pages.size (), width, height, depth, stride, _jpeg,
+                      _blankThreshold, _autoColour);
    _front = front;
    if (!jpeg)
       return _page->size ();
@@ -255,7 +299,7 @@ int Paperstack::addImageBack (int width, int height, int depth, int stride, bool
    /* assign sequential page numbers so the back lands right after the
     * front in the stack list. */
    _page_back = new PPage (_pages.size () + 1, width, height, depth, stride,
-                           _jpeg, _blankThreshold);
+                           _jpeg, _blankThreshold, _autoColour);
    if (!jpeg)
       return _page_back->size ();
    if (depth == 8)
@@ -304,8 +348,11 @@ QString Paperstack::coverageStrBack ()
 
 
 PPage::PPage (int pagenum, int width, int height, int depth, int stride,
-      bool jpeg, int blank_threshold)
+      bool jpeg, int blank_threshold, bool auto_colour)
    {
+   _autoColour = auto_colour;
+   _colourPixels = _interiorPixels = 0;
+   _row_x = _row_skip = _rows_done = 0;
    /* a back end that finds the foot of the sheet as it scans (the fujitsu
       backend with ald) cannot say the height when the page starts and
       reports -1. Size the buffers for a letter-shaped page for now; the
@@ -559,11 +606,6 @@ void PPage::finishJpeg (void)
    }
 
 
-/* A pixel counts towards coverage when it is dark enough that the
-   lineart conversion would make it black, so a page reports a similar
-   coverage whether scanned in colour, grey or mono. This matches the
-   default lineart threshold (mid-grey). */
-#define COVERAGE_THRESHOLD 128
 
 
 bool PPage::checkBlank (const unsigned char *buf, int size)
@@ -592,13 +634,40 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
          break;
 
       case 24 :
+         {
          /* use luminance, as the greyscale/lineart conversion does, so
-            the three modes agree */
-         for (; buf < end; buf += 3)
-            if ((buf [0] * 77 + buf [1] * 150 + buf [2] * 29) >> 8
-                < COVERAGE_THRESHOLD)
+            the three modes agree. Count the coloured pixels in the same
+            pass, for kind(), and hand the ink flags on by row for the
+            filled-region test */
+         int colour = 0;
+
+         while (buf < end)
+            {
+            /* the tail of a row is padding when the stride exceeds it */
+            if (_row_skip)
+               {
+               int skip = qMin (_row_skip, (int)(end - buf));
+
+               buf += skip;
+               _row_skip -= skip;
+               continue;
+               }
+            int lum = (buf [0] * 77 + buf [1] * 150 + buf [2] * 29) >> 8;
+            int mx = qMax (buf [0], qMax (buf [1], buf [2]));
+            int mn = qMin (buf [0], qMin (buf [1], buf [2]));
+
+            if (lum < COVERAGE_THRESHOLD)
                count++;
+            if ((mx - mn) * SATURATION_DIVISOR >= mx
+                && mx >= SATURATION_MIN_BRIGHT)
+               colour++;
+            if (_autoColour)
+               inkPixel (lum);
+            buf += 3;
+            }
+         _colourPixels += colour;
          break;
+         }
       }
 
    // work out total pixels in this block
@@ -707,6 +776,39 @@ int PPage::size (void)
 
 err_info *PPage::compressPage (Filepage *mp, bool mark_blank)
    {
+   Kind kind = _autoColour ? this->kind () : Kind_colour;
+
+   /* a colour page that turned out to need no colour is stored as grey
+      or, with no mid-tones either, as mono, from the decoded pixels */
+   if (kind != Kind_colour)
+      {
+      const unsigned char *src = (const unsigned char *)
+         (_jpeg ? _decomp.constData () : _data.constData ());
+      int lines = _jpeg ? _decomp_avail / _stride : _data.size () / _stride;
+      int height = qMin (lines, _height);
+      int stride = kind == Kind_grey ? _width : (_width + 7) / 8;
+      QByteArray out (stride * height, '\0');
+      unsigned char *dst = (unsigned char *)out.data ();
+
+      for (int y = 0; y < height; y++, src += _stride, dst += stride)
+         {
+         const unsigned char *in = src;
+
+         for (int x = 0; x < _width; x++, in += 3)
+            {
+            int lum = (in [0] * 77 + in [1] * 150 + in [2] * 29) >> 8;
+
+            if (kind == Kind_grey)
+               dst [x] = lum;
+            else if (lum < COVERAGE_THRESHOLD)
+               dst [x >> 3] |= 0x80 >> (x & 7);   // 1 is black, as SANE has it
+            }
+         }
+      mp->addData (_width, height, kind == Kind_grey ? 8 : 1, stride, _name,
+                   false, mark_blank, _pagenum, out, out.size ());
+      return mp->compress ();
+      }
+
 //   printf ("final count = %d, pixels = %d\n", _nonblankPixels, _pixels);
    mp->addData (_width, _height, _depth, _stride, _name, _jpeg, mark_blank, _pagenum, _data,
       _jpeg ? -1 : _size);
@@ -732,9 +834,98 @@ err_info *PPage::compressPage (Filepage *mp, bool mark_blank)
    }
 
 
+/* Take the next pixel of the page, in row order, for the filled-region
+   count. Ink flags are kept for the last INTERIOR_ROWS rows, each row
+   already eroded sideways by INTERIOR_RADIUS; once a row completes, the
+   mid-tone pixels of the middle row of the ring whose column has ink in
+   every row of it are the interior ones. Each row's count is held for
+   EDGE_ROWS rows before it is added, so the last EDGE_ROWS rows of the
+   page never are, and the first EDGE_ROWS are skipped */
+void PPage::inkPixel (int lum)
+   {
+   if (_rows.isEmpty ())
+      {
+      _rows = QByteArray (INTERIOR_ROWS * _width, '\0');
+      _row_counts = QVector<int> (EDGE_ROWS, 0);
+      }
+
+   char *row = _rows.data () + (_rows_done % INTERIOR_ROWS) * _width;
+   char flag = lum >= INK_THRESHOLD ? Ink_none
+         : lum >= MID_THRESHOLD ? Ink_mid : Ink_dark;
+
+   /* a pixel is kept only if it and its INTERIOR_RADIUS neighbours each
+      side have ink: mark it now, and unmark the neighbours a gap unmarks */
+   row [_row_x] = flag;
+   if (flag == Ink_none)
+      for (int i = qMax (0, _row_x - INTERIOR_RADIUS); i < _row_x; i++)
+         row [i] = Ink_none;
+   else if (_row_x < INTERIOR_RADIUS)
+      row [_row_x] = Ink_none;
+   if (++_row_x < _width)
+      return;
+
+   /* row complete: the last INTERIOR_RADIUS pixels have no right-hand
+      neighbours, then count the middle row of the ring */
+   for (int i = qMax (0, _width - INTERIOR_RADIUS); i < _width; i++)
+      row [i] = Ink_none;
+   _row_x = 0;
+   _row_skip = _stride - _width * 3;
+   if (++_rows_done >= INTERIOR_ROWS)
+      {
+      const char *rows [INTERIOR_ROWS];
+      int mid = (_rows_done - 1 - INTERIOR_RADIUS) % INTERIOR_ROWS;
+      int n = 0;
+
+      for (int r = 0; r < INTERIOR_ROWS; r++)
+         rows [r] = _rows.constData () + r * _width;
+      for (int x = 0; x < _width; x++)
+         {
+         if (rows [mid][x] != Ink_mid)
+            continue;
+         bool all = true;
+         for (int r = 0; r < INTERIOR_ROWS && all; r++)
+            all = rows [r][x] != Ink_none;
+         n += all;
+         }
+
+      /* add the count from EDGE_ROWS rows back, once past the top edge */
+      int done = _rows_done - INTERIOR_ROWS;
+
+      if (done >= 2 * EDGE_ROWS)
+         _interiorPixels += _row_counts [done % EDGE_ROWS];
+      _row_counts [done % EDGE_ROWS] = n;
+      }
+   }
+
+
+PPage::Kind PPage::kind (void) const
+   {
+   if (_depth != 24 || !_pixels)
+      return Kind_colour;
+   if ((double)_colourPixels / _pixels >= COLOUR_FRACTION)
+      return Kind_colour;
+   if ((double)_interiorPixels / _pixels >= GREY_FRACTION)
+      return Kind_grey;
+   return Kind_mono;
+   }
+
+
+/* what coverageStr() adds when a colour page is stored as something less */
+static const char *kind_suffix (PPage::Kind kind)
+   {
+   switch (kind)
+      {
+      case PPage::Kind_grey: return " grey";
+      case PPage::Kind_mono: return " mono";
+      default: return "";
+      }
+   }
+
+
 QString PPage::coverageStr ()
    {
    double cov;
+   QString suffix = _autoColour ? kind_suffix (kind ()) : "";
 
    // can't work out coverage from JPEG data
 //    if (_jpeg)
@@ -743,11 +934,11 @@ QString PPage::coverageStr ()
    // work out coverage
    cov = (double)_nonblankPixels / _pixels;
    if (_nonblankPixels == 0)
-      return "0";
+      return "0" + suffix;
 
    // if more than 0.1%, use x.y% notation
    if (cov >= 0.001)
-      return QString ("%1%").arg (cov * 100, 0, 'f', 1);
+      return QString ("%1%").arg (cov * 100, 0, 'f', 1) + suffix;
 
    cov = 1 / cov;
 
@@ -798,6 +989,7 @@ void Paperscan::ensureStack (QString &stack_name, QString &page_name,
 
       _stack->setBlankPolicy ((Paperstack::t_blankPolicy)xmlConfig->intValue("SCAN_BLANK"),
                xmlConfig->intValue("SCAN_BLANK_THRESHOLD"));
+      _stack->setAutoColour (xmlConfig->boolValue ("SCAN_AUTO_COLOUR"));
       emit stackNew (stack_name);
       }
    }

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -548,8 +548,11 @@ void PPage::finishJpeg (void)
    }
 
 
-#define RGB_THRESHOLD 240
-#define GREY_THRESHOLD 251
+/* A pixel counts towards coverage when it is dark enough that the
+   lineart conversion would make it black, so a page reports a similar
+   coverage whether scanned in colour, grey or mono. This matches the
+   default lineart threshold (mid-grey). */
+#define COVERAGE_THRESHOLD 128
 
 
 bool PPage::checkBlank (const unsigned char *buf, int size)
@@ -573,15 +576,16 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
 
       case 8 :
          for (; buf < end; buf++)
-            if (*buf < GREY_THRESHOLD)
+            if (*buf < COVERAGE_THRESHOLD)
                count++;
          break;
 
       case 24 :
+         /* use luminance, as the greyscale/lineart conversion does, so
+            the three modes agree */
          for (; buf < end; buf += 3)
-            if (buf [0] < RGB_THRESHOLD
-               || buf [1] < RGB_THRESHOLD
-               || buf [2] < RGB_THRESHOLD)
+            if ((buf [0] * 77 + buf [1] * 150 + buf [2] * 29) >> 8
+                < COVERAGE_THRESHOLD)
                count++;
          break;
       }

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -310,6 +310,17 @@ int Paperstack::addImageBack (int width, int height, int depth, int stride, bool
    }
 
 
+int Paperstack::restartBack (int width, int height, int depth, int stride,
+                             bool jpeg)
+   {
+   assert (_page_back);
+   assert (_page_back->_data.isEmpty ());
+   delete _page_back;
+   _page_back = NULL;
+   return addImageBack (width, height, depth, stride, jpeg);
+   }
+
+
 bool Paperstack::addImageBytesBack (unsigned char *buf, int size)
    {
    assert (_page_back);
@@ -1202,6 +1213,22 @@ void Paperscan::scan ()
                   {
                   _op = "sane_start";
                   status = _scanner->start ();
+
+                  /* the back is its own image, so take its size from its
+                     own start: a back end that crops each side to its
+                     content makes it differ from the front by a few
+                     pixels, and read at the front's width it would come
+                     out sheared and cut short */
+                  if (status == SANE_STATUS_GOOD
+                      && _scanner->getParameters (&parameters)
+                         == SANE_STATUS_GOOD)
+                     {
+                     _mutex.lock ();
+                     _stack->restartBack (parameters.pixels_per_line,
+                                          parameters.lines, image_bpp,
+                                          parameters.bytes_per_line, is_jpeg);
+                     _mutex.unlock ();
+                     }
                   }
                if (status == SANE_STATUS_GOOD)
                   status = readSide (buf_back, size, true, total_b);

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -24,6 +24,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include <assert.h>
 #include <stdio.h>
+#include <time.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -712,6 +713,8 @@ Paperscan::Paperscan (QObject *parent)
       thread is started, before scan() would have run */
    _end = false;
    _draining = false;
+   _sides_done = 0;
+   _cpu_seconds = 0;
    _progress_clock.start ();
    }
 
@@ -932,6 +935,7 @@ void Paperscan::scan ()
                emit stackNewPage (mp, cov_f, _info_str);
                if (mp->markBlank ()) total_blank++;
                total_sides++;
+               _sides_done = total_sides;
                }
             if (!err)
                {
@@ -941,6 +945,7 @@ void Paperscan::scan ()
                   emit stackNewPage (mp, cov_b, _info_str);
                   if (mp->markBlank ()) total_blank++;
                   total_sides++;
+                  _sides_done = total_sides;
                   }
                }
             if (!err) status = SANE_STATUS_GOOD;
@@ -1082,6 +1087,7 @@ void Paperscan::scan ()
                total_blank++;
             status = SANE_STATUS_GOOD;
             total_sides++;
+            _sides_done = total_sides;
             }
          else
             {
@@ -1243,11 +1249,15 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
 
 void Paperscan::run (void)
    {
+   struct timespec ts;
+
 //    qDebug () << "run";
 
    // scan
    scan ();
 
+   if (!clock_gettime (CLOCK_THREAD_CPUTIME_ID, &ts))
+      _cpu_seconds = ts.tv_sec + ts.tv_nsec / 1e9;
    }
 
 

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -715,6 +715,7 @@ Paperscan::Paperscan (QObject *parent)
    _draining = false;
    _sides_done = 0;
    _cpu_seconds = 0;
+   _max_waiting = -1;
    _progress_clock.start ();
    }
 
@@ -984,6 +985,13 @@ void Paperscan::scan ()
          QString str;
 
          str = QString ("Scanning page %1").arg (total_sides + 1);
+
+         /* say how far ahead the scanner is, if it can tell us: with a
+            fast feeder that is what the display seems to lag behind */
+         int waiting = _scanner->imagesWaiting ();
+         if (waiting > 0)
+            str += tr (", %1 waiting in the scanner").arg (waiting);
+         _max_waiting = qMax (_max_waiting, waiting);
          if (stack_count > 0)
             str += QString (" stack %1").arg (stack_count + 1);
          emit progress (str);

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -889,8 +889,10 @@ void Paperscan::scan ()
                   false */
                status = readSide (buf, size, false, total_f);
                if (status == SANE_STATUS_EOF)
+                  {
                   _op = "sane_start";
                   status = _scanner->start ();
+                  }
                if (status == SANE_STATUS_GOOD)
                   status = readSide (buf_back, size, true, total_b);
                break;

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -784,6 +784,7 @@ void Paperscan::scan ()
    emit progress (_progress_str);
 
    _end = false;
+   _draining = false;
 
    stack_limit = xmlConfig->intValue ("SCAN_STACK_COUNT");
    err = NULL;
@@ -1140,7 +1141,13 @@ void Paperscan::scan ()
       // work out whether to scan more sheets
       done = !adf || (single && total_sides >= single);
 
-      } while (!done && !_end && !err && !isCancelled ());
+      /* Stop means finish the batch, not abandon it. A feeder that runs
+         ahead of us has sheets scanned that we have not read yet: if the
+         backend can stop the feeder while keeping those, carry on until
+         it runs dry. Otherwise stop here as before */
+      if (_end && !_draining && !done && !err && !isCancelled ())
+         _draining = _scanner->stopFeed ();
+      } while (!done && (!_end || _draining) && !err && !isCancelled ());
 
    _scanner->cancel ();
 

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -1127,6 +1127,7 @@ Paperscan::Paperscan (QObject *parent)
    _end = false;
    _draining = false;
    _sides_done = 0;
+   _t_start = _t_read = _t_data = _t_confirm = 0;
    _cpu_seconds = 0;
    _max_waiting = -1;
    _progress_clock.start ();
@@ -1440,6 +1441,7 @@ void Paperscan::scan ()
                   emit doubleFeedDetected ();
                }
             _op = "sane_start";
+            qint64 t0 = QDateTime::currentMSecsSinceEpoch ();
             status = _scanner->start ();
             if (status == SANE_STATUS_INVAL && !busy_count)
                {
@@ -1448,6 +1450,7 @@ void Paperscan::scan ()
                _op = "sane_start";
                status = _scanner->start ();
                }
+            _t_start += QDateTime::currentMSecsSinceEpoch () - t0;
 //            printf ("status = %d\n", status);
             }
          if (status != SANE_STATUS_GOOD || isCancelled ())
@@ -1476,7 +1479,10 @@ void Paperscan::scan ()
             {
             todo = size;
             _op = "sane_read";
+            qint64 tr0 = QDateTime::currentMSecsSinceEpoch ();
             status = _scanner->read (buf, todo, &len);
+            qint64 tr1 = QDateTime::currentMSecsSinceEpoch ();
+            _t_read += tr1 - tr0;
 //             printf ("status = %d, len = %d, total = %d\n", status, len, total + len);
             if (status != 0)
                break;
@@ -1484,6 +1490,7 @@ void Paperscan::scan ()
             _mutex.lock ();
             _stack->addImageBytes (buf, len);
             _mutex.unlock ();
+            _t_data += QDateTime::currentMSecsSinceEpoch () - tr1;
             total += len;
             steps++;
 //             qDebug () << "thread up to " << total;
@@ -1515,7 +1522,9 @@ void Paperscan::scan ()
             Filepage *mp;
 
             // mp is destroyed by the receive, we do not destroy it here
+            qint64 tc0 = QDateTime::currentMSecsSinceEpoch ();
             err = _stack->confirmImage (mp, _mutex);
+            _t_confirm += QDateTime::currentMSecsSinceEpoch () - tc0;
             if (err)
                break;
 
@@ -1671,7 +1680,10 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
    while (status == SANE_STATUS_GOOD && !isCancelled ())
       {
       _op = "sane_read";
+      qint64 tr0 = QDateTime::currentMSecsSinceEpoch ();
       status = _scanner->read (buf, size, &len);
+      qint64 tr1 = QDateTime::currentMSecsSinceEpoch ();
+      _t_read += tr1 - tr0;
       if (status != SANE_STATUS_GOOD)
          break;
       _mutex.lock ();
@@ -1680,6 +1692,7 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
       else
          _stack->addImageBytes (buf, len);
       _mutex.unlock ();
+      _t_data += QDateTime::currentMSecsSinceEpoch () - tr1;
       total += len;
       notifyProgress (back ? _stack->curPageBack () : _stack->curPage ());
       }

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -97,6 +97,7 @@ Paperstack::Paperstack (QString stackName, QString pageName, bool jpeg)
    _blankPolicy = record;
    _blankThreshold = 500;
    _autoColour = false;
+   _sideways = Sideways_no;
    _jpeg = jpeg;
    _scanning = true;
    _cleared = 0;
@@ -243,6 +244,26 @@ void Paperstack::setAutoColour (bool on)
    }
 
 
+void Paperstack::setSideways (t_sideways how)
+   {
+   _sideways = how;
+   }
+
+
+PPage::Rotate Paperstack::rotationFor (bool front) const
+   {
+   if (_sideways == Sideways_no)
+      return PPage::Rotate_none;
+
+   /* the top of the page is at one side of the front and, the sheet being
+      seen from behind, at the other side of the back. With the top at the
+      left, a quarter turn clockwise brings it to the top */
+   bool top_left = (_sideways == Sideways_top_left) == front;
+
+   return top_left ? PPage::Rotate_cw : PPage::Rotate_ccw;
+   }
+
+
 void Paperstack::setBlankPolicy (t_blankPolicy policy, int blank_threshold)
    {
    _blankPolicy = policy;
@@ -273,9 +294,9 @@ int Paperstack::pageCount (void)
 int Paperstack::addImage (int width, int height, int depth, int stride, bool front, bool jpeg)
    {
    assert (!_page);
-   _page = new PPage (_pages.size (), width, height, depth, stride, _jpeg,
-                      _blankThreshold, _autoColour);
    _front = front;
+   _page = new PPage (_pages.size (), width, height, depth, stride, _jpeg,
+                      _blankThreshold, _autoColour, rotationFor (front));
    if (!jpeg)
       return _page->size ();
 
@@ -301,7 +322,8 @@ int Paperstack::addImageBack (int width, int height, int depth, int stride, bool
    /* assign sequential page numbers so the back lands right after the
     * front in the stack list. */
    _page_back = new PPage (_pages.size () + 1, width, height, depth, stride,
-                           _jpeg, _blankThreshold, _autoColour);
+                           _jpeg, _blankThreshold, _autoColour,
+                           rotationFor (false));
    if (!jpeg)
       return _page_back->size ();
    if (depth == 8)
@@ -361,9 +383,10 @@ QString Paperstack::coverageStrBack ()
 
 
 PPage::PPage (int pagenum, int width, int height, int depth, int stride,
-      bool jpeg, int blank_threshold, bool auto_colour)
+      bool jpeg, int blank_threshold, bool auto_colour, Rotate rotate)
    {
    _autoColour = auto_colour;
+   _rotate = rotate;
    _colourPixels = _interiorPixels = 0;
    _colourBand [0] = _colourBand [1] = _colourBand [2] = 0;
    _row_x = _row_skip = _rows_done = _partial_len = 0;
@@ -819,38 +842,105 @@ int PPage::size (void)
    }
 
 
+QByteArray PPage::convert (const unsigned char *src, int height, int depth,
+                           int &width_out, int &height_out,
+                           int &stride_out) const
+   {
+   bool turn = _rotate != Rotate_none;
+   int ow = turn ? height : _width;
+   int oh = turn ? _width : height;
+   int ostride = depth == 24 ? ow * 3 : depth == 8 ? ow : (ow + 7) / 8;
+   QByteArray out (ostride * oh, '\0');
+   unsigned char *dst = (unsigned char *)out.data ();
+
+   for (int dy = 0; dy < oh; dy++, dst += ostride)
+      for (int dx = 0; dx < ow; dx++)
+         {
+         int sx, sy;
+
+         /* where this output pixel comes from: a quarter turn clockwise
+            brings the left edge to the top, anticlockwise the right */
+         switch (_rotate)
+            {
+            case Rotate_cw :
+               sx = dy;
+               sy = height - 1 - dx;
+               break;
+            case Rotate_ccw :
+               sx = _width - 1 - dy;
+               sy = dx;
+               break;
+            default :
+               sx = dx;
+               sy = dy;
+               break;
+            }
+
+         const unsigned char *in = src + sy * _stride;
+         int r, g, b;
+
+         switch (_depth)
+            {
+            case 24 :
+               in += sx * 3;
+               r = in [0];
+               g = in [1];
+               b = in [2];
+               break;
+            case 8 :
+               r = g = b = in [sx];
+               break;
+            default :   // 1 is black, as SANE has it
+               r = g = b = in [sx >> 3] & (0x80 >> (sx & 7)) ? 0 : 255;
+               break;
+            }
+
+         int lum = (r * 77 + g * 150 + b * 29) >> 8;
+
+         switch (depth)
+            {
+            case 24 :
+               dst [dx * 3] = r;
+               dst [dx * 3 + 1] = g;
+               dst [dx * 3 + 2] = b;
+               break;
+            case 8 :
+               dst [dx] = lum;
+               break;
+            default :
+               if (lum < COVERAGE_THRESHOLD)
+                  dst [dx >> 3] |= 0x80 >> (dx & 7);
+               break;
+            }
+         }
+   width_out = ow;
+   height_out = oh;
+   stride_out = ostride;
+   return out;
+   }
+
+
 err_info *PPage::compressPage (Filepage *mp, bool mark_blank)
    {
    Kind kind = _autoColour ? this->kind () : Kind_colour;
+   int depth = kind == Kind_grey ? 8 : kind == Kind_mono ? 1 : _depth;
+
+   mp->_rotate = _rotate == Rotate_cw ? 90 : _rotate == Rotate_ccw ? 270 : 0;
 
    /* a colour page that turned out to need no colour is stored as grey
-      or, with no mid-tones either, as mono, from the decoded pixels */
-   if (kind != Kind_colour)
+      or, with no mid-tones either, as mono, and a page fed sideways is
+      turned upright: either is done from the decoded pixels */
+   if (depth != _depth || _rotate != Rotate_none)
       {
       const unsigned char *src = (const unsigned char *)
          (_jpeg ? _decomp.constData () : _data.constData ());
       int lines = _jpeg ? _decomp_avail / _stride : _data.size () / _stride;
-      int height = qMin (lines, _height);
-      int stride = kind == Kind_grey ? _width : (_width + 7) / 8;
-      QByteArray out (stride * height, '\0');
-      unsigned char *dst = (unsigned char *)out.data ();
+      int width, height, stride;
+      QByteArray out = convert (src, qMin (lines, _height), depth, width,
+                                height, stride);
 
-      for (int y = 0; y < height; y++, src += _stride, dst += stride)
-         {
-         const unsigned char *in = src;
-
-         for (int x = 0; x < _width; x++, in += 3)
-            {
-            int lum = (in [0] * 77 + in [1] * 150 + in [2] * 29) >> 8;
-
-            if (kind == Kind_grey)
-               dst [x] = lum;
-            else if (lum < COVERAGE_THRESHOLD)
-               dst [x >> 3] |= 0x80 >> (x & 7);   // 1 is black, as SANE has it
-            }
-         }
-      mp->addData (_width, height, kind == Kind_grey ? 8 : 1, stride, _name,
-                   false, mark_blank, _pagenum, out, out.size ());
+      mp->addData (width, height, depth, stride, _name, false, mark_blank,
+                   _pagenum, out, out.size ());
       return mp->compress ();
       }
 
@@ -1065,6 +1155,8 @@ void Paperscan::ensureStack (QString &stack_name, QString &page_name,
       _stack->setBlankPolicy ((Paperstack::t_blankPolicy)xmlConfig->intValue("SCAN_BLANK"),
                xmlConfig->intValue("SCAN_BLANK_THRESHOLD"));
       _stack->setAutoColour (xmlConfig->boolValue ("SCAN_AUTO_COLOUR"));
+      _stack->setSideways ((Paperstack::t_sideways)
+                           xmlConfig->intValue ("SCAN_SIDEWAYS"));
       emit stackNew (stack_name);
       }
    }

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -1126,6 +1126,7 @@ Paperscan::Paperscan (QObject *parent)
       thread is started, before scan() would have run */
    _end = false;
    _draining = false;
+   _stop_tried = false;
    _sides_done = 0;
    _t_start = _t_read = _t_data = _t_confirm = 0;
    _cpu_seconds = 0;
@@ -1345,6 +1346,7 @@ void Paperscan::scan ()
                total_b += blen;
                notifyProgress (_stack->curPageBack ());
                }
+            checkStopFeed ();
             }
          /* drain any final state notifyProgress() held back, so the
           * preview shows the complete page */
@@ -1495,6 +1497,7 @@ void Paperscan::scan ()
             steps++;
 //             qDebug () << "thread up to " << total;
             notifyProgress (_stack->curPage ());
+            checkStopFeed ();
             }
 
          // Check if error was due to double-feed
@@ -1584,8 +1587,8 @@ void Paperscan::scan ()
          ahead of us has sheets scanned that we have not read yet: if the
          backend can stop the feeder while keeping those, carry on until
          it runs dry. Otherwise stop here as before */
-      if (_end && !_draining && !done && !err && !isCancelled ())
-         _draining = _scanner->stopFeed ();
+      if (!done && !err && !isCancelled ())
+         checkStopFeed ();
       } while (!done && (!_end || _draining) && !err && !isCancelled ());
 
    _scanner->cancel ();
@@ -1695,6 +1698,7 @@ SANE_Status Paperscan::readSide (unsigned char *buf, int size, bool back,
       _t_data += QDateTime::currentMSecsSinceEpoch () - tr1;
       total += len;
       notifyProgress (back ? _stack->curPageBack () : _stack->curPage ());
+      checkStopFeed ();
       }
    return status;
    }
@@ -1773,6 +1777,27 @@ bool Paperscan::isCancelled (void)
    QMutexLocker locker (&_mutex);
 
    return _cancel;
+   }
+
+
+/* Stop means finish the batch rather than abandon it: the feeder stops
+   and the sheets already fed are read out. Ask for that the moment the
+   button is pressed, not at the end of the side, since a side can take
+   a long time to end when the paper misfeeds and until then the press
+   shows no sign of having done anything. Only worth asking once: a back
+   end that cannot stop the feeder says so, and the scan then ends after
+   this side as it always did */
+void Paperscan::checkStopFeed (void)
+   {
+   if (_stop_tried || _draining)
+      return;
+   _mutex.lock ();
+   bool ending = _end;
+   _mutex.unlock ();
+   if (!ending)
+      return;
+   _stop_tried = true;
+   _draining = _scanner->stopFeed ();
    }
 
 

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -352,7 +352,7 @@ PPage::PPage (int pagenum, int width, int height, int depth, int stride,
    {
    _autoColour = auto_colour;
    _colourPixels = _interiorPixels = 0;
-   _row_x = _row_skip = _rows_done = 0;
+   _row_x = _row_skip = _rows_done = _partial_len = 0;
    /* a back end that finds the foot of the sheet as it scans (the fujitsu
       backend with ald) cannot say the height when the page starts and
       reports -1. Size the buffers for a letter-shaped page for now; the
@@ -616,7 +616,7 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
       0, 1, 1, 2, 1, 2, 2, 3,
       1, 2, 2, 3, 2, 3, 3, 4
       };
-   int count = 0, pixels;
+   int count = 0, pixels = 0;
    const unsigned char *end = buf + size;
 
    // scan the buffer counting the number of non-blank pixels
@@ -652,9 +652,36 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
                _row_skip -= skip;
                continue;
                }
-            int lum = (buf [0] * 77 + buf [1] * 150 + buf [2] * 29) >> 8;
-            int mx = qMax (buf [0], qMax (buf [1], buf [2]));
-            int mn = qMin (buf [0], qMin (buf [1], buf [2]));
+
+            /* raw data arrives in chunks of any length, so a pixel can be
+               split across two: carry its first bytes over, or the rest
+               of the page is read a byte or two out of step and every
+               edge looks coloured */
+            const unsigned char *px;
+
+            if (_partial_len)
+               {
+               while (_partial_len < 3 && buf < end)
+                  _partial [_partial_len++] = *buf++;
+               if (_partial_len < 3)
+                  break;
+               px = _partial;
+               _partial_len = 0;
+               }
+            else if (end - buf < 3)
+               {
+               while (buf < end)
+                  _partial [_partial_len++] = *buf++;
+               break;
+               }
+            else
+               {
+               px = buf;
+               buf += 3;
+               }
+            int lum = (px [0] * 77 + px [1] * 150 + px [2] * 29) >> 8;
+            int mx = qMax (px [0], qMax (px [1], px [2]));
+            int mn = qMin (px [0], qMin (px [1], px [2]));
 
             if (lum < COVERAGE_THRESHOLD)
                count++;
@@ -663,7 +690,7 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
                colour++;
             if (_autoColour)
                inkPixel (lum);
-            buf += 3;
+            pixels++;
             }
          _colourPixels += colour;
          break;
@@ -671,7 +698,8 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
       }
 
    // work out total pixels in this block
-   pixels = size * 8 / _depth;
+   if (_depth != 24)
+      pixels = size * 8 / _depth;
 
    // if more than 1 in COVERAGE pixels are blank, consider it blank
 //   printf ("count = %d, pixels = %d\n", count, pixels);

--- a/paperstack.cpp
+++ b/paperstack.cpp
@@ -30,6 +30,8 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 #include "jpeglib.h"
 
+#include <QDir>
+#include <QFile>
 #include <QDateTime>
 #include <QDebug>
 
@@ -352,6 +354,7 @@ PPage::PPage (int pagenum, int width, int height, int depth, int stride,
    {
    _autoColour = auto_colour;
    _colourPixels = _interiorPixels = 0;
+   _colourBand [0] = _colourBand [1] = _colourBand [2] = 0;
    _row_x = _row_skip = _rows_done = _partial_len = 0;
    /* a back end that finds the foot of the sheet as it scans (the fujitsu
       backend with ald) cannot say the height when the page starts and
@@ -687,7 +690,10 @@ bool PPage::checkBlank (const unsigned char *buf, int size)
                count++;
             if ((mx - mn) * SATURATION_DIVISOR >= mx
                 && mx >= SATURATION_MIN_BRIGHT)
+               {
                colour++;
+               _colourBand [lum < 100 ? 0 : lum < 200 ? 1 : 2]++;
+               }
             if (_autoColour)
                inkPixel (lum);
             pixels++;
@@ -954,6 +960,36 @@ QString PPage::coverageStr ()
    {
    double cov;
    QString suffix = _autoColour ? kind_suffix (kind ()) : "";
+
+   /* PAPERMAN_KIND_DEBUG shows what the page-kind test saw, for tuning
+      its thresholds against real scans */
+   const char *debug = getenv ("PAPERMAN_KIND_DEBUG");
+
+   if (debug && QDir (debug).exists ())
+      {
+      /* a directory: keep the page's data as well, the scanner's JPEG or
+         the raw pixels as a PPM, to run the test on outside the scan */
+      QFile f (QString ("%1/page%2.%3").arg (debug).arg (_pagenum)
+               .arg (_jpeg ? "jpg" : "ppm"));
+
+      if (f.open (QIODevice::WriteOnly))
+         {
+         if (!_jpeg && _depth == 24)
+            f.write (QString ("P6\n%1 %2\n255\n").arg (_width)
+                     .arg (_data.size () / _stride).toLatin1 ());
+         f.write (_data);
+         }
+      }
+   if (debug)
+      fprintf (stderr, "page %d: %dx%d depth %d%s pixels %d, colour %d "
+               "(%.3f%%: dark %d mid %d light %d), interior %d (%.3f%%)%s\n",
+               _pagenum, _width, _height, _depth, _jpeg ? " jpeg" : "",
+               _pixels, _colourPixels,
+               _pixels ? 100.0 * _colourPixels / _pixels : 0,
+               _colourBand [0], _colourBand [1], _colourBand [2],
+               _interiorPixels,
+               _pixels ? 100.0 * _interiorPixels / _pixels : 0,
+               qPrintable (suffix));
 
    // can't work out coverage from JPEG data
 //    if (_jpeg)

--- a/paperstack.h
+++ b/paperstack.h
@@ -414,6 +414,17 @@ public:
          int &depth, int &stride);
 
 protected:
+   /** Read one side of the current sheet with sane_read(), for a scanner
+       which turns out not to support sane_read_dup()
+
+      \param buf     buffer to read into
+      \param size    size of buffer
+      \param back    true to feed the back-side image, false the front
+      \param total   updated with the number of bytes read
+      \returns SANE_STATUS_EOF when the side is complete, else an error */
+   SANE_Status readSide (unsigned char *buf, int size, bool back,
+                         long &total);
+
    /** our run loop */
    void run (void);
 

--- a/paperstack.h
+++ b/paperstack.h
@@ -425,6 +425,13 @@ protected:
    SANE_Status readSide (unsigned char *buf, int size, bool back,
                          long &total);
 
+   /** Describe a failed SANE call, for the user
+
+      \param status  the status it returned
+      \param page    page being scanned at the time, or 0 if none
+      \returns a message naming the call, the device and the status */
+   QString failStr (SANE_Status status, int page);
+
    /** our run loop */
    void run (void);
 
@@ -504,6 +511,7 @@ private:
    QString _stack_name;       //!< suggested stack name
    QString _page_name;        //!< suggested page name
    QString _progress_str;     //!< place to put progress information
+   QString _op;               //!< the SANE call in progress, for errors
    QString _info_str;         //!< place to put information string
    Paperstack *_stack;        //!< current stack we are scanning into
    QMutex _mutex;             //!< mutex to protect our variables

--- a/paperstack.h
+++ b/paperstack.h
@@ -306,6 +306,12 @@ public:
    /** Mirror of addImageBytes() for the back side. */
    bool addImageBytesBack (unsigned char *buf, int size);
 
+   /** Start the back page again with a new size, before any of its data
+       has arrived: the back is its own image and a back end that crops
+       each side to its content can make it a different size from the
+       front. Takes the same arguments as addImageBack() */
+   int restartBack (int width, int height, int depth, int stride, bool jpeg);
+
    /** confirm an image - add it to the stack - call this when there is
        no more data
 

--- a/paperstack.h
+++ b/paperstack.h
@@ -117,6 +117,14 @@ public:
       Kind_mono      //!< dark marks on white only: text, line art
       };
 
+   /** how a page is turned as it is stored, to be upright */
+   enum Rotate
+      {
+      Rotate_none,
+      Rotate_cw,     //!< a quarter turn clockwise
+      Rotate_ccw     //!< a quarter turn anticlockwise
+      };
+
 private:
    /** constructor for page
 
@@ -128,12 +136,28 @@ private:
       \param jpeg     true if data being added with addBytes is JPEG compressed
       \param blank_threshold  blank threshold 1:n
       \param auto_colour  true to store a colour page as grey or mono when
-                        its pixels show it needs no more */
+                        its pixels show it needs no more
+      \param rotate   how to turn the page as it is stored */
    PPage (int pagenum, int width, int height, int depth, int stride,
-         bool jpeg, int blank_threshold, bool auto_colour);
+         bool jpeg, int blank_threshold, bool auto_colour,
+         Rotate rotate = Rotate_none);
 
    /** the kind of page this is, from the pixels counted so far */
    Kind kind (void) const;
+
+private:
+   /** build the page as stored from its decoded pixels, at the given
+       depth and turned as _rotate says
+
+      \param src      the decoded pixels, _stride bytes per row
+      \param height   rows of them
+      \param depth    depth wanted: 24, 8 or 1
+      \param width_out, height_out, stride_out  the result's shape
+      \returns the pixels of the page as stored */
+   QByteArray convert (const unsigned char *src, int height, int depth,
+                       int &width_out, int &height_out, int &stride_out) const;
+
+public:
 
 private:
    /** feed the next pixel's luminance to the filled-region count */
@@ -230,6 +254,7 @@ private:
    int _pixels;         //!< total number of pixels
    int _pixelTarget;    //!< number of non-white pixels we need to have a non-blank page
    bool _autoColour;    //!< store the page as grey or mono if it is not colour
+   Rotate _rotate;      //!< how to turn the page as it is stored
    int _colourPixels;   //!< pixels with a noticeable saturation
    int _colourBand [3]; //!< those pixels by luminance: dark, mid, light
    int _interiorPixels; //!< mid-tone pixels inside a filled region, see kind()
@@ -281,6 +306,25 @@ public:
    /** store colour pages as grey or mono when their pixels show they need
        no more, or keep them as scanned */
    void setAutoColour (bool on);
+
+   /** how the sheets are fed: upright, or sideways with the top of the
+       page at the left or the right of the front */
+   enum t_sideways
+      {
+      Sideways_no,
+      Sideways_top_left,
+      Sideways_top_right
+      };
+
+   /** say how the sheets are fed, so that pages fed sideways are turned
+       upright as they are stored: the back of a sheet is seen from the
+       other side, so its top is at the opposite edge */
+   void setSideways (t_sideways how);
+
+   /** the turn a page needs to be upright, from how the sheets are fed
+
+      \param front   true for the front of a sheet, false for the back */
+   PPage::Rotate rotationFor (bool front) const;
 
    /** adds a new image with the given parameters - data will come later.
        The image depth also determines the number of colours.
@@ -391,6 +435,7 @@ private:
    t_blankPolicy _blankPolicy;  //!< what to do with blank pages
    int _blankThreshold;         //!< threshold for blank pages 1:n
    bool _autoColour;            //!< reduce colour pages that need no colour
+   t_sideways _sideways;        //!< how the sheets are fed
    bool _front;                 //!< true if this is a front page (else back)
    bool _jpeg;                  //!< true if we are doing JPEG compression (else raw data)
 

--- a/paperstack.h
+++ b/paperstack.h
@@ -392,6 +392,12 @@ public:
        the page, so that another message may be sent for it */
    void progressHandled (const PPage *page);
 
+   //! number of sides the scanning thread has finished so far
+   int sidesDone (void) const { return _sides_done; }
+
+   //! CPU time used by the scanning thread, in seconds, once it has finished
+   double cpuSeconds (void) const { return _cpu_seconds; }
+
    /** free a previously scanned page */
    void pageAdded (const Filepage *mp);
 
@@ -536,6 +542,8 @@ private:
    err_info _cancel_err;      //!< error to return from a cancel operation
    bool _end;                 //!< true to end the scan
    bool _draining;            //!< feeder stopped; reading out its buffered pages
+   int _sides_done;           //!< sides finished, for the display to compare with
+   double _cpu_seconds;       //!< CPU time used by run()
    QSet<int> _progress_pending;   //!< pages with a progress message not yet handled
    QHash<int, qint64> _progress_time; //!< when each page last sent progress
    QElapsedTimer _progress_clock;  //!< clock for _progress_time

--- a/paperstack.h
+++ b/paperstack.h
@@ -140,6 +140,10 @@ private:
    /** set up ready for jpeg decompression */
    void setupJpeg (void);
 
+   /** the back end did not know the height when the page started: now it
+       is known, size the buffers and the blank-page target for it */
+   void setHeight (int height);
+
    /** continue JPEG decompression with any new data we have */
    void continueJpeg (void);
 
@@ -190,7 +194,8 @@ private:
 private:
    int _size;     //!< size of image in bytes
    int _width;    //!< width of image
-   int _height;   //!< height of image
+   int _height;   //!< height of image, provisional until _height_known
+   bool _height_known;  //!< false while the back end has yet to say the height
    int _depth;    //!< depth of image
    int _stride;   //!< number of bytes per line
 //   unsigned char *_buf;    //!< buffer containing image

--- a/paperstack.h
+++ b/paperstack.h
@@ -231,6 +231,7 @@ private:
    int _pixelTarget;    //!< number of non-white pixels we need to have a non-blank page
    bool _autoColour;    //!< store the page as grey or mono if it is not colour
    int _colourPixels;   //!< pixels with a noticeable saturation
+   int _colourBand [3]; //!< those pixels by luminance: dark, mid, light
    int _interiorPixels; //!< mid-tone pixels inside a filled region, see kind()
    int _row_x;          //!< pixels of the current row seen so far
    int _row_skip;       //!< padding bytes of the current row still to skip

--- a/paperstack.h
+++ b/paperstack.h
@@ -631,6 +631,9 @@ private:
       \returns true if the scan should be cancelled, false if all ok */
    bool isCancelled (void);
 
+   /** stop the feeder if Stop has been pressed, at most once */
+   void checkStopFeed (void);
+
 private:
    QScanner *_scanner;        //!< the scanner we are using
    QString _stack_name;       //!< suggested stack name
@@ -645,6 +648,7 @@ private:
    err_info _cancel_err;      //!< error to return from a cancel operation
    bool _end;                 //!< true to end the scan
    bool _draining;            //!< feeder stopped; reading out its buffered pages
+   bool _stop_tried;          //!< the feeder has been asked to stop once
    int _sides_done;           //!< sides finished, for the display to compare with
    int _max_waiting;          //!< most images seen waiting in the scanner
    /* where the scanning thread's time goes, in ms, for

--- a/paperstack.h
+++ b/paperstack.h
@@ -398,6 +398,9 @@ public:
    //! CPU time used by the scanning thread, in seconds, once it has finished
    double cpuSeconds (void) const { return _cpu_seconds; }
 
+   //! the most images the scanner has had waiting for us, or -1 if unknown
+   int maxWaiting (void) const { return _max_waiting; }
+
    /** free a previously scanned page */
    void pageAdded (const Filepage *mp);
 
@@ -543,6 +546,7 @@ private:
    bool _end;                 //!< true to end the scan
    bool _draining;            //!< feeder stopped; reading out its buffered pages
    int _sides_done;           //!< sides finished, for the display to compare with
+   int _max_waiting;          //!< most images seen waiting in the scanner
    double _cpu_seconds;       //!< CPU time used by run()
    QSet<int> _progress_pending;   //!< pages with a progress message not yet handled
    QHash<int, qint64> _progress_time; //!< when each page last sent progress

--- a/paperstack.h
+++ b/paperstack.h
@@ -109,6 +109,14 @@ public:
        progress events during a progressive duplex scan). */
    int pagenum (void) const { return _pagenum; }
 
+   /** what a page turned out to hold, judged from its pixels */
+   enum Kind
+      {
+      Kind_colour,   //!< enough coloured pixels to be worth keeping in colour
+      Kind_grey,     //!< no colour, but mid-tones: a greyscale page
+      Kind_mono      //!< dark marks on white only: text, line art
+      };
+
 private:
    /** constructor for page
 
@@ -118,9 +126,23 @@ private:
       \param depth    depth of image in bits per pixel (1, 8 or 24)
       \param stride   bytes per line
       \param jpeg     true if data being added with addBytes is JPEG compressed
-      \param blank_threshold  blank threshold 1:n */
+      \param blank_threshold  blank threshold 1:n
+      \param auto_colour  true to store a colour page as grey or mono when
+                        its pixels show it needs no more */
    PPage (int pagenum, int width, int height, int depth, int stride,
-         bool jpeg, int blank_threshold);
+         bool jpeg, int blank_threshold, bool auto_colour);
+
+   /** the kind of page this is, from the pixels counted so far */
+   Kind kind (void) const;
+
+private:
+   /** feed the next pixel's luminance to the filled-region count */
+   void inkPixel (int lum);
+
+   /** what a pixel is for the filled-region count */
+   enum Ink { Ink_none, Ink_dark, Ink_mid };
+
+public:
    ~PPage ();
    bool addBytes (const unsigned char *buf, int size);
 
@@ -207,6 +229,14 @@ private:
    int _nonblankPixels;     //!< number of non-white pixels
    int _pixels;         //!< total number of pixels
    int _pixelTarget;    //!< number of non-white pixels we need to have a non-blank page
+   bool _autoColour;    //!< store the page as grey or mono if it is not colour
+   int _colourPixels;   //!< pixels with a noticeable saturation
+   int _interiorPixels; //!< mid-tone pixels inside a filled region, see kind()
+   int _row_x;          //!< pixels of the current row seen so far
+   int _row_skip;       //!< padding bytes of the current row still to skip
+   QByteArray _rows;    //!< a ring of INTERIOR_ROWS rows of eroded Ink flags
+   int _rows_done;      //!< rows completed so far
+   QVector<int> _row_counts; //!< interior pixels of the last EDGE_ROWS rows
    bool _mark_blank;    //!< true to mark page blank
 //   Desktopmodel *_model;   //!< model that this page is destined for
    QByteArray _data;    //!< data bytes
@@ -244,6 +274,10 @@ public:
 
    /** set the blank policy and threshold */
    void setBlankPolicy (t_blankPolicy policy, int blank_threshold);
+
+   /** store colour pages as grey or mono when their pixels show they need
+       no more, or keep them as scanned */
+   void setAutoColour (bool on);
 
    /** adds a new image with the given parameters - data will come later.
        The image depth also determines the number of colours.
@@ -347,6 +381,7 @@ private:
    bool _scanning;              //!< are we scanning at the moment?
    t_blankPolicy _blankPolicy;  //!< what to do with blank pages
    int _blankThreshold;         //!< threshold for blank pages 1:n
+   bool _autoColour;            //!< reduce colour pages that need no colour
    bool _front;                 //!< true if this is a front page (else back)
    bool _jpeg;                  //!< true if we are doing JPEG compression (else raw data)
 

--- a/paperstack.h
+++ b/paperstack.h
@@ -519,6 +519,7 @@ private:
    bool _cancel;              //!< true to cancel the scan
    err_info _cancel_err;      //!< error to return from a cancel operation
    bool _end;                 //!< true to end the scan
+   bool _draining;            //!< feeder stopped; reading out its buffered pages
    };
 
 

--- a/paperstack.h
+++ b/paperstack.h
@@ -234,6 +234,8 @@ private:
    int _interiorPixels; //!< mid-tone pixels inside a filled region, see kind()
    int _row_x;          //!< pixels of the current row seen so far
    int _row_skip;       //!< padding bytes of the current row still to skip
+   unsigned char _partial [3]; //!< bytes of a pixel split across chunks
+   int _partial_len;    //!< how many of them there are
    QByteArray _rows;    //!< a ring of INTERIOR_ROWS rows of eroded Ink flags
    int _rows_done;      //!< rows completed so far
    QVector<int> _row_counts; //!< interior pixels of the last EDGE_ROWS rows

--- a/paperstack.h
+++ b/paperstack.h
@@ -495,6 +495,12 @@ public:
    //! the most images the scanner has had waiting for us, or -1 if unknown
    int maxWaiting (void) const { return _max_waiting; }
 
+   /** where the scanning thread's time went, in ms */
+   void phases (qint64 &start, qint64 &read, qint64 &data,
+                qint64 &confirm) const
+      { start = _t_start; read = _t_read; data = _t_data;
+        confirm = _t_confirm; }
+
    /** free a previously scanned page */
    void pageAdded (const Filepage *mp);
 
@@ -641,6 +647,13 @@ private:
    bool _draining;            //!< feeder stopped; reading out its buffered pages
    int _sides_done;           //!< sides finished, for the display to compare with
    int _max_waiting;          //!< most images seen waiting in the scanner
+   /* where the scanning thread's time goes, in ms, for
+      PAPERMAN_SCAN_STATS: they should account for most of the scan */
+   qint64 _t_start;           //!< in sane_start(), where a network back
+                              //!< end fetches and decodes the whole page
+   qint64 _t_read;            //!< in sane_read(), taking the data over
+   qint64 _t_data;            //!< counting coverage and colour as it lands
+   qint64 _t_confirm;         //!< turning the page and writing it out
    double _cpu_seconds;       //!< CPU time used by run()
    QSet<int> _progress_pending;   //!< pages with a progress message not yet handled
    QHash<int, qint64> _progress_time; //!< when each page last sent progress

--- a/paperstack.h
+++ b/paperstack.h
@@ -38,6 +38,9 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 
 
 #include <QMutex>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QSet>
 #include <QThread>
 #include <QWaitCondition>
 
@@ -385,6 +388,10 @@ public:
    /** stop scanning after the current page */
    void endScan (void);
 
+   /** Called by the receiver of stackPageProgress() once it has looked at
+       the page, so that another message may be sent for it */
+   void progressHandled (const PPage *page);
+
    /** free a previously scanned page */
    void pageAdded (const Filepage *mp);
 
@@ -479,7 +486,7 @@ signals:
 
    /** indicate that more bytes have arrived for the current page being scanned
        These are available through Paperstack->getData() */
-   void stackPageProgress (const PPage *page);
+   void stackPageProgress (const PPage *page);   // sent through notifyProgress()
 
    /** provide the user with the number of bytes so far read
 
@@ -501,6 +508,15 @@ private:
 
    void scan (void);
 
+   /** Tell the main thread that a page has more data, coalescing messages
+       so that at most one is outstanding per page and no more than one
+       every PROGRESS_INTERVAL ms
+
+      \param page    page with more data, or NULL for none
+      \param final   true if this is the page's last data, which must be
+                     shown, so the interval does not apply */
+   void notifyProgress (const PPage *page, bool final = false);
+
    /** check if the scan should be cancelled
 
       \returns true if the scan should be cancelled, false if all ok */
@@ -520,6 +536,9 @@ private:
    err_info _cancel_err;      //!< error to return from a cancel operation
    bool _end;                 //!< true to end the scan
    bool _draining;            //!< feeder stopped; reading out its buffered pages
+   QSet<int> _progress_pending;   //!< pages with a progress message not yet handled
+   QHash<int, qint64> _progress_time; //!< when each page last sent progress
+   QElapsedTimer _progress_clock;  //!< clock for _progress_time
    };
 
 

--- a/pdfio.cpp
+++ b/pdfio.cpp
@@ -47,14 +47,74 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 using namespace PoDoFo;
 
 
-/* PoDoFo 1.x reworked its API: pages live in a PdfPageCollection,
+/* PoDoFo 0.10 reworked its API, which 1.x then kept: pages live in a PdfPageCollection,
    images are created by the document and described by PdfImageInfo,
    the content tokenizer became PdfContentStreamReader and most accessors
    return references rather than pointers. Debian and Ubuntu still ship
    0.9.8 while MSYS2 (used for the Windows build) has 1.x, so support
    both */
-#if PODOFO_VERSION_MAJOR >= 1
+#if PODOFO_VERSION_MAJOR > 0 || PODOFO_VERSION_MINOR >= 10
 #define PODOFO_1X
+#endif
+
+#ifdef PODOFO_1X
+
+/* the few places where 0.10 and 1.x differ */
+#if PODOFO_VERSION_MAJOR >= 1
+typedef PdfColorSpaceType PdfColourSpace;
+
+static inline PdfPage &create_a4_page (PdfMemDocument &doc)
+   {
+   return doc.GetPages ().CreatePage (PdfPageSize::A4);
+   }
+
+static inline int get_page_rotation (const PdfPage &page)
+   {
+   return (int)page.GetRotation ();
+   }
+
+static inline void set_page_rotation (PdfPage &page, int degrees)
+   {
+   page.SetRotation (degrees);
+   }
+
+static inline const PdfResources *page_resources (const PdfPage &page)
+   {
+   return &page.GetResources ();
+   }
+
+// report Do as a plain operator rather than resolving the XObject
+static const PdfContentReaderFlags READER_FLAGS = (PdfContentReaderFlags)
+      ((int)PdfContentReaderFlags::SkipFollowFormXObjects
+       | (int)PdfContentReaderFlags::SkipHandleNonFormXObjects);
+#else
+typedef PdfColorSpace PdfColourSpace;
+
+static inline PdfPage &create_a4_page (PdfMemDocument &doc)
+   {
+   return doc.GetPages ().CreatePage (
+         PdfPage::CreateStandardPageSize (PdfPageSize::A4));
+   }
+
+static inline int get_page_rotation (const PdfPage &page)
+   {
+   return page.GetRotationRaw ();
+   }
+
+static inline void set_page_rotation (PdfPage &page, int degrees)
+   {
+   page.SetRotationRaw (degrees);
+   }
+
+static inline const PdfResources *page_resources (const PdfPage &page)
+   {
+   return page.GetResources ();
+   }
+
+static const PdfContentReaderFlags READER_FLAGS =
+      PdfContentReaderFlags::DontFollowXObjectForms;
+#endif
+
 #endif
 
 
@@ -239,8 +299,8 @@ static void set_image_pixels (PdfImage &image, const QByteArray &ba,
    info.Width = width;
    info.Height = height;
    info.BitsPerComponent = depth == 1 ? 1 : 8;
-   info.ColorSpace = depth <= 8 ? PdfColorSpaceType::DeviceGray
-         : PdfColorSpaceType::DeviceRGB;
+   info.ColorSpace = depth <= 8 ? PdfColourSpace::DeviceGray
+         : PdfColourSpace::DeviceRGB;
    image.SetDataRaw (bufferview (ba.constData (), ba.size ()), info);
 
    /* SetDataRaw() stores the bytes as they are, so compress them now */
@@ -258,7 +318,7 @@ err_info *Pdfio::addPage (const Filepage *mp)
       {
       Q_ASSERT (_doc);
 #ifdef PODOFO_1X
-      PdfPage &page = _doc->GetPages ().CreatePage (PdfPageSize::A4);
+      PdfPage &page = create_a4_page (*_doc);
 
       QImage imthumb;
       QByteArray ba = mp->getThumbnailRaw (false, imthumb, false);
@@ -361,7 +421,7 @@ err_info *Pdfio::addPageJpeg(const QByteArray &jpegData, int width, int height,
       {
       Q_ASSERT (_doc);
 #ifdef PODOFO_1X
-      PdfPage &page = _doc->GetPages ().CreatePage (PdfPageSize::A4);
+      PdfPage &page = create_a4_page (*_doc);
       std::unique_ptr<PdfImage> image = _doc->CreateImage ();
       PdfImageInfo info;
 
@@ -370,8 +430,8 @@ err_info *Pdfio::addPageJpeg(const QByteArray &jpegData, int width, int height,
       info.Height = height;
       info.BitsPerComponent = 8;
       info.Filters = PdfFilterList {PdfFilterType::DCTDecode};
-      info.ColorSpace = colour ? PdfColorSpaceType::DeviceRGB
-            : PdfColorSpaceType::DeviceGray;
+      info.ColorSpace = colour ? PdfColourSpace::DeviceRGB
+            : PdfColourSpace::DeviceGray;
       image->SetDataRaw (bufferview (jpegData.constData (), jpegData.size ()),
                          info);
       draw_scaled (page, *image);
@@ -441,7 +501,8 @@ err_info *Pdfio::make_error (const PdfError &eCode)
 int Pdfio::page_rotation (int pagenum) const
    {
 #ifdef PODOFO_1X
-   return (int)_doc->GetPages ().GetPageAt (pagenum).GetRotation () % 360;
+   return ((get_page_rotation (_doc->GetPages ().GetPageAt (pagenum)) % 360)
+           + 360) % 360;
 #else
    return ((_doc->GetPage (pagenum)->GetRotation () % 360) + 360) % 360;
 #endif
@@ -687,7 +748,7 @@ err_info *Pdfio::rotatePage (int pagenum, int degrees)
          return err_make (ERRFN, ERR_could_not_find_image_chunk_for_page1,
                pagenum + 1);
       PdfPage &page = pages.GetPageAt (pagenum);
-      page.SetRotation ((page.GetRotation () + degrees) % 360);
+      set_page_rotation (page, (get_page_rotation (page) + degrees) % 360);
 #else
       PdfPage *page = _doc->GetPage (pagenum);
 
@@ -733,22 +794,26 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
    PdfPage &page = _doc->GetPages ().GetPageAt (pagenum);
    PdfContentReaderArgs args;
 
-   // report Do as a plain operator rather than resolving the XObject
-   args.Flags = (PdfContentReaderFlags)
-         ((int)PdfContentReaderFlags::SkipFollowFormXObjects
-          | (int)PdfContentReaderFlags::SkipHandleNonFormXObjects);
+   args.Flags = READER_FLAGS;
    PdfContentStreamReader reader (page, args);
    PdfContent content;
 
    while (image_only && reader.TryReadNext (content))
       {
-      switch (content.GetType ())
+#if PODOFO_VERSION_MAJOR >= 1
+      PdfContentType type = content.GetType ();
+      PdfOperator op = content.GetOperator ();
+      const PdfVariantStack &stack = content.GetStack ();
+      const PdfName *name = NULL;
+#else
+      PdfContentType type = content.Type;
+      PdfOperator op = content.Operator;
+      const PdfVariantStack &stack = content.Stack;
+      const PdfName *name = content.Name;
+#endif
+      switch (type)
          {
          case PdfContentType::Operator :
-            {
-            PdfOperator op = content.GetOperator ();
-            const PdfVariantStack &stack = content.GetStack ();
-
             if (op != PdfOperator::q && op != PdfOperator::Q
                 && op != PdfOperator::cm && op != PdfOperator::Do)
                image_only = false;
@@ -757,7 +822,13 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
                image_name = QString::fromStdString (
                      std::string (stack [0].GetName ().GetString ()));
             break;
-            }
+
+         /* 0.10 resolves the Do itself and reports the XObject's name */
+         case PdfContentType::DoXObject :
+            if (name && image_name.isEmpty ())
+               image_name = QString::fromStdString (
+                     std::string (name->GetString ()));
+            break;
 
          case PdfContentType::UnexpectedKeyword :
             image_only = false;
@@ -772,8 +843,9 @@ const PdfObject *Pdfio::get_image_obj (int pagenum, const PdfDictionary *&dict)
 
    /* find the XObject the page draws: the one named by Do if we saw it,
       otherwise the last one in the resources */
-   const PdfResources &res = page.GetResources ();
-   const PdfObject *xobjects = res.GetDictionary ().FindKey ("XObject");
+   const PdfResources *res = page_resources (page);
+   const PdfObject *xobjects = res
+         ? res->GetDictionary ().FindKey ("XObject") : nullptr;
    if (xobjects && xobjects->IsDictionary ())
       {
       for (auto &pair : xobjects->GetDictionary ())

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -543,6 +543,12 @@ void Pscan::progressSize( const char *str )
 }
 
 
+void Pscan::progressRate( const QString &str )
+{
+    rateStr->setText (str);
+}
+
+
 void Pscan::setupBright()
 {
     int exp, min, max;

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -74,6 +74,9 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     connect(duplex, SIGNAL(clicked()), this, SLOT(duplex_clicked()));
     connect(autosize, SIGNAL(clicked()), this, SLOT(autosize_clicked()));
     autosize->hide ();
+    connect(autocolour, SIGNAL(clicked()), this, SLOT(autocolour_clicked()));
+    if (xmlConfig)
+       autocolour->setChecked (xmlConfig->boolValue ("SCAN_AUTO_COLOUR"));
     connect(adf, SIGNAL(clicked()), this, SLOT(adf_clicked()));
     connect(scan, SIGNAL(clicked()), this, SLOT(scan_clicked()));
     connect(settings, SIGNAL(clicked()), this, SLOT(settings_clicked()));
@@ -361,6 +364,15 @@ void Pscan::autosize_clicked()
       _scanDialog->setAutoSize (autosize->isChecked ());
    /* the scan area no longer applies while the scanner is cropping */
    pageSize->setDisabled (autosize->isChecked ());
+}
+
+
+/* paperman does this itself, from the pixels, so it is a setting of ours
+   rather than one of the scanner's */
+void Pscan::autocolour_clicked()
+{
+   if (xmlConfig)
+      xmlConfig->setBoolValue ("SCAN_AUTO_COLOUR", autocolour->isChecked ());
 }
 
 

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -75,8 +75,12 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     connect(autosize, SIGNAL(clicked()), this, SLOT(autosize_clicked()));
     autosize->hide ();
     connect(autocolour, SIGNAL(clicked()), this, SLOT(autocolour_clicked()));
+    connect(sideways, SIGNAL(activated(int)), this, SLOT(sideways_activated(int)));
     if (xmlConfig)
+       {
        autocolour->setChecked (xmlConfig->boolValue ("SCAN_AUTO_COLOUR"));
+       sideways->setCurrentIndex (xmlConfig->intValue ("SCAN_SIDEWAYS"));
+       }
     connect(adf, SIGNAL(clicked()), this, SLOT(adf_clicked()));
     connect(scan, SIGNAL(clicked()), this, SLOT(scan_clicked()));
     connect(settings, SIGNAL(clicked()), this, SLOT(settings_clicked()));
@@ -373,6 +377,14 @@ void Pscan::autocolour_clicked()
 {
    if (xmlConfig)
       xmlConfig->setBoolValue ("SCAN_AUTO_COLOUR", autocolour->isChecked ());
+}
+
+
+/* likewise paperman turns the pages itself */
+void Pscan::sideways_activated(int how)
+{
+   if (xmlConfig)
+      xmlConfig->setIntValue ("SCAN_SIDEWAYS", how);
 }
 
 

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -72,6 +72,8 @@ Pscan::Pscan(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     connect(pageSize, SIGNAL(activated(int)), this, SLOT(size_activated(int)));
     connect(res, SIGNAL(activated(int)), this, SLOT(res_activated(int)));
     connect(duplex, SIGNAL(clicked()), this, SLOT(duplex_clicked()));
+    connect(autosize, SIGNAL(clicked()), this, SLOT(autosize_clicked()));
+    autosize->hide ();
     connect(adf, SIGNAL(clicked()), this, SLOT(adf_clicked()));
     connect(scan, SIGNAL(clicked()), this, SLOT(scan_clicked()));
     connect(settings, SIGNAL(clicked()), this, SLOT(settings_clicked()));
@@ -298,6 +300,7 @@ void Pscan::scannerChanged (QScanner *scanner)
     if (b)
         b->setChecked(true);
     setupBright ();
+    updateAutoSize ();
     if (_do_preset_check)
        presetCheck();
     _folders->checkFolders();
@@ -349,6 +352,30 @@ void Pscan::adf_clicked()
 void Pscan::duplex_clicked()
 {
    _scanDialog->setDuplex (duplex->isChecked ());
+}
+
+
+void Pscan::autosize_clicked()
+{
+   if (_scanDialog)
+      _scanDialog->setAutoSize (autosize->isChecked ());
+   /* the scan area no longer applies while the scanner is cropping */
+   pageSize->setDisabled (autosize->isChecked ());
+}
+
+
+void Pscan::updateAutoSize (void)
+{
+   bool has = _scanDialog && _scanDialog->hasAutoSize ();
+
+   autosize->setVisible (has);
+   if (has)
+      {
+      autosize->setChecked (_scanDialog->autoSize ());
+      pageSize->setDisabled (autosize->isChecked ());
+      }
+   else
+      pageSize->setEnabled (true);
 }
 
 
@@ -506,6 +533,7 @@ void Pscan::setPreviewWidget( PreviewWidget *widget )
 void Pscan::setScanDialog( QScanDialog *dialog )
 {
    _scanDialog = dialog;
+   updateAutoSize ();
 }
 
 

--- a/pscan.cpp
+++ b/pscan.cpp
@@ -396,7 +396,12 @@ void Pscan::updateAutoSize (void)
    if (has)
       {
       autosize->setChecked (_scanDialog->autoSize ());
-      pageSize->setDisabled (autosize->isChecked ());
+      /* only leave the size out of the user's hands when auto-size
+         trims the width too. The fujitsu backend's ald trims the length
+         alone, so the paper width still decides where a page is cut,
+         and it is the setting to reach for when one comes out short */
+      pageSize->setDisabled (autosize->isChecked ()
+                             && _scanDialog->autoSizeTrimsWidth ());
       }
    else
       pageSize->setEnabled (true);

--- a/pscan.h
+++ b/pscan.h
@@ -113,6 +113,8 @@ public slots:
     virtual void setPreviewWidget( PreviewWidget * widget );
     virtual void setScanDialog( QScanDialog * dialog );
     virtual void progressSize( const char * str );
+    //! show the rate pages are arriving at, or clear it with an empty string
+    void progressRate( const QString & str );
     virtual void info( const char * str );
     virtual void options_clicked();
     virtual void presetShortcut1();

--- a/pscan.h
+++ b/pscan.h
@@ -101,6 +101,7 @@ public slots:
     virtual void duplex_clicked();
     virtual void autosize_clicked();
     virtual void autocolour_clicked();
+    virtual void sideways_activated(int how);
     virtual void res_activated( int id );
     virtual void brightChanged( int bright );
     virtual void contrastChanged( int contrast );

--- a/pscan.h
+++ b/pscan.h
@@ -89,6 +89,9 @@ public:
 
 public slots:
     virtual void scannerChanged( QScanner * scanner );
+
+    /** Show and set the Auto-size box to match the scanner's option */
+    void updateAutoSize (void);
     virtual void setMainwidget( Mainwidget * main );
     virtual void source_clicked();
     virtual void settings_clicked();
@@ -96,6 +99,7 @@ public slots:
     virtual void pendingDone();
     virtual void adf_clicked();
     virtual void duplex_clicked();
+    virtual void autosize_clicked();
     virtual void res_activated( int id );
     virtual void brightChanged( int bright );
     virtual void contrastChanged( int contrast );

--- a/pscan.h
+++ b/pscan.h
@@ -63,6 +63,8 @@ public:
 
 class Pscan : public QDialog, public Ui::Pscan
 {
+    friend class TestQscanner;
+
     Q_OBJECT
 
 public:

--- a/pscan.h
+++ b/pscan.h
@@ -100,6 +100,7 @@ public slots:
     virtual void adf_clicked();
     virtual void duplex_clicked();
     virtual void autosize_clicked();
+    virtual void autocolour_clicked();
     virtual void res_activated( int id );
     virtual void brightChanged( int bright );
     virtual void contrastChanged( int contrast );

--- a/pscan.ui
+++ b/pscan.ui
@@ -497,6 +497,16 @@ Use Ctrl-1 to Ctrl-6 to select the first 6 presets</string>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="autocolour">
+           <property name="toolTip">
+            <string>When scanning in colour, store pages that have no colour as grey, or as mono if they have no shading either</string>
+           </property>
+           <property name="text">
+            <string>Auto colour</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/pscan.ui
+++ b/pscan.ui
@@ -479,6 +479,16 @@ Use Ctrl-1 to Ctrl-6 to select the first 6 presets</string>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="autosize">
+           <property name="toolTip">
+            <string>Let the scanner detect each sheet's size and crop to it</string>
+           </property>
+           <property name="text">
+            <string>Auto size</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/pscan.ui
+++ b/pscan.ui
@@ -278,23 +278,46 @@ Use Ctrl-F or F4 to quickly access this field</string>
         </layout>
        </item>
        <item>
+        <widget class="QLabel" name="progressStr">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Displays page and stack number while scanning</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
-          <widget class="QLabel" name="progressStr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="rateStr">
            <property name="toolTip">
-            <string>Displays page and stack number while scanning</string>
+            <string>Pages received per second, averaged over the last ten seconds</string>
            </property>
            <property name="text">
             <string/>
-           </property>
-           <property name="wordWrap">
-            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -304,7 +327,7 @@ Use Ctrl-F or F4 to quickly access this field</string>
             <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
+            <enum>QSizePolicy::Fixed</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -316,26 +339,11 @@ Use Ctrl-F or F4 to quickly access this field</string>
          </item>
          <item>
           <widget class="QLabel" name="sizeStr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
            <property name="toolTip">
             <string>Displays total stack size in bytes</string>
            </property>
            <property name="text">
             <string/>
-           </property>
-           <property name="wordWrap">
-            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/pscan.ui
+++ b/pscan.ui
@@ -559,6 +559,48 @@ Use Alt-L to toggle US letter/legal</string>
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel" name="textLabel3_3">
+           <property name="text">
+            <string>Feed</string>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="sideways">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Sheets fed sideways are turned upright as they are stored: say which side of the front the top of the page is at</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Upright</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Top at left</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Top at right</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="SliderSpin" name="bright" native="true">
          <property name="minimumSize">
           <size>

--- a/qi/qoptionscrollview.cpp
+++ b/qi/qoptionscrollview.cpp
@@ -38,9 +38,15 @@ QOptionScrollView::QOptionScrollView(QWidget * parent, const char * name,Qt::Win
 #endif
   mpMainWidget = new QWidget(/*viewport()*/);
   mpMainLayout = new QBoxLayout(QBoxLayout::TopToBottom, mpMainWidget);
-//   QLabel *label = new QLabel ("hello there");
-//   mpMainLayout->addWidget (label);
-//  addChild(mpMainWidget);
+  /* let the scroll area size the content from the layout's minimum hint
+     as widgets are added, rather than relying on the layout to push a
+     minimum size onto the widget, which does not always happen */
+  setWidgetResizable (true);
+  /* the content follows the viewport's width, so the options squeeze
+     rather than scroll sideways: the layout must not impose its minimum
+     width on the widget, and the width is ignored in the size hint */
+  mpMainLayout->setSizeConstraint (QLayout::SetNoConstraint);
+  mpMainWidget->setSizePolicy (QSizePolicy::Ignored, QSizePolicy::Preferred);
   setWidget (mpMainWidget);
 //   mpMainWidget->setLayout (mpMainLayout);
 //   setLayout (mpMainLayout);
@@ -64,14 +70,6 @@ void QOptionScrollView::viewportResizeEvent(QResizeEvent* qre)
 }
 #endif
 
-
-/**  */
-void QOptionScrollView::resizeEvent(QResizeEvent* qre)
-{
-   // resize the scrollview to take full advantage of the width available
-  QScrollArea::resizeEvent(qre);
-  mpMainWidget->resize (geometry ().width (), mpMainWidget->geometry ().height ());
-}
 
 void QOptionScrollView::addWidget(QWidget* qw,int stretch)
 {

--- a/qi/qoptionscrollview.h
+++ b/qi/qoptionscrollview.h
@@ -34,7 +34,6 @@ public:
   void addWidget(QWidget* qw,int stretch=0);
 protected:
   /**  */
-  virtual void resizeEvent(QResizeEvent* qre);
 //s  virtual void viewportResizeEvent(QResizeEvent* qre);
 private: // Private attributes
   /** */

--- a/qsanestatusmessage.cpp
+++ b/qsanestatusmessage.cpp
@@ -20,12 +20,15 @@
 #include <qlayout.h>
 #include <qpushbutton.h>
 
-QSaneStatusMessage::QSaneStatusMessage(SANE_Status status, QWidget*parent)
+QSaneStatusMessage::QSaneStatusMessage(SANE_Status status, QWidget*parent,
+                                       const QString &detail)
                    :QMessageBox(parent)
 {
   mSaneStatus = status;
   setWindowTitle(tr("SANE Message"));
   setMessage();
+  if (!detail.isEmpty())
+    setInformativeText(detail);
 }
 
 QSaneStatusMessage::~QSaneStatusMessage()

--- a/qsanestatusmessage.h
+++ b/qsanestatusmessage.h
@@ -33,7 +33,10 @@ class QSaneStatusMessage : public QMessageBox
 {
 Q_OBJECT
 public:
-	QSaneStatusMessage(SANE_Status status, QWidget* parent);
+	/** \param detail  what was being done when the status came back, shown
+	                  under the message (may be empty) */
+	QSaneStatusMessage(SANE_Status status, QWidget* parent,
+	                   const QString &detail = QString ());
 	~QSaneStatusMessage();
 private:
   SANE_Status mSaneStatus;

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -41,6 +41,7 @@
 #include "qscannersetupdlg.h"
 #include "qscrollbaroption.h"
 #include "qscandialog.h"
+#include "qi/qbooloption.h"
 #include "qsanestatusmessage.h"
 #include "qstringoption.h"
 #include "qwordarrayoption.h"
@@ -2696,6 +2697,36 @@ bool QScanDialog::setAdf (bool adf)
    if (option != -1)
       setOption (mOptionSource, name [option]);
    return option != -1;
+}
+
+
+bool QScanDialog::hasAutoSize (void)
+{
+   return findOption ("auto-size", (int)SANE_TYPE_BOOL) != 0;
+}
+
+
+bool QScanDialog::autoSize (void)
+{
+   QSaneOption *opt = findOption ("auto-size", (int)SANE_TYPE_BOOL);
+
+   if (!opt)
+      return false;
+   return mpScanner->saneWordValue (opt->saneOptionNumber ()) != 0;
+}
+
+
+bool QScanDialog::setAutoSize (bool on)
+{
+   QSaneOption *opt = findOption ("auto-size", (int)SANE_TYPE_BOOL);
+
+   if (!opt || !opt->inherits ("QBoolOption"))
+      return false;
+   ((QBoolOption *)opt)->setState (on ? SANE_TRUE : SANE_FALSE);
+   slotOptionChanged (opt->optionNumber ());
+   /* the scanner marks the scan-area options inactive, so refresh them */
+   slotReloadOptions ();
+   return true;
 }
 
 

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -2700,15 +2700,32 @@ bool QScanDialog::setAdf (bool adf)
 }
 
 
+/* The finet backend has an auto-size option, which crops the image to
+   the paper. The fujitsu backend's nearest thing that costs nothing is
+   ald, automatic lower-edge detection, where the scanner ends each image
+   at the foot of the sheet instead of the window: the width stays the
+   page-width setting. Its hwdeskewcrop would trim the width too, but
+   makes the backend read every page in full before it can start the
+   next, which loses the buffered feeding and halves the speed */
+QSaneOption *QScanDialog::autoSizeOption (void)
+{
+   QSaneOption *opt = findOption ("auto-size", (int)SANE_TYPE_BOOL);
+
+   if (!opt)
+      opt = findOption ("ald", (int)SANE_TYPE_BOOL);
+   return opt;
+}
+
+
 bool QScanDialog::hasAutoSize (void)
 {
-   return findOption ("auto-size", (int)SANE_TYPE_BOOL) != 0;
+   return autoSizeOption () != 0;
 }
 
 
 bool QScanDialog::autoSize (void)
 {
-   QSaneOption *opt = findOption ("auto-size", (int)SANE_TYPE_BOOL);
+   QSaneOption *opt = autoSizeOption ();
 
    if (!opt)
       return false;
@@ -2718,7 +2735,7 @@ bool QScanDialog::autoSize (void)
 
 bool QScanDialog::setAutoSize (bool on)
 {
-   QSaneOption *opt = findOption ("auto-size", (int)SANE_TYPE_BOOL);
+   QSaneOption *opt = autoSizeOption ();
 
    if (!opt || !opt->inherits ("QBoolOption"))
       return false;

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -801,13 +801,8 @@ void QScanDialog::slotReloadOptions()
     in_here = false;
     return;
   }
-  //We also don't resize, if the preview widget is a part of the
-  //main dialog (== isn't a toplevel widget).
-  if(mLayout == QIN::ScrollLayout)
-  {
-    QWidget *w = mpOptionScrollView->widget ();
-    w->setMinimumSize(w->layout ()->minimumSize ());
-  }
+  //The scroll view sizes its content itself, so only the tab layout
+  //needs a hand here
   if(mLayout == QIN::TabLayout)
   {
     //stupid, but works (?)

--- a/qscandialog.cpp
+++ b/qscandialog.cpp
@@ -1704,7 +1704,16 @@ void QScanDialog::slotSetPredefinedSize(ScanArea* sca)
   {
 //    printf ("change slot under ADF\n");
     QString oldname = sca->getName ();
-    setPageSize (sca->width (), sca->height ());
+
+    /* Sheets fed sideways go through with the page's height across the
+       scanner, so the size the user picked describes the page, not the
+       window: hand it over the other way round. Without this a page
+       longer than the paper width is cut off at the foot, and on a back
+       end that only trims the length there is nothing to put it back */
+    if (xmlConfig && xmlConfig->intValue ("SCAN_SIDEWAYS"))
+      setPageSize (sca->height (), sca->width ());
+    else
+      setPageSize (sca->width (), sca->height ());
     setPreviewRange ();
 
     // this may invalidate sca, so find it again, by name!
@@ -2714,6 +2723,12 @@ QSaneOption *QScanDialog::autoSizeOption (void)
    if (!opt)
       opt = findOption ("ald", (int)SANE_TYPE_BOOL);
    return opt;
+}
+
+
+bool QScanDialog::autoSizeTrimsWidth (void)
+{
+   return findOption ("auto-size", (int)SANE_TYPE_BOOL) != 0;
 }
 
 

--- a/qscandialog.h
+++ b/qscandialog.h
@@ -104,6 +104,8 @@ public:
   bool setDuplex (bool duplex);
 
   /** True if the scanner offers automatic paper-size detection */
+  //! the option behind the auto-size checkbox, or NULL if the backend has none
+  QSaneOption *autoSizeOption (void);
   bool hasAutoSize (void);
 
   /** The current state of the automatic-size option */

--- a/qscandialog.h
+++ b/qscandialog.h
@@ -108,6 +108,10 @@ public:
   QSaneOption *autoSizeOption (void);
   bool hasAutoSize (void);
 
+  /** true if the back end's auto-size trims the width as well as the
+      length, so the paper size no longer decides where a page is cut */
+  bool autoSizeTrimsWidth (void);
+
   /** The current state of the automatic-size option */
   bool autoSize (void);
 

--- a/qscandialog.h
+++ b/qscandialog.h
@@ -103,6 +103,15 @@ public:
   /** set duplex */
   bool setDuplex (bool duplex);
 
+  /** True if the scanner offers automatic paper-size detection */
+  bool hasAutoSize (void);
+
+  /** The current state of the automatic-size option */
+  bool autoSize (void);
+
+  /** Turn automatic paper-size detection on or off */
+  bool setAutoSize (bool on);
+
   /** set DPI */
   void setDpi (int dpi);
 

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -166,6 +166,7 @@ QScanner::QScanner() : QObject()
   mNonBlockingIo = SANE_FALSE;
   mAppCancel = false;
   mCancelled = false;
+  mNoReadDup = false;
   mOpenOk = false;
   mInitOk = false;
   mDeviceCnt = 0;
@@ -1237,7 +1238,7 @@ static sane_read_dup_fn lookup_read_dup (void)
 
 bool QScanner::hasReadDup (void)
    {
-   return lookup_read_dup () != NULL;
+   return !mNoReadDup && lookup_read_dup () != NULL;
    }
 
 
@@ -1246,9 +1247,19 @@ SANE_Status QScanner::readDup (SANE_Byte *front_buf, SANE_Byte *back_buf,
                                SANE_Int *front_len, SANE_Int *back_len)
    {
    sane_read_dup_fn fn = lookup_read_dup ();
-   if (!fn)
+   SANE_Status status;
+
+   /* the simulated scanner has no SANE handle behind it, so it must not
+      reach the library, as with the other sane_* wrappers */
+   if (!fn || mDeviceHandle == SIMUL_DEV)
       return SANE_STATUS_UNSUPPORTED;
-   return fn (mDeviceHandle, front_buf, back_buf, max_len, front_len, back_len);
+   status = fn (mDeviceHandle, front_buf, back_buf, max_len, front_len,
+                back_len);
+   /* libsane's dispatcher answers for back ends that lack the entry point,
+      so the scan must carry on through sane_read() */
+   if (status == SANE_STATUS_UNSUPPORTED)
+      mNoReadDup = true;
+   return status;
    }
 
 

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -1238,6 +1238,10 @@ static sane_read_dup_fn lookup_read_dup (void)
 
 bool QScanner::hasReadDup (void)
    {
+   /* PAPERMAN_NO_READ_DUP=1 reads duplex the ordinary way, side by side,
+      for comparison */
+   if (getenv ("PAPERMAN_NO_READ_DUP"))
+      return false;
    return !mNoReadDup && lookup_read_dup () != NULL;
    }
 
@@ -3938,6 +3942,48 @@ bool QScanner::checkDoubleFeed (void)
    int val = saneWordValue (mOptionDoubleFeed);
 
    return val > 0;
+}
+
+
+void QScanner::useFastTransfer (const QStringList &except)
+{
+   QMap<QString, QString> opts;
+   int num;
+   bool stats = getenv ("PAPERMAN_SCAN_STATS") != NULL;
+
+   if (findOption ("buffermode") != -1 && !except.contains ("buffermode"))
+      opts ["buffermode"] = "On";
+   num = findOption ("compression");
+   if (num != -1 && !except.contains ("compression"))
+      {
+      int mode = findOption ("mode", false);
+      QString cur = saneStringValue (num);
+
+      /* only in colour, where the option is active, and only from the
+         backend's own default, so a choice of None in the dialog holds */
+      if (mode != -1 && saneStringValue (mode) == "Color"
+          && (cur.isEmpty () || cur == "None"))
+         opts ["compression"] = "JPEG";
+      }
+   if (!opts.isEmpty ())
+      setOptionsByName (opts);
+   if (stats)
+      {
+      QStringList report;
+
+      foreach (const char *name, QList<const char *> () << "mode"
+               << "buffermode" << "compression")
+         {
+         int n = findOption (name, false);
+
+         if (n != -1)
+            report << QString ("%1=%2").arg (name).arg (saneStringValue (n));
+         }
+      qWarning ("fast transfer: set %s; backend now has %s; read_dup %s",
+                qPrintable (QStringList (opts.keys ()).join (",")),
+                qPrintable (report.join (" ")),
+                hasReadDup () ? "in use" : "not used");
+      }
 }
 
 

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -3111,8 +3111,15 @@ bool QScanner::isReadOnly(int num)
     return false;
 }
 /**  */
-void QScanner::setOptionsByName(QMap <QString,QString> omap)
+void QScanner::setOptionsByName(QMap <QString,QString> omap,
+                                bool allowTransport)
 {
+  if (!allowTransport)
+    {
+    foreach (const QString &name, omap.keys ())
+      if (isTransportOption (name))
+        omap.remove (name);
+    }
   //We can only set active and settable options, otherwise
   //most backends return an error.
   //The following approach is used
@@ -3246,7 +3253,8 @@ void QScanner::settingsDomElement(QDomDocument doc,QDomElement domel)
   for(int i=0;i<mOptionNumber;i++)
   {
     //only append active & settable options
-    if(isOptionActive(i) && isOptionSettable(i))
+    if(isOptionActive(i) && isOptionSettable(i)
+       && !isTransportOption(getOptionName(i)))
     {
       type = getOptionType(i);
       //we don't save vectors here

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -3880,9 +3880,14 @@ void QScanner::findOptions (void)
   // then-dump mode where readDup() blocks until the page has fully
   // transited and the preview stays blank until then. See
   // SCAN_PREVIEW_INVESTIGATION.md.
+  /* A modest chunk shows the page filling in as it arrives. 4 KB was far
+     too small once the backend delivered JPEG: hundreds of reads a side,
+     each resuming the decoder and sending progress, cost more than the
+     scan itself and paperman fell well behind a USB scanner that was
+     delivering at full speed. 256 KB still gives a few updates a side */
   mOptionBufferSize = findOption ("buffer-size");
   if (mOptionBufferSize != -1)
-    setBufferSize (4096);
+    setBufferSize (256 * 1024);
 }
 
 

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -3933,6 +3933,22 @@ bool QScanner::checkDoubleFeed (void)
    return val > 0;
 }
 
+
+bool QScanner::stopFeed (void)
+{
+   int num = findOption ("stop-feed");
+
+   if (num == -1 || getOptionType (num) != SANE_TYPE_BUTTON)
+      return false;
+
+   SANE_Int info;
+   SANE_Status status = do_sane_control_option (mDeviceHandle, num,
+                                                SANE_ACTION_SET_VALUE, 0L,
+                                                &info);
+
+   return status == SANE_STATUS_GOOD;
+}
+
 #if 0
   s->opt[SIMUL_NUM_OPTS].name = SANE_NAME_NUM_OPTIONS;
   s->opt[SIMUL_NUM_OPTS].title = SANE_TITLE_NUM_OPTIONS;

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -3167,7 +3167,9 @@ void QScanner::setOptionsByName(QMap <QString,QString> omap)
            }
            break;
           case SANE_TYPE_BOOL:
-           sw = it.value().toInt();
+           /* as on the command line: yes/no, true/false, on/off or 1/0 */
+           qs = it.value().trimmed().toLower();
+           sw = qs == "yes" || qs == "true" || qs == "on" || qs.toInt();
            setOption(optnum,&sw);
            break;
           case SANE_TYPE_STRING:

--- a/qscanner.cpp
+++ b/qscanner.cpp
@@ -3936,6 +3936,16 @@ bool QScanner::checkDoubleFeed (void)
 }
 
 
+int QScanner::imagesWaiting (void)
+{
+   int num = findOption ("images-waiting", false);
+
+   if (num == -1)
+      return -1;
+   return saneWordValue (num);
+}
+
+
 bool QScanner::stopFeed (void)
 {
    int num = findOption ("stop-feed");

--- a/qscanner.h
+++ b/qscanner.h
@@ -456,15 +456,18 @@ is able to choose an option value automatically. */
       legal range. */
   void setBufferSize (int bytes);
 
-  /** True if libsane provides sane_read_dup, in which case readDup() will
-      deliver front and back data progressively in a single call. */
+  /** True if libsane provides sane_read_dup and the back end has not
+      refused it, in which case readDup() will deliver front and back data
+      progressively in a single call. */
   bool hasReadDup (void);
 
   /** Read both sides of a duplex scan in one call. Caller passes two
       output buffers of the same maxlen; *front_len / *back_len are filled
       with the bytes actually returned for each side. Returns SANE_STATUS_GOOD
       while either side may still produce data; SANE_STATUS_EOF when both
-      sides are drained. Asserts hasReadDup(). */
+      sides are drained. Asserts hasReadDup(). A back end without the
+      extension returns SANE_STATUS_UNSUPPORTED, after which hasReadDup()
+      is false for this scanner. */
   SANE_Status readDup (SANE_Byte *front_buf, SANE_Byte *back_buf,
                        SANE_Int max_len,
                        SANE_Int *front_len, SANE_Int *back_len);
@@ -524,6 +527,7 @@ successfull */
   SANE_Status mSaneStatus;
   /**  */
   bool mCancelled;
+  bool mNoReadDup;         //!< the back end refused sane_read_dup()
   /**  */
   QProgressDialog* mpProgress;
 

--- a/qscanner.h
+++ b/qscanner.h
@@ -321,7 +321,22 @@ is able to choose an option value automatically. */
   /**  */
   bool isReadOnly(int num);
   /**  */
-  void setOptionsByName(QMap <QString,QString> omap);
+  /** set options from a name/value map, as saved settings and --set do
+
+      \param omap            the options and their values
+      \param allowTransport  also set transport options (see
+                             isTransportOption()), as --set may; saved
+                             settings may not */
+  void setOptionsByName(QMap <QString,QString> omap,
+                        bool allowTransport = false);
+
+  /** Is this option a transport knob, which QScanner sets for itself
+      (the read chunk size) rather than a scan setting? Such options are
+      not saved with a device's settings nor restored from them: a saved
+      buffer-size of 4 KB once made every USB read a 4 KB round trip and
+      a scan three times slower than the scanner */
+  static bool isTransportOption (const QString &name)
+     { return name == "buffer-size"; }
   /**Returns the name of the selected device.
     */
   QString name();

--- a/qscanner.h
+++ b/qscanner.h
@@ -449,6 +449,15 @@ is able to choose an option value automatically. */
      \returns true if double-feed is detected, false otherwise */
   bool checkDoubleFeed (void);
 
+  /** Ask the backend to stop the feeder but keep delivering the pages it
+      has already scanned, so that a batch stopped early loses nothing.
+      Only backends with a "stop-feed" button offer this (finet today).
+      Must be called from the scanning thread, between pages.
+
+     \returns true if the feeder is now stopped and the remaining pages
+              will follow, false if the backend cannot do this */
+  bool stopFeed (void);
+
   /** Request the backend to use a smaller per-read chunk so the frontend
       sees the page progressively. No-op if the backend has no
       "buffer-size" option (only the patched fujitsu backend does today).

--- a/qscanner.h
+++ b/qscanner.h
@@ -465,6 +465,14 @@ is able to choose an option value automatically. */
      \returns the count, or -1 if the backend cannot say */
   int imagesWaiting (void);
 
+  /** Turn on the fast-transfer settings a backend may offer: buffering
+      in the scanner ("buffermode"), so it scans ahead rather than
+      stopping after every sheet, and JPEG delivery ("compression") in
+      colour, which cuts a side from 25 MB to under 1 MB. The patched
+      fujitsu backend has both; without them a USB fi-8950 runs at a
+      third of its speed. Options a backend lacks are left alone */
+  void useFastTransfer (const QStringList &except = QStringList ());
+
   /** Request the backend to use a smaller per-read chunk so the frontend
       sees the page progressively. No-op if the backend has no
       "buffer-size" option (only the patched fujitsu backend does today).

--- a/qscanner.h
+++ b/qscanner.h
@@ -458,6 +458,13 @@ is able to choose an option value automatically. */
               will follow, false if the backend cannot do this */
   bool stopFeed (void);
 
+  /** How many finished images the scanner is holding that have not been
+      fetched yet, i.e. how far it is ahead of us. Only backends with a
+      read-only "images-waiting" option know (finet today)
+
+     \returns the count, or -1 if the backend cannot say */
+  int imagesWaiting (void);
+
   /** Request the backend to use a smaller per-read chunk so the frontend
       sees the page progressively. No-op if the backend has no
       "buffer-size" option (only the patched fujitsu backend does today).

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,5 @@
+#include <QSettings>
+#include <QTemporaryDir>
 #include <QtTest/QtTest>
 #include <cstring>
 
@@ -37,6 +39,18 @@ int test_run(int, char **in_argv, QApplication *,
    int status = 0;
    const char *className = filter;
    const char *funcName = nullptr;
+
+   /* Keep the tests away from the user's own settings. The widgets read
+    * the saved splitter sizes and repository list from QSettings and
+    * write them back on close, so without this the results depend on
+    * the machine and a test run scribbles on the real configuration */
+   QTemporaryDir settings_dir;
+   if (!settings_dir.isValid()) {
+      fprintf(stderr, "Cannot create a temporary settings directory\n");
+      return 1;
+   }
+   QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope,
+                      settings_dir.path());
 
    // Split "Class::function" into class filter and function filter
    static char filterBuf[256];

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -13,6 +13,7 @@
 #include "desktopwidget.h"
 #include "dirmodel.h"
 #include "filemax.h"
+#include "utils.h"
 #include "dirview.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
@@ -1313,6 +1314,38 @@ void TestDesktopUi::testScanIntoStack()
    QString pathname =
       model->data(new_ind, Desktopmodel::Role_pathname).toString();
    QVERIFY(QFile::exists(pathname));
+}
+
+void TestDesktopUi::testScanCommandLine()
+{
+   /* the command-line scan uses the desktop machinery headless: it must
+      leave a new stack in the requested directory, and must not disturb
+      the saved scanner settings */
+   QString path = setupRepo();
+   QVERIFY(QDir().mkpath(path + "/inbox"));
+
+   if (!xmlConfig)
+      new QXmlConfig();
+   QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
+   int old_single = xmlConfig->intValue("SCAN_SINGLE");
+
+   QCOMPARE(Mainwindow::runScan(path, "inbox", "simulscan", 2,
+                                QStringList() << "mode=Color"), 0);
+
+   QCOMPARE(xmlConfig->stringValue("LAST_DEVICE", QString()), old_device);
+   QCOMPARE(xmlConfig->intValue("SCAN_SINGLE"), old_single);
+
+   QStringList stacks = QDir(path + "/inbox").entryList(
+         QStringList() << "*.max", QDir::Files);
+   QCOMPARE(stacks.size(), 1);
+   Filemax max(path + "/inbox/", stacks[0], nullptr);
+   QVERIFY(!max.load());
+   QCOMPARE(max.pagecount(), 2);
+
+   // a missing directory is an error rather than a scan
+   QCOMPARE(Mainwindow::runScan(path, "nosuch", "simulscan", 1), 1);
+
+   utilSetHeadless(false);
 }
 
 void TestDesktopUi::testRepositoryAddRemoveUndo()

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -22,6 +22,7 @@
 #include "pagewidget.h"
 #include "searchserver.h"
 #include "qxmlconfig.h"
+#include <QScrollBar>
 #include "test_desktopui.h"
 
 void TestDesktopUi::setupShown(Mainwindow *me, Desktopmodel *&model,
@@ -1336,6 +1337,21 @@ void TestDesktopUi::testScanIntoStack()
    QString pathname =
       model->data(new_ind, Desktopmodel::Role_pathname).toString();
    QVERIFY(QFile::exists(pathname));
+
+   /* the page view followed the scan: it is scrolled to the end and the
+      last page is on screen, even once there were more pages than fit */
+   Pageview *pageview = me.getDesktop()->getPagewidget()->findChild<Pageview *>();
+   QVERIFY(pageview);
+   QAbstractItemModel *pages = pageview->model();
+   QVERIFY(pages);
+   QCOMPARE(pages->rowCount(), scanned->pagecount());
+   QScrollBar *vs = pageview->verticalScrollBar();
+   QCOMPARE(vs->value(), vs->maximum());
+   /* the last row is on screen: its rect may run a few pixels past the
+      viewport (cell spacing, or a relayout still pending), so ask only
+      that it overlaps the viewport */
+   QModelIndex last = pages->index(pages->rowCount() - 1, 0);
+   QVERIFY(pageview->viewport()->rect().intersects(pageview->visualRect(last)));
 }
 
 void TestDesktopUi::testScanCommandLine()

--- a/test/test_desktopui.cpp
+++ b/test/test_desktopui.cpp
@@ -1287,16 +1287,38 @@ void TestDesktopUi::testScanIntoStack()
    if (!xmlConfig)
       new QXmlConfig();
    QString old_device = xmlConfig->stringValue("LAST_DEVICE", QString());
-   xmlConfig->setStringValue("LAST_DEVICE", "simulscan");
+   xmlConfig->setStringValue("LAST_DEVICE", getenv("PM_SCAN_DEVICE") ? getenv("PM_SCAN_DEVICE") : "simulscan");
 
    Mainwidget *main = Mainwidget::singleton();
    QVERIFY(main);
+   if (getenv("PM_SCAN_SET")) {
+      QMap<QString, QString> opts;
+      foreach (const QString &kv, QString(getenv("PM_SCAN_SET")).split(','))
+         opts[kv.section('=', 0, 0)] = kv.section('=', 1);
+      main->setScanOptions(opts);
+   }
    int before = model->rowCount(repo_ind);
 
-   /* the simulated ADF holds 120 pages, so press the stop button (which
-      finishes the current page and ends the scan) shortly after the
-      scan begins */
-   QTimer::singleShot(400, main, [main]() { main->stopScan(false); });
+   /* the simulated ADF holds 120 pages at about a second each, so press
+      the stop button (which finishes the current page and ends the scan)
+      as soon as the scan is under way. Opening the scanner can take
+      several seconds here, so wait for it rather than using a fixed
+      delay, which would fire too early and let all 120 pages scan.
+      PM_SCAN_STOP_MS gives a fixed delay instead, for timing a longer
+      run on a real scanner (see PM_SCAN_DEVICE and PM_SCAN_SET) */
+   if (getenv("PM_SCAN_STOP_MS"))
+      QTimer::singleShot(atoi(getenv("PM_SCAN_STOP_MS")), main,
+                         [main]() { main->stopScan(false); });
+   else {
+      QTimer *stopper = new QTimer(main);
+      connect(stopper, &QTimer::timeout, main, [main, stopper]() {
+         if (main->isScanning()) {
+            main->stopScan(false);
+            stopper->stop();
+         }
+      });
+      stopper->start(100);
+   }
    me.actionScango->trigger();
 
    xmlConfig->setStringValue("LAST_DEVICE", old_device);

--- a/test/test_desktopui.h
+++ b/test/test_desktopui.h
@@ -109,6 +109,7 @@ private slots:
 
    //! Test scanning into a new stack with the simulated scanner
    void testScanIntoStack();
+   void testScanCommandLine();
 
    //! Test adding and removing a repository, with undo and redo
    void testRepositoryAddRemoveUndo();

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -13,6 +13,7 @@
 #include "filepdf.h"
 
 #include "op.h"
+#include "paperstack.h"
 
 #include "test_file.h"
 
@@ -1077,4 +1078,87 @@ void TestFile::testJpegTransform()
    QImage flipped(dir + "photo.jpg");
    QVERIFY(qGray(flipped.pixel(5, 20)) > 128);    // now light on the left
    QVERIFY(qGray(flipped.pixel(55, 20)) < 128);   // and dark on the right
+}
+
+
+/* Feed a synthetic 24-bit page through a Paperstack with auto colour on
+   and return the depth it was stored at, with the coverage string */
+static int scanSynthetic (const QByteArray &rgb, int width, int height,
+                          QString &coverage)
+{
+   Paperstack stack ("stack", "page", false);
+   QMutex mutex;
+   Filepage *mp = NULL;
+
+   stack.setAutoColour (true);
+   stack.addImage (width, height, 24, width * 3, true, false);
+   stack.addImageBytes ((unsigned char *)rgb.data (), rgb.size ());
+   coverage = stack.coverageStr ();
+   err_info *err = stack.confirmImage (mp, mutex);
+   if (err || !mp)
+      return -1;
+   int depth = mp->_depth;
+   delete mp;
+   return depth;
+}
+
+void TestFile::testAutoColour()
+{
+   const int width = 200, height = 200;
+   QByteArray page (width * height * 3, (char)255);
+   unsigned char *p = (unsigned char *)page.data ();
+   QString cov;
+
+   /* black text-like strokes on white with soft edges, and some print
+      showing through from the back of the sheet: mono, as text is */
+   for (int y = 10; y < height - 10; y += 10)
+      for (int x = 0; x < width; x++)
+         {
+         unsigned char *px = p + (y * width + x) * 3;
+         px [0] = px [1] = px [2] = 0;
+         px [-3 * width] = px [1 - 3 * width] = px [2 - 3 * width] = 150;
+         px [3 * width] = px [1 + 3 * width] = px [2 + 3 * width] = 200;
+         }
+   QCOMPARE (scanSynthetic (page, width, height, cov), 1);
+   QVERIFY (cov.endsWith (" mono"));
+
+   /* add a bold black heading and the mid-grey shadow of the paper edge
+      that the scanner leaves along the top and bottom: still mono */
+   for (int y = 40; y < 60; y++)
+      for (int x = 20; x < 180; x++)
+         {
+         unsigned char *px = p + (y * width + x) * 3;
+         px [0] = px [1] = px [2] = 10;
+         }
+   for (int y = 0; y < height; y++)
+      if (y < 8 || y >= height - 12)
+         for (int x = 0; x < width; x++)
+            {
+            unsigned char *px = p + (y * width + x) * 3;
+            px [0] = px [1] = px [2] = 160;
+            }
+   QCOMPARE (scanSynthetic (page, width, height, cov), 1);
+   QVERIFY (cov.endsWith (" mono"));
+
+   // the same page with a dark red mark on it: enough colour to keep
+   for (int y = 80; y < 100; y++)
+      for (int x = 20; x < 60; x++)
+         {
+         unsigned char *px = p + (y * width + x) * 3;
+         px [0] = 90; px [1] = 30; px [2] = 30;
+         }
+   QCOMPARE (scanSynthetic (page, width, height, cov), 24);
+   QVERIFY (!cov.endsWith (" mono") && !cov.endsWith (" grey"));
+
+   /* a blank page with a small dark photograph on it, a twentieth of
+      the page in the darker mid-tones: grey */
+   page.fill ((char)255);
+   for (int y = 80; y < 120; y++)
+      for (int x = 50; x < 100; x++)
+         {
+         unsigned char *px = p + (y * width + x) * 3;
+         px [0] = px [1] = px [2] = 70 + ((x * 7 + y * 3) % 60);
+         }
+   QCOMPARE (scanSynthetic (page, width, height, cov), 8);
+   QVERIFY (cov.endsWith (" grey"));
 }

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1084,14 +1084,17 @@ void TestFile::testJpegTransform()
 /* Feed a synthetic 24-bit page through a Paperstack with auto colour on
    and return the depth it was stored at, with the coverage string */
 static int scanSynthetic (const QByteArray &rgb, int width, int height,
-                          QString &coverage, int chunk = 0)
+                          QString &coverage, int chunk = 0,
+                          Paperstack::t_sideways sideways = Paperstack::Sideways_no,
+                          bool front = true, Filepage **mpp = NULL)
 {
    Paperstack stack ("stack", "page", false);
    QMutex mutex;
    Filepage *mp = NULL;
 
    stack.setAutoColour (true);
-   stack.addImage (width, height, 24, width * 3, true, false);
+   stack.setSideways (sideways);
+   stack.addImage (width, height, 24, width * 3, front, false);
    /* feed the page in chunks of the given size, as a back end delivering
       raw data does, or all at once */
    if (!chunk)
@@ -1104,8 +1107,71 @@ static int scanSynthetic (const QByteArray &rgb, int width, int height,
    if (err || !mp)
       return -1;
    int depth = mp->_depth;
-   delete mp;
+   if (mpp)
+      *mpp = mp;
+   else
+      delete mp;
    return depth;
+}
+
+//! whether the given pixel of a stored mono page is black
+static bool monoPixel (const Filepage *mp, int x, int y)
+{
+   const unsigned char *data = (const unsigned char *)mp->_data.constData ();
+
+   return data [y * mp->_stride + (x >> 3)] & (0x80 >> (x & 7));
+}
+
+/* Sheets fed sideways are turned upright as they are stored: the front a
+   quarter turn one way and the back, seen from the other side of the
+   sheet, the other way */
+void TestFile::testSideways()
+{
+   const int width = 200, height = 100;
+   QByteArray page (width * height * 3, (char)255);
+   unsigned char *p = (unsigned char *)page.data ();
+   QString cov;
+   Filepage *mp;
+
+   // a black square in the top-left corner of the scan
+   for (int y = 0; y < 20; y++)
+      for (int x = 0; x < 20; x++)
+         {
+         unsigned char *px = p + (y * width + x) * 3;
+         px [0] = px [1] = px [2] = 0;
+         }
+
+   /* the top of the page at the left of the front: a quarter turn
+      clockwise puts the square top right */
+   QCOMPARE (scanSynthetic (page, width, height, cov, 0,
+                            Paperstack::Sideways_top_left, true, &mp), 1);
+   QCOMPARE (mp->_width, height);
+   QCOMPARE (mp->_height, width);
+   QVERIFY (monoPixel (mp, 90, 10));
+   QVERIFY (!monoPixel (mp, 10, 10));
+   QVERIFY (!monoPixel (mp, 10, 190));
+   delete mp;
+
+   // the back of that sheet turns the other way: the square goes bottom left
+   QCOMPARE (scanSynthetic (page, width, height, cov, 0,
+                            Paperstack::Sideways_top_left, false, &mp), 1);
+   QCOMPARE (mp->_width, height);
+   QVERIFY (monoPixel (mp, 10, 190));
+   QVERIFY (!monoPixel (mp, 90, 10));
+   delete mp;
+
+   // with the top at the right, the front turns anticlockwise instead
+   QCOMPARE (scanSynthetic (page, width, height, cov, 0,
+                            Paperstack::Sideways_top_right, true, &mp), 1);
+   QVERIFY (monoPixel (mp, 10, 190));
+   delete mp;
+
+   // fed upright, the page is stored as scanned
+   QCOMPARE (scanSynthetic (page, width, height, cov, 0,
+                            Paperstack::Sideways_no, true, &mp), 1);
+   QCOMPARE (mp->_width, width);
+   QVERIFY (monoPixel (mp, 10, 10));
+   delete mp;
 }
 
 void TestFile::testAutoColour()

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -1084,7 +1084,7 @@ void TestFile::testJpegTransform()
 /* Feed a synthetic 24-bit page through a Paperstack with auto colour on
    and return the depth it was stored at, with the coverage string */
 static int scanSynthetic (const QByteArray &rgb, int width, int height,
-                          QString &coverage)
+                          QString &coverage, int chunk = 0)
 {
    Paperstack stack ("stack", "page", false);
    QMutex mutex;
@@ -1092,7 +1092,13 @@ static int scanSynthetic (const QByteArray &rgb, int width, int height,
 
    stack.setAutoColour (true);
    stack.addImage (width, height, 24, width * 3, true, false);
-   stack.addImageBytes ((unsigned char *)rgb.data (), rgb.size ());
+   /* feed the page in chunks of the given size, as a back end delivering
+      raw data does, or all at once */
+   if (!chunk)
+      chunk = rgb.size ();
+   for (int pos = 0; pos < rgb.size (); pos += chunk)
+      stack.addImageBytes ((unsigned char *)rgb.data () + pos,
+                           qMin (chunk, rgb.size () - pos));
    coverage = stack.coverageStr ();
    err_info *err = stack.confirmImage (mp, mutex);
    if (err || !mp)
@@ -1120,6 +1126,12 @@ void TestFile::testAutoColour()
          px [3 * width] = px [1 + 3 * width] = px [2 + 3 * width] = 200;
          }
    QCOMPARE (scanSynthetic (page, width, height, cov), 1);
+   QVERIFY (cov.endsWith (" mono"));
+
+   /* the same page in chunks that split pixels between them, as raw
+      data from a back end arrives: the pixels must stay in step, or the
+      stroke edges read as colour */
+   QCOMPARE (scanSynthetic (page, width, height, cov, 1001), 1);
    QVERIFY (cov.endsWith (" mono"));
 
    /* add a bold black heading and the mid-grey shadow of the paper edge

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -15,6 +15,9 @@ private slots:
    //! typeFromName maps extensions (and unknown extensions) to e_type
    void testTypeFromName();
 
+   //! a scanned colour page is kept, greyed or made mono by its pixels
+   void testAutoColour();
+
    //! typeName/typeExt round-trip and stay aligned with e_type
    void testTypeNameAndExt();
 

--- a/test/test_file.h
+++ b/test/test_file.h
@@ -18,6 +18,9 @@ private slots:
    //! a scanned colour page is kept, greyed or made mono by its pixels
    void testAutoColour();
 
+   //! Test that pages fed sideways are turned upright as they are stored
+   void testSideways();
+
    //! typeName/typeExt round-trip and stay aligned with e_type
    void testTypeNameAndExt();
 

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -441,3 +441,61 @@ void TestPagewidget::testEditAttributesRevert()
    QCOMPARE(model->data(ind, Desktopmodel::Role_author).toString(),
             "Fred");
 }
+
+/* The scan preview is built from bands as they arrive. With the fujitsu
+   lower-edge detection the page starts with a guessed height and the
+   real one arrives part way through, so the surface changes shape: what
+   was painted must be carried over at the new scale and the rest stay
+   hatched, or the page shows gaps and bands in the wrong place */
+void TestPagewidget::testScanPreviewReshape()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+   Pagemodel *pm = page->_pagemodel;
+
+   pm->beginningScan();
+   pm->beginningPage();
+   int pagenum = pm->rowCount(QModelIndex()) - 1;
+   Pageinfo &pi = pm->_pages[pagenum];
+   QVERIFY(pi.scanning());
+
+   // the first band arrives while the page is thought to be portrait
+   QImage band(100, 20, QImage::Format_RGB32);
+   band.fill(Qt::red);
+   pm->newScaledImage(band, 0, pagenum, QSize(100, 130));
+   QCOMPARE(pi._scan_image.size(), QSize(100, 130));
+   QCOMPARE(pi._scan_painted, 20);
+   QCOMPARE(pi._scan_image.pixelColor(50, 10), QColor(Qt::red));
+
+   // the height is learnt: the page is landscape, so the surface shrinks
+   band.fill(Qt::blue);
+   pm->newScaledImage(band, 20, pagenum, QSize(100, 80));
+   QCOMPARE(pi._scan_image.size(), QSize(100, 80));
+   QCOMPARE(pi._scan_painted, 40);
+   QCOMPARE(pi._scan_image.pixelColor(50, 10), QColor(Qt::red));
+   QCOMPARE(pi._scan_image.pixelColor(50, 30), QColor(Qt::blue));
+
+   // below the bands the surface is still the hatched placeholder
+   const QImage &img = pi._scan_image;
+   int white = 0, other = 0;
+   for (int y = 45; y < 80; y++)
+      for (int x = 0; x < 100; x++)
+         {
+         QColor col = img.pixelColor(x, y);
+         if (col == QColor(Qt::white))
+            white++;
+         else
+            {
+            QVERIFY(col != QColor(Qt::red) && col != QColor(Qt::blue));
+            other++;
+            }
+         }
+   QVERIFY(white > 0 && other > 0);
+
+   // the preview stands for the page at the current page size
+   QCOMPARE(pi._size, pm->_pagesize);
+   pm->endingScan();
+}

--- a/test/test_pagewidget.cpp
+++ b/test/test_pagewidget.cpp
@@ -289,6 +289,40 @@ void TestPagewidget::testRotateThumbnailReady()
    QVERIFY(!dodgy);
 }
 
+/* Large page views are decoded on the background render thread; check
+   that thumbnails still all become ready (the worker delivers them via a
+   queued signal) and that nothing deadlocks. */
+void TestPagewidget::testBackgroundRender()
+{
+   Desktopmodel *model;
+   Pagewidget *page;
+   Mainwindow me;
+
+   openTestStack(&me, model, page);
+   Pagemodel *pm = page->_pagemodel;
+
+   // ask for a large view so the images are decoded off the GUI thread
+   page->setPagesize(QSize(1600, 2200));
+   // confirm this size really takes the background (full-decode) path
+   QModelIndex stack;
+   QVERIFY(page->getCurrentIndex(stack, true));
+   QVERIFY2(model->imageNeedsDecode(stack, 0, QSize(1600, 2200)),
+            "test size did not trigger the background render path");
+   for (int i = 0; i < pm->_pages.size(); i++)
+      pm->_pages[i]._rescale = true;
+   pm->scheduleRescale();
+
+   int n = pm->rowCount(QModelIndex());
+   bool ready = QTest::qWaitFor([&] {
+      for (int i = 0; i < n; i++)
+         if (pm->_pages[i]._pixmap.isNull())
+            return false;
+      return true;
+   }, 10000);
+   QVERIFY2(ready, "background render did not produce all thumbnails");
+}
+
+
 //! Count dark pixels in an image, sampling every few pixels
 static int darkPixels(const QImage &img)
 {

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -38,6 +38,7 @@ private slots:
 
    //! Test a rotated page's thumbnail is ready at once, not blanked
    void testRotateThumbnailReady();
+   void testBackgroundRender();
 
    //! Test the rotate action updates the displayed page
    void testRotateActionDisplay();

--- a/test/test_pagewidget.h
+++ b/test/test_pagewidget.h
@@ -49,6 +49,9 @@ private slots:
    //! Test that revert discards unsaved attribute edits
    void testEditAttributesRevert();
 
+   //! Test the scan preview keeps its bands when the page's shape changes
+   void testScanPreviewReshape();
+
 private:
    /** Open the 5-page test stack in the page view of a shown
        Mainwindow

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -12,6 +12,7 @@
 #include "qi/qsaneoption.h"
 #include <QScrollArea>
 #include <QGroupBox>
+#include <QCheckBox>
 #include "qi/scanarea.h"
 
 #define SIMUL_NAME "simulscan"
@@ -32,6 +33,30 @@ void TestQscanner::testOpenSimul()
    QVERIFY (scanner.isOpen ());
    QCOMPARE (scanner.xResolutionDpi (), 300);
    QCOMPARE (scanner.yResolutionDpi (), 300);
+}
+
+
+/* The scan panel's Auto-size box must appear for a scanner that offers
+   auto-size. Device-gated */
+void TestQscanner::testAutoSizePanel()
+{
+   const char *dev = getenv ("PAPERMAN_TEST_DEVICE");
+   if (!dev)
+      QSKIP ("set PAPERMAN_TEST_DEVICE to a scanner with auto-size");
+   ensureXmlConfig ();
+   QScanner *scanner = new QScanner;
+   scanner->setDeviceName (dev);
+   QVERIFY (scanner->openDevice ());
+   QScanDialog *dlg = new QScanDialog (scanner, 0);
+   if (!dlg->hasAutoSize ())
+      QSKIP ("scanner has no auto-size option");
+   Pscan panel (0);
+   QCheckBox *box = panel.findChild<QCheckBox *> ("autosize");
+   QVERIFY (box);
+   QVERIFY (box->isHidden ());          // hidden until a scanner is known
+   panel.setScanDialog (dlg);
+   panel.scannerChanged (scanner);
+   QVERIFY2 (!box->isHidden (), "auto-size box stayed hidden");
 }
 
 

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -8,6 +8,8 @@
 #include "mainwindow.h"
 #include "desktopwidget.h"
 #include "desktopmodel.h"
+#include "pagewidget.h"
+#include <QListView>
 #include <QElapsedTimer>
 #include <QTemporaryDir>
 #include "qscanner.h"
@@ -100,6 +102,11 @@ void TestQscanner::testScanGuiTiming()
    timer.start ();
    main->scanInto (repo_ind);          // returns when the batch is done
 
+   if (getenv ("DUMP_PNG"))
+      {
+      QTest::qWait (300);
+      me.grab ().save (getenv ("DUMP_PNG"));
+      }
    QVERIFY2 (stamps.size () >= 2, qPrintable (QString ("only %1 pages")
                                               .arg (stamps.size ())));
    QList<qint64> gaps;

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -4,6 +4,12 @@
 
 #include "pscan.h"
 #include "qscandialog.h"
+#include "utils.h"
+#include "mainwindow.h"
+#include "desktopwidget.h"
+#include "desktopmodel.h"
+#include <QElapsedTimer>
+#include <QTemporaryDir>
 #include "qscanner.h"
 #include "qxmlconfig.h"
 #include "test_qscanner.h"
@@ -36,8 +42,84 @@ void TestQscanner::testOpenSimul()
 }
 
 
-/* The scan panel's Auto-size box must appear for a scanner that offers
-   auto-size. Device-gated */
+/* Drive a real GUI scan (shown window, live preview and thumbnails) and
+   time how fast pages arrive, to compare the GUI path with headless.
+   Device-gated; PAPERMAN_TEST_PAGES sets the count, PAPERMAN_TEST_AUTOSIZE
+   turns auto-size on */
+void TestQscanner::testScanGuiTiming()
+{
+   const char *dev = getenv ("PAPERMAN_TEST_DEVICE");
+   if (!dev)
+      QSKIP ("set PAPERMAN_TEST_DEVICE");
+   ensureXmlConfig ();
+   int pages = getenv ("PAPERMAN_TEST_PAGES")
+      ? atoi (getenv ("PAPERMAN_TEST_PAGES")) : 20;
+   const char *asenv = getenv ("PAPERMAN_TEST_AUTOSIZE");
+   bool autosize = asenv && asenv[0];
+
+   /* open the scanner from config without a chooser dialog, but keep the
+      window shown so the preview and thumbnails still render */
+   utilSetHeadless (true);
+
+   QTemporaryDir repo;
+   QVERIFY (repo.isValid ());
+
+   Mainwindow me;
+   Desktopwidget *desktop = me.getDesktop ();
+   QVERIFY (!desktop->addDir (repo.path ()));
+   Desktopmodel *model = desktop->getModel ();
+   me.resize (1024, 768);
+   me.show ();
+   QVERIFY (QTest::qWaitForWindowExposed (&me));
+   QString path = repo.path ();
+   if (path.endsWith ("/"))
+      path.chop (1);
+   QModelIndex repo_ind = desktop->getDirIndex (path + "/");
+   QVERIFY (repo_ind.isValid ());
+
+   Mainwidget *main = Mainwidget::singleton ();
+   QVERIFY (main);
+   /* the widget loaded the real config file, so set the device now */
+   QString old_dev = xmlConfig->stringValue ("LAST_DEVICE", QString ());
+   int old_single = xmlConfig->intValue ("SCAN_SINGLE");
+   xmlConfig->setStringValue ("LAST_DEVICE", dev);
+   xmlConfig->setIntValue ("SCAN_SINGLE", pages);
+   QMap<QString, QString> opt;
+   opt["resolution"] = "300";
+   opt["mode"] = "Color";
+   opt["source"] = "ADF Duplex";
+   if (autosize)
+      opt["auto-size"] = "yes";
+   main->setScanOptions (opt);
+
+   QElapsedTimer timer;
+   QList<qint64> stamps;
+   connect (model, &Desktopmodel::newScannedPage, this,
+            [&] (const QString &, bool) { stamps << timer.elapsed (); });
+
+   timer.start ();
+   main->scanInto (repo_ind);          // returns when the batch is done
+
+   QVERIFY2 (stamps.size () >= 2, qPrintable (QString ("only %1 pages")
+                                              .arg (stamps.size ())));
+   QList<qint64> gaps;
+   for (int i = 1; i < stamps.size (); i++)
+      gaps << stamps[i] - stamps[i - 1];
+   std::sort (gaps.begin (), gaps.end ());
+   qint64 total = stamps.last () - stamps.first ();
+   qDebug ("GUI scan %s: %d pages, %lld ms total, %lld ms/page mean, "
+           "min %lld median %lld max %lld",
+           autosize ? "auto-size" : "fixed", (int) stamps.size (),
+           (long long) total, (long long) (total / (stamps.size () - 1)),
+           (long long) gaps.first (),
+           (long long) gaps[gaps.size () / 2], (long long) gaps.last ());
+
+   utilSetHeadless (false);
+   xmlConfig->setStringValue ("LAST_DEVICE", old_dev);
+   xmlConfig->setIntValue ("SCAN_SINGLE", old_single);
+}
+
+
 void TestQscanner::testAutoSizePanel()
 {
    const char *dev = getenv ("PAPERMAN_TEST_DEVICE");

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -35,6 +35,46 @@ void TestQscanner::testOpenSimul()
 }
 
 
+/* Auto-size, when the backend offers it, must round-trip through the
+   scan dialog and disable the manual scan-area options. Runs only when
+   PAPERMAN_TEST_DEVICE names a scanner that supports it */
+void TestQscanner::testAutoSize()
+{
+   const char *dev = getenv ("PAPERMAN_TEST_DEVICE");
+   if (!dev)
+      QSKIP ("set PAPERMAN_TEST_DEVICE to a scanner with auto-size");
+   ensureXmlConfig ();
+   QScanner *scanner = new QScanner;
+   scanner->setDeviceName (dev);
+   QVERIFY (scanner->openDevice ());
+   QScanDialog dlg (scanner, 0);
+   if (!dlg.hasAutoSize ())
+      QSKIP ("scanner has no auto-size option");
+   QVERIFY (!dlg.autoSize ());
+   QVERIFY (dlg.setAutoSize (true));
+   QVERIFY (dlg.autoSize ());
+   if (getenv ("DUMP_PNG"))
+      {
+      dlg.show ();
+      QTest::qWait (200);
+      dlg.grab ().save (getenv ("DUMP_PNG"));
+      }
+   /* the scan-area options should now be inactive */
+   int tlx = -1;
+   for (int i = 1; i < scanner->optionCount (); i++)
+      {
+      SANE_String_Const nm = scanner->getOptionName (i);
+      if (nm && !strcmp (nm, SANE_NAME_SCAN_TL_X))
+         tlx = i;
+      }
+   QVERIFY (tlx > 0);
+   QVERIFY (!scanner->isOptionActive (tlx));
+   QVERIFY (dlg.setAutoSize (false));
+   QVERIFY (!dlg.autoSize ());
+   QVERIFY (scanner->isOptionActive (tlx));
+}
+
+
 /* The scan dialog's option list must lay out its groups: the scroll
    view once left them at zero height for some back ends */
 void TestQscanner::testOptionDialogLayout()

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -358,6 +358,10 @@ void TestQscanner::testPscanControls()
 void TestQscanner::testPscanPaperToggle()
 {
    ensureXmlConfig ();
+   /* the paper sizes are handed to the scanner the other way round when
+      the sheets are fed sideways, so pin the feed: this test is about
+      the sizes themselves */
+   xmlConfig->setIntValue ("SCAN_SIDEWAYS", 0);
    QScanner scanner;
    scanner.setDeviceName (SIMUL_NAME);
    QVERIFY (scanner.openDevice ());
@@ -406,6 +410,56 @@ void TestQscanner::testPscanPaperToggle()
    QVERIFY (bryForName.contains (legalName));
    QVERIFY (bryForName.contains (letterName));
    QVERIFY (bryForName[legalName] > bryForName[letterName] + 50.0);
+}
+
+
+/* Sheets fed sideways go through with the page's height across the
+   scanner, so the size the user picks describes the page and has to
+   reach the scanner the other way round. Letter fed sideways must give
+   a scan area 11 inches across and 8.5 down, not the reverse */
+void TestQscanner::testPscanPaperSideways()
+{
+   ensureXmlConfig ();
+   QScanner scanner;
+   scanner.setDeviceName (SIMUL_NAME);
+   QVERIFY (scanner.openDevice ());
+
+   QScanDialog dialog (&scanner, 0);
+   Pscan pscan;
+   pscan.setScanDialog (&dialog);
+   pscan.scannerChanged (&scanner);
+   pscan.setPreviewWidget (dialog.getPreview ());
+
+   PreviewWidget *pv = dialog.getPreview ();
+   if (pv->getPreDefLetter () == -1)
+      QSKIP ("scanner does not offer a Letter size");
+
+   int letter = pv->getPreDefLetter ();
+   double upright_x, upright_y, sideways_x, sideways_y;
+
+   xmlConfig->setIntValue ("SCAN_SIDEWAYS", 0);
+   pscan.selectPreviewSize (letter);
+   upright_x = SANE_UNFIX (scanner.saneWordValue (scanner.getBrxOption ()));
+   upright_y = SANE_UNFIX (scanner.saneWordValue (scanner.getBryOption ()));
+
+   xmlConfig->setIntValue ("SCAN_SIDEWAYS", 2);
+   pscan.selectPreviewSize (letter);
+   sideways_x = SANE_UNFIX (scanner.saneWordValue (scanner.getBrxOption ()));
+   sideways_y = SANE_UNFIX (scanner.saneWordValue (scanner.getBryOption ()));
+   xmlConfig->setIntValue ("SCAN_SIDEWAYS", 0);
+
+   /* Upright, Letter is taller than it is wide. Fed sideways the page's
+      width becomes the length of the scan, so the scan must get shorter
+      by that much. The width should grow to the page's height to match,
+      but a scanner too narrow to take the page lengthways caps it, as
+      the simulated one does, so only the length is checked here */
+   QVERIFY2 (upright_y > upright_x, "Letter upright should be taller than wide");
+   QVERIFY2 (qAbs (sideways_y - upright_x) < 2.0,
+             "fed sideways, the scan length should be the page's width");
+   QVERIFY2 (sideways_y < upright_y - 20.0,
+             "fed sideways, the scan should be shorter than upright");
+   QVERIFY2 (sideways_x >= upright_x - 2.0,
+             "fed sideways, the scan should be no narrower than upright");
 }
 
 

--- a/test/test_qscanner.cpp
+++ b/test/test_qscanner.cpp
@@ -9,6 +9,9 @@
 #include "test_qscanner.h"
 
 #include "qi/previewwidget.h"
+#include "qi/qsaneoption.h"
+#include <QScrollArea>
+#include <QGroupBox>
 #include "qi/scanarea.h"
 
 #define SIMUL_NAME "simulscan"
@@ -29,6 +32,38 @@ void TestQscanner::testOpenSimul()
    QVERIFY (scanner.isOpen ());
    QCOMPARE (scanner.xResolutionDpi (), 300);
    QCOMPARE (scanner.yResolutionDpi (), 300);
+}
+
+
+/* The scan dialog's option list must lay out its groups: the scroll
+   view once left them at zero height for some back ends */
+void TestQscanner::testOptionDialogLayout()
+{
+   ensureXmlConfig ();
+   QScanner *scanner = new QScanner;
+   const char *dev = getenv ("PAPERMAN_TEST_DEVICE");
+   scanner->setDeviceName (dev ? dev : SIMUL_NAME);
+   QVERIFY (scanner->openDevice ());
+   QVERIFY (scanner->getGroupCount () > 0);
+   QScanDialog dlg (scanner, 0);
+   dlg.show ();
+   QTest::qWait (200);
+   if (getenv ("DUMP_PNG"))
+      dlg.grab ().save (getenv ("DUMP_PNG"));
+   QList<QGroupBox *> boxes = dlg.findChildren<QGroupBox *> ();
+   QCOMPARE (boxes.size (), scanner->getGroupCount ());
+   foreach (QGroupBox *gb, boxes)
+      {
+      QVERIFY2 (gb->height () > 0, qPrintable (gb->title ()));
+      QVERIFY (gb->findChildren<QSaneOption *> ().size () > 0);
+      }
+   QScrollArea *sa = dlg.findChild<QScrollArea *> ();
+   QVERIFY (sa && sa->widget ());
+   QVERIFY (sa->widget ()->height () > sa->viewport ()->height ());
+   QVERIFY2 (sa->widget ()->width () <= sa->viewport ()->width (),
+             qPrintable (QString ("content %1 wide, viewport %2")
+                         .arg (sa->widget ()->width ())
+                         .arg (sa->viewport ()->width ())));
 }
 
 

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -14,6 +14,7 @@ public:
 private slots:
    //! Opening the simulated scanner succeeds and is queryable.
    void testOpenSimul();
+   void testOptionDialogLayout();
 
    //! reconnect() leaves the scanner in an open, usable state.
    void testReconnectKeepsOpen();

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -50,6 +50,9 @@ private slots:
    //! The Alt-L paper-size toggle keeps the size sent to the scanner in
    //! step with the size shown in the combo, across repeated toggles.
    void testPscanPaperToggle();
+
+   //! Test a sideways feed turns the paper size round for the scanner
+   void testPscanPaperSideways();
 };
 
 #endif // TEST_QSCANNER_H

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -17,6 +17,7 @@ private slots:
    void testOptionDialogLayout();
    void testAutoSize();
    void testAutoSizePanel();
+   void testScanGuiTiming();
 
    //! reconnect() leaves the scanner in an open, usable state.
    void testReconnectKeepsOpen();

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -16,6 +16,7 @@ private slots:
    void testOpenSimul();
    void testOptionDialogLayout();
    void testAutoSize();
+   void testAutoSizePanel();
 
    //! reconnect() leaves the scanner in an open, usable state.
    void testReconnectKeepsOpen();

--- a/test/test_qscanner.h
+++ b/test/test_qscanner.h
@@ -15,6 +15,7 @@ private slots:
    //! Opening the simulated scanner succeeds and is queryable.
    void testOpenSimul();
    void testOptionDialogLayout();
+   void testAutoSize();
 
    //! reconnect() leaves the scanner in an open, usable state.
    void testReconnectKeepsOpen();

--- a/tools/psip-bench.py
+++ b/tools/psip-bench.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Measure how fast an fi-8000 series scanner hands over images on the network.
+
+This talks the scanner's HTTP/JSON protocol directly (see
+doc/finet-protocol.md in the sane-backends tree), with nothing of the SANE
+backend or paperman in the way: it starts a batch, fetches sides as fast as
+it can without decoding them, and prints the timing of every side and a
+summary. It always stops the feeder and closes the session, so it can be
+interrupted with Ctrl-C.
+
+    tools/psip-bench.py                       # 50 sides at 300 dpi colour duplex
+    tools/psip-bench.py -n 100 -r 200         # 100 sides at 200 dpi
+    tools/psip-bench.py --no-prepick          # let the feeder wait on delivery
+    tools/psip-bench.py --save /tmp/sides     # keep the JPEGs
+"""
+import argparse
+import http.client
+import json
+import sys
+import time
+
+TOKEN = 'Bearer ***CLIENTACCESSTOKEN***'   # the scanner's fixed token, not a secret
+UNITS = 1200                               # the scanner measures in 1/1200 inch
+
+
+class Scanner:
+    def __init__(self, host):
+        self.host = host
+        self.conn = http.client.HTTPConnection(host, 80, timeout=90)
+        self.sid = None
+        self.capturing = False
+
+    def call(self, method, params, timeout=60):
+        body = json.dumps({'commandId': 'bench', 'commandTimeOut': str(timeout),
+                           'method': method, 'parameters': params})
+        self.conn.request('POST', '/api/privet/session', body=body,
+                          headers={'Authorization': TOKEN,
+                                   'Content-Type': 'application/json'})
+        return json.loads(self.conn.getresponse().read())
+
+    def get(self, uri):
+        self.conn.request('GET', uri, headers={'Authorization': TOKEN})
+        return self.conn.getresponse().read()
+
+    def info(self):
+        self.conn.request('GET', '/api/privet/info', headers={'Authorization': TOKEN})
+        return json.loads(self.conn.getresponse().read())
+
+    def open(self):
+        r = self.call('createSession', {'connect': 'PSIP'})
+        if r.get('status') != 'success':
+            raise SystemExit('createSession: %s (a session is open: close it '
+                             'or power-cycle the scanner)' % r.get('status'))
+        self.sid = r['results']['session']['sessionId']
+
+    def session(self):
+        return self.call('getSession', {'operationCode': 1, 'sessionId': self.sid},
+                         5)['results']['session']
+
+    def close(self):
+        if not self.sid:
+            return
+        if self.capturing:
+            self.call('stopCapturing', {'pauseScanning': 'false', 'sessionId': self.sid}, 5)
+            self.capturing = False
+        self.call('closeSession', {'sessionId': self.sid}, 5)
+        self.sid = None
+
+
+def attrs(pairs):
+    return {'attributes': [{'attribute': k, 'values': {'value': str(v)}}
+                           for k, v in pairs]}
+
+
+def make_task(a):
+    """The task the finet backend sends, with the options this tool varies"""
+    width = int(a.width * UNITS)
+    height = int(a.height * UNITS)
+    read = {
+        'imageCacheMode': attrs([('imageCacheMode', 'scannerMemory')]),
+        'imageTransferMethod': attrs([('imageTransferMethod', 'alternate')]),
+    }
+    if a.divided:
+        read['devidedSize'] = attrs([('devidedSize', '12')])
+    return {'actions': {'streams': {'sources': {
+        'feedControls': {
+            'numberOfSheets': attrs([('sheetCounts', '0')]),
+            'doubleFeed': attrs([('overlap', 'enable'), ('length', 'disable'),
+                                 ('response', 'recovery'),
+                                 ('deviceSpecification', 'disable'),
+                                 ('iOMFLength', '0')]),
+            'background': attrs([('bgColor', a.background)]),
+            'prePick': attrs([('prePickControl',
+                               'enable' if a.prepick else 'disable')]),
+        },
+        'pixelFormats': attrs([
+            ('resolution', a.resolution), ('width', width), ('height', height),
+            ('offsetWidth', 0), ('offsetHeight', 0),
+            ('automaticSize', 'disable'), ('compression', 'jpeg'),
+            ('jpegQuality', a.quality), ('jpgSubSampling', '422'),
+            ('overscan', 'off'), ('automaticDeskew', 'disable'),
+            ('endOfPageDetection', 'on' if a.end_of_page else 'off'),
+            ('paperWidth', width), ('paperLength', height)]),
+        'readControls': read,
+    }}}}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    p.add_argument('host', nargs='?', default='192.168.4.98', help='scanner address')
+    p.add_argument('-n', '--sides', type=int, default=50, help='sides to fetch (default 50)')
+    p.add_argument('-r', '--resolution', type=int, default=300)
+    p.add_argument('-q', '--quality', type=int, default=80, help='JPEG quality')
+    p.add_argument('--width', type=float, default=12.0, help='window width in inches')
+    p.add_argument('--height', type=float, default=17.0, help='window height in inches')
+    p.add_argument('--background', default='black', choices=['black', 'white'])
+    p.add_argument('--no-prepick', dest='prepick', action='store_false',
+                   help='let the feeder wait on delivery instead of running ahead')
+    p.add_argument('--no-divided', dest='divided', action='store_false',
+                   help='fetch without devidedSize/imagePartNum')
+    p.add_argument('--end-of-page', action='store_true',
+                   help='endOfPageDetection on')
+    p.add_argument('--save', metavar='DIR', help='save the JPEGs in DIR')
+    p.add_argument('-v', '--verbose', action='store_true', help='print every side')
+    a = p.parse_args()
+
+    s = Scanner(a.host)
+    inf = s.info()
+    print('%s %s, state %s' % (inf.get('model'), inf.get('serialNumber'),
+                               inf.get('deviceState')))
+    s.open()
+    try:
+        st = s.session()
+        if st['deviceStatus']['sensor']['hopperEmpty'] == 'on':
+            raise SystemExit('the hopper is empty')
+        s.call('sendTask', {'sessionId': s.sid, 'task': make_task(a)}, 5)
+        r = s.call('startCapturing', {'ignore_mf_detection': 'false',
+                                      'restartCapturing': 'false',
+                                      'sessionId': s.sid}, 35)
+        if r['results']['session'].get('detected') != 'success':
+            raise SystemExit('startCapturing: %s' % r['results']['session'].get('detected'))
+        s.capturing = True
+
+        t0 = time.time()
+        block = 1
+        sides = []          # (t_done, wait, fetch, size)
+        first = None
+        waiting_max = 0
+        while len(sides) < a.sides:
+            params = {'duplexMetadata': 'disable', 'imageBlockNum': block,
+                      'sessionId': s.sid, 'withMetadata': 'enable'}
+            if a.divided:
+                params['imagePartNum'] = 1
+            t = time.time()
+            r = s.call('readImageBlock', params, 60)
+            wait = time.time() - t
+            if r.get('status') == 'noImage':
+                st = s.session()
+                if st['deviceStatus']['sensor']['hopperEmpty'] == 'on' and not st['imageBlocks']:
+                    print('hopper empty after %d sides' % len(sides))
+                    break
+                continue
+            md = r['results']['metadata']
+            uri = md['address']['uri']
+            t = time.time()
+            data = s.get(uri)
+            fetch = time.time() - t
+            if first is None:
+                first = time.time()
+            s.call('releaseImageBlocks', {'imageBlockNum': block, 'sessionId': s.sid}, 60)
+            sides.append((time.time() - t0, wait, fetch, len(data)))
+            if a.save:
+                open('%s/side-%03d.jpg' % (a.save, block), 'wb').write(data)
+            if a.verbose:
+                print('%6.2fs side %3d %-5s wait %4.0f ms, fetch %3.0f ms, %4.0f KB' % (
+                    sides[-1][0], block, md['address'].get('source', ''),
+                    wait * 1000, fetch * 1000, len(data) / 1024))
+            elif len(sides) % 10 == 0:
+                el = time.time() - first
+                print('%3d sides, %.0f ms/side so far' % (len(sides), 1000 * el / len(sides)))
+            block += 1
+            if block % 10 == 0:
+                waiting_max = max(waiting_max, len(s.session()['imageBlocks']))
+
+        # stop the feeder but keep what has gone through, and count it
+        s.call('stopCapturing', {'pauseScanning': 'true', 'sessionId': s.sid}, 5)
+        time.sleep(1.5)
+        left = len(s.session()['imageBlocks'])
+
+        if len(sides) > 1:
+            el = sides[-1][0] - sides[0][0]
+            n = len(sides) - 1
+            fronts = [w for i, (_, w, _, _) in enumerate(sides) if i % 2 == 0]
+            backs = [w for i, (_, w, _, _) in enumerate(sides) if i % 2 == 1]
+            print('%d sides in %.1fs: %.0f ms/side (%.0f sides/min); first side after %.1fs' % (
+                len(sides), el, 1000 * el / n, 60000 * n / (el * 1000), sides[0][0]))
+            print('readImageBlock wait: fronts %.0f ms, backs %.0f ms; GET %.0f ms; %.0f KB/side' % (
+                1000 * sum(fronts) / len(fronts), 1000 * sum(backs) / max(len(backs), 1),
+                1000 * sum(f for _, _, f, _ in sides) / len(sides),
+                sum(z for _, _, _, z in sides) / len(sides) / 1024))
+            print('images waiting in the scanner: up to %d during the run, %d still '
+                  'buffered when the feeder was stopped' % (waiting_max, left))
+    finally:
+        s.close()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('\ninterrupted')
+        sys.exit(1)

--- a/tools/sane-bench.py
+++ b/tools/sane-bench.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Time a batch scan through SANE, side by side, with scanimage.
+
+Works over USB (fujitsu backend) and over the network (finet backend), so
+the two can be compared like for like: scanimage fetches each side and
+writes it out, and this prints when each side completed and the intervals
+between them. For a fujitsu device it turns on buffermode and, in colour,
+JPEG compression, without which the fi-8950 stops after every sheet and
+sends 25 MB per side over USB.
+
+    tools/sane-bench.py                              # last device, 50 sides
+    tools/sane-bench.py -d 'fujitsu:fi-8950:1933'    # over USB
+    tools/sane-bench.py -d finet:192.168.4.98 -n 100
+    tools/sane-bench.py -d ... -- --resolution 200   # extra scanimage options
+"""
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    p.add_argument('-d', '--device', help='SANE device (default: scanimage picks)')
+    p.add_argument('-n', '--sides', type=int, default=50, help='sides to scan (default 50)')
+    p.add_argument('-r', '--resolution', type=int, default=300)
+    p.add_argument('-m', '--mode', default='Color')
+    p.add_argument('--source', default='ADF Duplex')
+    p.add_argument('--keep', metavar='DIR', help='keep the images in DIR')
+    p.add_argument('--no-fast', action='store_true',
+                   help='do not add buffermode/compression for a fujitsu device')
+    p.add_argument('-v', '--verbose', action='store_true', help='print every side')
+    p.add_argument('extra', nargs='*', help='further scanimage options after --')
+    a = p.parse_args()
+
+    outdir = a.keep or tempfile.mkdtemp(prefix='sane-bench-')
+    os.makedirs(outdir, exist_ok=True)
+    fujitsu = a.device is not None and a.device.startswith('fujitsu')
+    jpeg = fujitsu and not a.no_fast and a.mode == 'Color'
+    cmd = ['scanimage']
+    if a.device:
+        cmd += ['-d', a.device]
+    cmd += ['--source', a.source, '--mode', a.mode, '--resolution', str(a.resolution)]
+    if fujitsu and not a.no_fast:
+        cmd += ['--buffermode=On']
+        if jpeg:
+            cmd += ['--compression=JPEG', '--format=jpeg']
+    cmd += ['--batch=%s/side%%03d.%s' % (outdir, 'jpg' if jpeg else 'pnm'),
+            '--batch-count=%d' % a.sides, '--batch-print'] + a.extra
+    print(' '.join(cmd))
+
+    t0 = time.time()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            text=True, bufsize=1)
+    done = []       # completion time of each side
+    errors = []
+    try:
+        for line in proc.stdout:
+            line = line.rstrip('\n')
+            if line.startswith(outdir):
+                done.append(time.time() - t0)
+                size = os.path.getsize(line) if os.path.exists(line) else 0
+                if a.verbose:
+                    gap = done[-1] - done[-2] if len(done) > 1 else 0
+                    print('%6.2fs side %3d  +%4.0f ms  %5.0f KB' % (
+                        done[-1], len(done), gap * 1000, size / 1024))
+                elif len(done) % 10 == 0:
+                    print('%3d sides, %.0f ms/side so far' % (
+                        len(done), 1000 * (done[-1] - done[0]) / (len(done) - 1)))
+            elif line and not re.match(r'^(Scanning|Scanned|Batch|Output)', line):
+                errors.append(line)
+    except KeyboardInterrupt:
+        proc.terminate()
+        print('\ninterrupted')
+    proc.wait()
+    for e in errors[-5:]:
+        print('scanimage:', e)
+
+    if len(done) > 1:
+        el = done[-1] - done[0]
+        n = len(done) - 1
+        gaps = sorted(done[i + 1] - done[i] for i in range(n))
+        print('%d sides in %.1fs after the first: %.0f ms/side (%.0f sides/min); '
+              'first side after %.1fs' % (len(done), el, 1000 * el / n,
+                                          60 * n / el, done[0]))
+        print('interval between sides: median %.0f ms, min %.0f, max %.0f' % (
+            1000 * gaps[n // 2], 1000 * gaps[0], 1000 * gaps[-1]))
+        print('images in %s' % outdir)
+    if not a.keep and len(done) <= 1:
+        shutil.rmtree(outdir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils.cpp
+++ b/utils.cpp
@@ -1218,7 +1218,7 @@ QString utilUserName()
 #endif
 }
 
-static bool test_mode;
+static bool headless_mode;
 
 // how long to keep retrying a rename in total, in 50ms steps
 static const int RENAME_RETRIES = 20;
@@ -1253,14 +1253,14 @@ bool utilReplaceFile(const QString &from, const QString &to, QString *error)
    return false;
 }
 
-void utilSetTestMode(bool testing)
+void utilSetHeadless(bool headless)
 {
-   test_mode = testing;
+   headless_mode = headless;
 }
 
-bool utilTestMode()
+bool utilHeadless()
 {
-   return test_mode;
+   return headless_mode;
 }
 
 void utilInit(const QString& group)

--- a/utils.cpp
+++ b/utils.cpp
@@ -44,6 +44,7 @@ X-Comment: On Debian GNU/Linux systems, the complete text of the GNU General
 #include <QImage>
 #ifndef QT_NO_WIDGETS
 #include <QMessageBox>
+#include <QStyle>
 #endif
 #include <QMimeData>
 #include <QRegularExpression>
@@ -1260,6 +1261,23 @@ bool utilHeadless()
 {
    return headless_mode;
 }
+
+#ifndef QT_NO_WIDGETS
+const QPalette &utilStylePalette(QStyle *style)
+{
+   static QPalette pal;
+   static QStyle *pal_style = nullptr;
+   static qint64 pal_key = -1;
+   qint64 key = QGuiApplication::palette().cacheKey();
+
+   if (style != pal_style || key != pal_key) {
+      pal = style->standardPalette();
+      pal_style = style;
+      pal_key = key;
+   }
+   return pal;
+}
+#endif
 
 void utilInit(const QString& group)
 {

--- a/utils.cpp
+++ b/utils.cpp
@@ -294,7 +294,6 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
             uint32_t *out;
             int i;
 
-            mem_check ();
             in = (byte *)buffer [0];
             i = cinfo.output_width;
             if (max_width != -1 && i > max_width)
@@ -302,7 +301,6 @@ void jpeg_decode (byte *data, int size, byte * volatile dest, int line_bytes,
             for (out = (uint32_t *)dest; i != 0;
                  i--, in += 3)
                *out++ = in [2] | (in [1] << 8) | (in [0] << 16);
-            mem_check ();
             }
          else
             {

--- a/utils.h
+++ b/utils.h
@@ -337,11 +337,11 @@ bool utilSetDirGroup(const QString& dirname);
  */
 QString utilUserName();
 
-/** record that the program is running its test suite: error reports go
-    to the console instead of a modal dialog, which would hang a headless
-    test run */
-void utilSetTestMode(bool testing);
-bool utilTestMode();
+/** record that the program is running without a user at the screen (the
+    test suite or the command-line scan mode): error reports go to the
+    console instead of a modal dialog, which would otherwise wait forever */
+void utilSetHeadless(bool headless);
+bool utilHeadless();
 
 /** rename a file, retrying briefly if it fails
 

--- a/utils.h
+++ b/utils.h
@@ -343,6 +343,19 @@ QString utilUserName();
 void utilSetHeadless(bool headless);
 bool utilHeadless();
 
+class QPalette;
+class QStyle;
+
+#ifndef QT_NO_WIDGETS
+/** the style's standard palette, kept between calls
+
+    QStyle::standardPalette() builds the palette from scratch every time,
+    which is most of the cost of painting an item in the page and desktop
+    views. The result only changes with the style or the application
+    palette, so keep it until one of those does */
+const QPalette &utilStylePalette(QStyle *style);
+#endif
+
 /** rename a file, retrying briefly if it fails
 
     On Windows a file which has just been written is often still held


### PR DESCRIPTION
The TWAIN back end this PR started as went in separately as #97. What is left
is the work that came out of driving a Ricoh fi-8950 hard: making the display
keep up with a fast feeder, deciding each page's colour and orientation from
its pixels, and the diagnostics needed to find out why any of it is slow.

## Keeping up with the feeder

The scanner delivers about six sides a second and the display falls steadily
behind, still showing pages as scanning long after the scanner has finished
them. Several separate causes:

- The build is never optimised. The project file adds `-O2` unless the build
  is for debug or coverage, but the line above it removes `release` from
  CONFIG, so the condition never holds and every build is `-O0`. That matters
  where a scan touches every pixel: the coverage and colour pass takes 135ms a
  side and the scanning thread 251ms of CPU a side; optimised, 24ms and 131ms.
  At six sides a second a side has 167ms, so the old figure does not fit and
  the new one does.
- Page images are decoded on a background thread, and the render thread is
  kept off the file while the scan writes it.
- The page view keeps uniform item sizes, so adding hundreds of pages is no
  longer O(n^2).
- Progress messages are coalesced: one per page at a time, and no more than
  one every 40ms.
- The live preview is kept as the page's thumbnail for the rest of the scan
  rather than decoding each finished page again on the GUI thread.
- The JPEG decode loop no longer calls `mem_check()`, where 50 malloc/free per
  scanline use two thirds of the GUI thread.
- Backends are read in 256 KB chunks, and a backend's fast-transfer settings
  are applied before each scan.

## Per-page colour and orientation

- A colour scan of a mostly-text batch stores every page as a colour JPEG. The
  fi-8950 cannot sort pages itself: a capture of the vendor's driver shows it
  asks for colour every time and decides on the host. Pages are now judged from
  their pixels in the pass that already counts coverage, and stored as grey or
  mono when they need no more.
- Sheets fed sideways are turned upright as they are stored, the front one way
  and the back the other, since the back is seen from the other side of the
  sheet.
- The paper size is handed to the scanner the other way round when the feed is
  sideways. Without this a page longer than the paper width is cut off at the
  foot, which is how a 9.2in book scanned through an 8.5in window loses the
  bottom of every page.
- The fujitsu lower-edge detection sits under the Auto-size checkbox.

## Diagnostics

`PAPERMAN_SCAN_STATS` reports the scan rate and where the scanning thread's
time goes; `PAPERMAN_SNAP` and `--snap` take window snapshots;
`PAPERMAN_KIND_DEBUG` shows what the page-kind test counts; `--list` prints
the pages in a stack with their size and depth; and there are bench tools for
SANE and for the scanner's network delivery.

## Fixes

Crashes clicking a just-scanned page (the render thread and the scan sharing a
stack file), a page starting with a height the back end does not know, a
headless reconnect building a GUI dialog, pixels read out of step across raw
24-bit chunks, the back page sized from the front's parameters, and a failed
scan reconnecting the scanner on the GUI thread, which freezes the interface
for a minute on USB timeouts just as the user reaches for Stop.

`paperman-client` also fails to link from clean: its project file never lists
backendstats.cpp.
